### PR TITLE
Refactor serial connection to use ESPHome UARTDevice

### DIFF
--- a/src/include/jutta_proto/JuttaConnection.hpp
+++ b/src/include/jutta_proto/JuttaConnection.hpp
@@ -24,8 +24,9 @@ class JuttaConnection {
  public:
     /**
      * Initializes a new Jutta (UART) connection.
+     * ESPHome provides the configured UART component.
      **/
-    explicit JuttaConnection(std::string&& device);
+    explicit JuttaConnection(esphome::uart::UARTComponent* parent);
 
     /**
      * Tries to initializes the Jutta serial (UART) connection.

--- a/src/include/serial/SerialConnection.hpp
+++ b/src/include/serial/SerialConnection.hpp
@@ -4,30 +4,18 @@
 #include <string>
 #include <vector>
 
+#include "esphome/components/uart/uart.h"
+
 //---------------------------------------------------------------------------
 namespace serial {
 //---------------------------------------------------------------------------
-enum SerialConnectionState { SC_DISABLED = 0,
-                             SC_OPENED = 1,
-                             SC_READY = 2,
-                             SC_ERROR = 3 };
-
-/**
- * Based on: https://en.wikibooks.org/wiki/Serial_Programming/termios
- **/
-class SerialConnection {
- private:
-    const std::string device;
-    int fd = -1;
-    SerialConnectionState state{SC_DISABLED};
-
+class SerialConnection : public esphome::uart::UARTDevice {
  public:
-    explicit SerialConnection(std::string&& device);
-    ~SerialConnection();
+    explicit SerialConnection(esphome::uart::UARTComponent* parent);
 
     /**
-     * Tries to initializes the serial (UART) connection.
-     * Throws a exception in case something goes wrong.
+     * Initializes the serial (UART) connection.
+     * ESPHome handles the low level initialisation.
      **/
     void init();
 
@@ -38,27 +26,15 @@ class SerialConnection {
     [[nodiscard]] size_t read_serial(std::array<uint8_t, 4>& buffer) const;
     /**
      * Writes the given data buffer to the serial connection.
+     * Returns true on success.
      **/
-    [[nodiscard]] size_t write_serial(const std::array<uint8_t, 4>& data) const;
+    [[nodiscard]] bool write_serial(const std::array<uint8_t, 4>& data) const;
     void flush() const;
 
     /**
      * Returns all available serial port paths for this device.
      **/
     static std::vector<std::string> get_available_ports();
-
- private:
-    /**
-     * Tries to open the given serial port and stores the resulting file descriptor in fd.
-     * Throws a exception in case something goes wrong.
-     **/
-    void openTty(const std::string& device);
-    /**
-     * Tries to configure the current file descriptor fd as serial (UART) device.
-     * Throws a exception in case something goes wrong.
-     **/
-    void configureTty();
-    void closeTty();
 };
 //---------------------------------------------------------------------------
 }  // namespace serial

--- a/src/jutta_proto/JuttaConnection.cpp
+++ b/src/jutta_proto/JuttaConnection.cpp
@@ -13,7 +13,7 @@
 //---------------------------------------------------------------------------
 namespace jutta_proto {
 //---------------------------------------------------------------------------
-JuttaConnection::JuttaConnection(std::string&& device) : serial(std::move(device)) {}
+JuttaConnection::JuttaConnection(esphome::uart::UARTComponent* parent) : serial(parent) {}
 
 void JuttaConnection::init() {
     actionLock.lock();
@@ -212,11 +212,11 @@ bool JuttaConnection::write_encoded_unsafe(const std::array<uint8_t, 4>& encData
 
 bool JuttaConnection::read_encoded_unsafe(std::array<uint8_t, 4>& buffer) const {
     size_t size = serial.read_serial(buffer);
-    if (size <= 0 || size > 4) {
+    if (size == 0 || size > buffer.size()) {
         SPDLOG_TRACE("No serial data found.");
         return false;
     }
-    if (size < 4) {
+    if (size < buffer.size()) {
         SPDLOG_WARN("Invalid amount of UART data found ({} byte) - ignoring.", size);
         return false;
     }

--- a/src/serial/SerialConnection.cpp
+++ b/src/serial/SerialConnection.cpp
@@ -1,123 +1,48 @@
 #include "serial/SerialConnection.hpp"
 #include "logger/Logger.hpp"
-#include <cassert>
-#include <cstddef>
-#include <exception>
-#include <sstream>
-#include <stdexcept>
-#include <system_error>
-
-extern "C" {
-#include <fcntl.h>
-#include <sys/stat.h>
-#include <termios.h>
-#include <unistd.h>
-}
+#include <array>
 
 //---------------------------------------------------------------------------
 namespace serial {
 //---------------------------------------------------------------------------
-SerialConnection::SerialConnection(std::string&& device) : device(std::move(device)) {}
 
-SerialConnection::~SerialConnection() {
-    closeTty();
-}
+SerialConnection::SerialConnection(esphome::uart::UARTComponent* parent) : esphome::uart::UARTDevice(parent) {}
 
 void SerialConnection::init() {
-    assert(state == SC_DISABLED);
-    openTty(device);
-    configureTty();
-    assert(state == SC_READY);
-}
-
-void SerialConnection::openTty(const std::string& device) {
-    assert(state == SC_DISABLED || state == SC_ERROR);
-    // Open with:
-    // O_RDWR - Open for read and write.
-    // O_NOCTTY - The device never becomes the controlling terminal of the process.
-    // O_NDELAY - Use non-blocking I/O.
-    // NOLINTNEXTLINE (hicpp-signed-bitwise)
-    fd = open(device.c_str(), O_RDWR | O_NOCTTY | O_NDELAY);
-    if (fd < 0) {
-        // NOLINTNEXTLINE (concurrency-mt-unsafe)
-        throw std::runtime_error("Failed to open '" + device + "' with: " + strerror(errno));
+    if (this->parent_ == nullptr) {
+        SPDLOG_ERROR("UART component not configured for serial connection.");
+        return;
     }
-    tcflush(fd, TCIOFLUSH);
-    state = SC_OPENED;
-    SPDLOG_INFO("Successfully opened serial device: {}", device);
-}
-
-void SerialConnection::configureTty() {
-    assert(state == SC_OPENED);
-    assert(fd != -1);  // Ensure opening was successfull
-    // Ensure the device is a TTY:
-    if (!isatty(fd)) {
-        throw std::runtime_error("Failed to configure '" + device + "'. The device is no TTY.");
-    }
-
-    termios config{};
-    if (tcgetattr(fd, &config) < 0) {
-        // NOLINTNEXTLINE (concurrency-mt-unsafe)
-        throw std::runtime_error("Failed to get configuration for '" + device + "' with: " + strerror(errno));
-    }
-
-    config.c_iflag = 0;
-    config.c_oflag = 0;
-    config.c_cflag = CS8 | CREAD | CLOCAL;
-    config.c_lflag = 0;
-    /**
-     * Max time in tenth of seconds between characters allowed.
-     * We abuse this since the coffee maker will make a 8ms break between each byte it sends.
-     * For fail safe reasons we allow 2 ms between the individual bytes.
-     * http://unixwiz.net/techtips/termios-vmin-vtime.html
-     **/
-    config.c_cc[VTIME] = 2;
-    /**
-     * Number of characters have been received, with no more data available.
-     * http://unixwiz.net/techtips/termios-vmin-vtime.html
-     **/
-    config.c_cc[VMIN] = 4;
-    if (cfsetispeed(&config, B9600) < 0 || cfsetospeed(&config, B9600) < 0) {
-        // NOLINTNEXTLINE (concurrency-mt-unsafe)
-        throw std::runtime_error("Failed to set the baud rate for '" + device + "' with: " + strerror(errno));
-    }
-
-    if (tcsetattr(fd, TCSANOW, &config) < 0) {
-        // NOLINTNEXTLINE (concurrency-mt-unsafe)
-        throw std::runtime_error("Failed to set configuration for '" + device + "' with: " + strerror(errno));
-    }
-    state = SC_READY;
-    SPDLOG_INFO("Successfully configured serial device.");
-}
-
-void SerialConnection::closeTty() {
-    if (state != SC_DISABLED) {
-        close(fd);
-        fd = -1;
-        SPDLOG_INFO("Serial device closed.");
-        state = SC_DISABLED;
-    }
+    SPDLOG_INFO("Serial connection handled by ESPHome UART component.");
 }
 
 size_t SerialConnection::read_serial(std::array<uint8_t, 4>& buffer) const {
-    assert(state == SC_READY);
-    return read(fd, buffer.data(), buffer.size());
+    if (this->parent_ == nullptr) {
+        SPDLOG_ERROR("UART component not configured for serial connection.");
+        return 0;
+    }
+    auto* self = const_cast<SerialConnection*>(this);
+    return self->read_array(buffer.data(), buffer.size());
 }
 
-size_t SerialConnection::write_serial(const std::array<uint8_t, 4>& data) const {
-    assert(state == SC_READY);
-    size_t result = write(fd, data.data(), data.size());
-    return result;
+bool SerialConnection::write_serial(const std::array<uint8_t, 4>& data) const {
+    if (this->parent_ == nullptr) {
+        SPDLOG_ERROR("UART component not configured for serial connection.");
+        return false;
+    }
+    auto* self = const_cast<SerialConnection*>(this);
+    self->write_array(data.data(), data.size());
+    return true;
 }
 
 void SerialConnection::flush() const {
-    // Wait until everything has been send:
-    tcdrain(fd);
+    if (this->parent_ != nullptr) {
+        this->parent_->flush();
+    }
 }
 
 std::vector<std::string> SerialConnection::get_available_ports() {
-    std::vector<std::string> ports{};
-    return ports;
+    return {};
 }
 //---------------------------------------------------------------------------
 }  // namespace serial

--- a/src/test_exec/handshake_test.cpp
+++ b/src/test_exec/handshake_test.cpp
@@ -142,7 +142,8 @@ int main(int /*argc*/, char** /*argv*/) {
     logger::setup_logger(spdlog::level::debug);
     SPDLOG_INFO("Starting handshake test...");
 
-    jutta_proto::JuttaConnection connection("/dev/serial/by-id/usb-FTDI_FT232R_USB_UART_A5047JSK-if00-port0");
+    // Provide the ESPHome UART component when running this executable on a device.
+    jutta_proto::JuttaConnection connection(nullptr);
     connection.init();
     while (true) {
         std::shared_ptr<std::string> coffeeMakerType = nullptr;


### PR DESCRIPTION
## Summary
- replace the POSIX-based SerialConnection with an implementation that derives from `esphome::uart::UARTDevice`
- adapt JuttaConnection to the new UARTDevice API and modernised read/write checks
- update the handshake test stub to use the new constructor signature

## Testing
- not run (ESPHome environment required)


------
https://chatgpt.com/codex/tasks/task_e_68d311a03f1c832886489d5afe1ea9f7