### PR TITLE
Refactor CoffeeMaker to non-blocking state machine

### DIFF
--- a/src/test_exec/handshake_test.cpp
+++ b/src/test_exec/handshake_test.cpp
@@ -158,7 +158,14 @@ int main(int /*argc*/, char** /*argv*/) {
         // Handshake:
         SPDLOG_INFO("Continuing with the handshake...");
         SPDLOG_INFO("Sending '@T1'...");
-        if (!connection.write_decoded_wait_for("@T1\r\n", "@t1\r\n")) {
+        auto wait_result = jutta_proto::JuttaConnection::WaitResult::Pending;
+        while (wait_result == jutta_proto::JuttaConnection::WaitResult::Pending) {
+            wait_result = connection.write_decoded_wait_for("@T1\r\n", "@t1\r\n");
+            if (wait_result == jutta_proto::JuttaConnection::WaitResult::Pending) {
+                std::this_thread::sleep_for(std::chrono::milliseconds{50});
+            }
+        }
+        if (wait_result != jutta_proto::JuttaConnection::WaitResult::Success) {
             SPDLOG_WARN("Failed to receive '@t1'");
             continue;
         }


### PR DESCRIPTION
## Summary
- convert the CoffeeMaker logic to a loop-driven state machine that sequences commands without blocking
- replace the synchronous wait helpers in JuttaConnection with pollable WaitResult-based helpers
- adjust the handshake test harness to poll on the new non-blocking API

## Testing
- cmake -S . -B build *(fails: Unknown CMake command "conan_cmake_configure")*


------
https://chatgpt.com/codex/tasks/task_e_68d314f06db88328bb486d104aff53f1