### PR TITLE
Add ESPHome Jutta Proto component

### DIFF
--- a/docs/components/jutta_proto.md
+++ b/docs/components/jutta_proto.md
@@ -1,0 +1,80 @@
+# Jutta Proto Component
+
+The Jutta Proto component integrates the custom JURA protocol implementation with ESPHome. It establishes the UART handshake
+with a JURA coffee maker and exposes convenient automation actions for brewing drinks via YAML.
+
+## Configuration
+
+```yaml
+uart:
+  id: jura_uart
+  tx_pin: 17
+  rx_pin: 16
+  baud_rate: 9600
+  parity: NONE
+  stop_bits: 1
+
+jutta_proto:
+  id: jura
+  uart_id: jura_uart
+```
+
+The component takes care of the handshake during startup. Once the handshake finishes, all brewing actions become available.
+
+## Automation Actions
+
+Use the registered actions inside automations or button handlers. When only one `jutta_proto` component is configured, the
+`id` argument can be omitted.
+
+### Start a predefined recipe
+
+```yaml
+button:
+  - platform: template
+    name: "Brew Espresso"
+    on_press:
+      - jutta_proto.start_brew:
+          coffee: espresso
+```
+
+Available options for `coffee` are `espresso`, `coffee`, `cappuccino`, `milk_foam`, `caffe_barista`, `lungo_barista`,
+`espresso_doppio`, and `macchiato`.
+
+### Brew with custom timing
+
+```yaml
+script:
+  - id: brew_lungo
+    mode: restart
+    then:
+      - jutta_proto.custom_brew:
+          id: jura
+          grind_duration: 4s
+          water_duration: 45s
+```
+
+### Cancel an ongoing custom brew
+
+```yaml
+switch:
+  - platform: template
+    name: "Cancel Brew"
+    turn_on_action:
+      - jutta_proto.cancel_custom_brew: jura
+```
+
+### Switch between front panel pages
+
+```yaml
+script:
+  - id: jura_next_page
+    then:
+      - jutta_proto.switch_page:
+          id: jura
+          page: 1
+```
+
+## Diagnostics
+
+The component logs handshake progress during startup. The `dump_config()` output lists the detected machine type as well as the
+latest key exchange messages, which can help troubleshoot UART or wiring issues.

--- a/esphome/components/jutta_proto/__init__.py
+++ b/esphome/components/jutta_proto/__init__.py
@@ -1,0 +1,151 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome import automation
+from esphome.components import uart
+from esphome.const import CONF_ID
+
+DEPENDENCIES = ["uart"]
+AUTO_LOAD = ["uart"]
+
+CONF_COFFEE = "coffee"
+CONF_GRIND_DURATION = "grind_duration"
+CONF_WATER_DURATION = "water_duration"
+CONF_PAGE = "page"
+
+jutta_component_ns = cg.esphome_ns.namespace("esphome").namespace("jutta_proto")
+jutta_proto_ns = cg.global_ns.namespace("jutta_proto")
+
+JuraComponent = jutta_component_ns.class_(
+    "JuraComponent", cg.Component, uart.UARTDevice
+)
+CoffeeType = jutta_proto_ns.enum("CoffeeMaker::coffee_t")
+
+StartBrewAction = jutta_component_ns.class_(
+    "StartBrewAction", automation.Action, template_args=automation.TEMPLATE_ARGS
+)
+CustomBrewAction = jutta_component_ns.class_(
+    "CustomBrewAction", automation.Action, template_args=automation.TEMPLATE_ARGS
+)
+CancelCustomBrewAction = jutta_component_ns.class_(
+    "CancelCustomBrewAction", automation.Action, template_args=automation.TEMPLATE_ARGS
+)
+SwitchPageAction = jutta_component_ns.class_(
+    "SwitchPageAction", automation.Action, template_args=automation.TEMPLATE_ARGS
+)
+
+COFFEE_TYPES = {
+    "espresso": CoffeeType.ESPRESSO,
+    "coffee": CoffeeType.COFFEE,
+    "cappuccino": CoffeeType.CAPPUCCINO,
+    "milk_foam": CoffeeType.MILK_FOAM,
+    "caffe_barista": CoffeeType.CAFFE_BARISTA,
+    "lungo_barista": CoffeeType.LUNGO_BARISTA,
+    "espresso_doppio": CoffeeType.ESPRESSO_DOPPIO,
+    "macchiato": CoffeeType.MACCHIATO,
+}
+
+DEFAULT_GRIND_DURATION = cv.TimePeriod(milliseconds=3600)
+DEFAULT_WATER_DURATION = cv.TimePeriod(milliseconds=40000)
+
+JURA_COMPONENT_IDS = []
+
+
+CONFIG_SCHEMA = (
+    cv.Schema({cv.GenerateID(): cv.declare_id(JuraComponent)})
+    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+
+def _normalize_start_brew(value):
+    if isinstance(value, str):
+        value = {CONF_COFFEE: value}
+    return cv.Schema(
+        {
+            cv.Optional(CONF_ID): cv.use_id(JuraComponent),
+            cv.Required(CONF_COFFEE): cv.enum(COFFEE_TYPES, lower=True),
+        }
+    )(value)
+
+
+def _normalize_custom_brew(value):
+    if isinstance(value, str):
+        raise cv.Invalid("Custom brew action requires a dictionary of options")
+    return cv.Schema(
+        {
+            cv.Optional(CONF_ID): cv.use_id(JuraComponent),
+            cv.Optional(CONF_GRIND_DURATION, default=DEFAULT_GRIND_DURATION): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_WATER_DURATION, default=DEFAULT_WATER_DURATION): cv.positive_time_period_milliseconds,
+        }
+    )(value)
+
+
+def _normalize_cancel(value):
+    if value is None:
+        value = {}
+    if isinstance(value, str):
+        value = {CONF_ID: value}
+    return cv.Schema({cv.Optional(CONF_ID): cv.use_id(JuraComponent)})(value)
+
+
+def _normalize_switch_page(value):
+    if isinstance(value, int):
+        value = {CONF_PAGE: value}
+    return cv.Schema(
+        {
+            cv.Optional(CONF_ID): cv.use_id(JuraComponent),
+            cv.Required(CONF_PAGE): cv.int_range(min=0),
+        }
+    )(value)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    JURA_COMPONENT_IDS.append(config[CONF_ID])
+    await cg.register_component(var, config)
+    await uart.register_uart_device(var, config)
+
+
+async def _get_parent(config):
+    if CONF_ID in config:
+        return await cg.get_variable(config[CONF_ID])
+    if not JURA_COMPONENT_IDS:
+        raise cv.Invalid("No jutta_proto component configured")
+    if len(JURA_COMPONENT_IDS) > 1:
+        raise cv.Invalid("Multiple jutta_proto components configured, please set 'id'")
+    return await cg.get_variable(JURA_COMPONENT_IDS[0])
+
+
+@automation.register_action("jutta_proto.start_brew", StartBrewAction, _normalize_start_brew)
+async def start_brew_action_to_code(config, action_id, template_args):
+    parent = await _get_parent(config)
+    var = cg.new_Pvariable(action_id, template_args, parent)
+    cg.add(var.set_coffee(config[CONF_COFFEE]))
+    return var
+
+
+@automation.register_action("jutta_proto.custom_brew", CustomBrewAction, _normalize_custom_brew)
+async def custom_brew_action_to_code(config, action_id, template_args):
+    parent = await _get_parent(config)
+    var = cg.new_Pvariable(action_id, template_args, parent)
+    grind = config[CONF_GRIND_DURATION]
+    water = config[CONF_WATER_DURATION]
+    cg.add(var.set_grind_duration(grind.total_milliseconds))
+    cg.add(var.set_water_duration(water.total_milliseconds))
+    return var
+
+
+@automation.register_action("jutta_proto.cancel_custom_brew", CancelCustomBrewAction, _normalize_cancel)
+async def cancel_brew_action_to_code(config, action_id, template_args):
+    parent = await _get_parent(config)
+    var = cg.new_Pvariable(action_id, template_args, parent)
+    return var
+
+
+@automation.register_action("jutta_proto.switch_page", SwitchPageAction, _normalize_switch_page)
+async def switch_page_action_to_code(config, action_id, template_args):
+    parent = await _get_parent(config)
+    var = cg.new_Pvariable(action_id, template_args, parent)
+    cg.add(var.set_page(config[CONF_PAGE]))
+    return var
+

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -1,0 +1,285 @@
+#include "esphome/components/jutta_proto/jutta_proto.h"
+
+#include <utility>
+
+#include "esphome/core/time.h"
+
+namespace esphome {
+namespace jutta_proto {
+
+static const char *const TAG = "jutta_proto";
+
+void JuraComponent::setup() {
+  if (this->parent_ == nullptr) {
+    ESP_LOGE(TAG, "UART parent not configured for JUTTA Proto component.");
+    this->mark_failed();
+    return;
+  }
+
+  this->connection_ = std::make_unique<::jutta_proto::JuttaConnection>(this->parent_);
+  this->connection_->init();
+
+  this->handshake_stage_ = HandshakeStage::HELLO;
+  ESP_LOGI(TAG, "Starting handshake with coffee maker...");
+}
+
+void JuraComponent::loop() {
+  if (this->connection_ != nullptr && this->handshake_stage_ != HandshakeStage::DONE &&
+      this->handshake_stage_ != HandshakeStage::FAILED) {
+    this->process_handshake();
+  }
+
+  if (this->coffee_maker_ != nullptr) {
+    this->coffee_maker_->loop();
+    if (!this->coffee_maker_->is_locked()) {
+      this->custom_cancel_flag_ = false;
+    }
+  }
+}
+
+void JuraComponent::dump_config() {
+  ESP_LOGCONFIG(TAG, "JUTTA Proto");
+  if (!this->device_type_.empty()) {
+    ESP_LOGCONFIG(TAG, "  Detected device: %s", this->device_type_.c_str());
+  } else {
+    ESP_LOGCONFIG(TAG, "  Detected device: (pending)");
+  }
+
+  const char *state = "unknown";
+  switch (this->handshake_stage_) {
+    case HandshakeStage::IDLE:
+      state = "idle";
+      break;
+    case HandshakeStage::HELLO:
+      state = "awaiting type";
+      break;
+    case HandshakeStage::SEND_T1:
+      state = "waiting for @t1";
+      break;
+    case HandshakeStage::WAIT_T2:
+      state = "waiting for @T2";
+      break;
+    case HandshakeStage::SEND_T2:
+      state = "sending @t2";
+      break;
+    case HandshakeStage::WAIT_T3:
+      state = "waiting for @T3";
+      break;
+    case HandshakeStage::SEND_T3:
+      state = "sending @t3";
+      break;
+    case HandshakeStage::DONE:
+      state = "ready";
+      break;
+    case HandshakeStage::FAILED:
+      state = "failed";
+      break;
+  }
+  ESP_LOGCONFIG(TAG, "  Handshake state: %s", state);
+
+  if (!this->handshake_t2_response_.empty()) {
+    ESP_LOGCONFIG(TAG, "  Last key exchange T2: %s", this->handshake_t2_response_.c_str());
+  }
+  if (!this->handshake_t3_response_.empty()) {
+    ESP_LOGCONFIG(TAG, "  Last key exchange T3: %s", this->handshake_t3_response_.c_str());
+  }
+
+  if (this->coffee_maker_ != nullptr) {
+    ESP_LOGCONFIG(TAG, "  Coffee maker ready: %s", YESNO(true));
+  } else {
+    ESP_LOGCONFIG(TAG, "  Coffee maker ready: %s", YESNO(false));
+  }
+}
+
+void JuraComponent::process_handshake() {
+  using ::jutta_proto::JuttaConnection;
+  using ::jutta_proto::JUTTA_GET_TYPE;
+
+  switch (this->handshake_stage_) {
+    case HandshakeStage::IDLE:
+      break;
+    case HandshakeStage::HELLO: {
+      auto response = this->connection_->write_decoded_with_response(JUTTA_GET_TYPE, std::chrono::milliseconds{1000});
+      if (response != nullptr) {
+        this->device_type_ = *response;
+        ESP_LOGI(TAG, "Detected coffee maker response: %s", this->device_type_.c_str());
+        this->handshake_buffer_.clear();
+        this->handshake_stage_ = HandshakeStage::SEND_T1;
+      }
+      break;
+    }
+    case HandshakeStage::SEND_T1: {
+      auto wait_result = this->connection_->write_decoded_wait_for("@T1\r\n", "@t1\r\n", std::chrono::milliseconds{1000});
+      if (wait_result == JuttaConnection::WaitResult::Success) {
+        ESP_LOGD(TAG, "Received @t1 acknowledgment.");
+        this->handshake_buffer_.clear();
+        this->handshake_deadline_ = 0;
+        this->handshake_stage_ = HandshakeStage::WAIT_T2;
+      } else if (wait_result == JuttaConnection::WaitResult::Timeout) {
+        this->restart_handshake("timeout waiting for @t1");
+      } else if (wait_result == JuttaConnection::WaitResult::Error) {
+        this->restart_handshake("failed to send @T1");
+      }
+      break;
+    }
+    case HandshakeStage::WAIT_T2: {
+      if (this->handshake_deadline_ == 0) {
+        this->handshake_deadline_ = esphome::millis() + 5000;
+      }
+      bool any = this->read_handshake_bytes();
+      if (any) {
+        auto pos = this->handshake_buffer_.find("@T2");
+        if (pos != std::string::npos) {
+          auto end = this->handshake_buffer_.find("\r\n", pos);
+          if (end != std::string::npos) {
+            this->handshake_t2_response_ = this->handshake_buffer_.substr(pos, end - pos);
+          } else {
+            this->handshake_t2_response_ = this->handshake_buffer_.substr(pos);
+          }
+          ESP_LOGD(TAG, "Received %s", this->handshake_t2_response_.c_str());
+          this->handshake_buffer_.clear();
+          this->handshake_deadline_ = 0;
+          this->handshake_stage_ = HandshakeStage::SEND_T2;
+        }
+      }
+      if (this->handshake_deadline_ != 0 && time_reached(esphome::millis(), this->handshake_deadline_)) {
+        this->restart_handshake("timeout waiting for @T2");
+      }
+      break;
+    }
+    case HandshakeStage::SEND_T2: {
+      if (this->connection_->write_decoded("@t2:8120000000\r\n")) {
+        ESP_LOGD(TAG, "Sent @t2 response.");
+        this->handshake_stage_ = HandshakeStage::WAIT_T3;
+        this->handshake_buffer_.clear();
+        this->handshake_deadline_ = 0;
+      } else {
+        this->restart_handshake("failed to send @t2");
+      }
+      break;
+    }
+    case HandshakeStage::WAIT_T3: {
+      if (this->handshake_deadline_ == 0) {
+        this->handshake_deadline_ = esphome::millis() + 5000;
+      }
+      bool any = this->read_handshake_bytes();
+      if (any) {
+        auto pos = this->handshake_buffer_.find("@T3");
+        if (pos != std::string::npos) {
+          auto end = this->handshake_buffer_.find("\r\n", pos);
+          if (end != std::string::npos) {
+            this->handshake_t3_response_ = this->handshake_buffer_.substr(pos, end - pos);
+          } else {
+            this->handshake_t3_response_ = this->handshake_buffer_.substr(pos);
+          }
+          ESP_LOGD(TAG, "Received %s", this->handshake_t3_response_.c_str());
+          this->handshake_buffer_.clear();
+          this->handshake_deadline_ = 0;
+          this->handshake_stage_ = HandshakeStage::SEND_T3;
+        }
+      }
+      if (this->handshake_deadline_ != 0 && time_reached(esphome::millis(), this->handshake_deadline_)) {
+        this->restart_handshake("timeout waiting for @T3");
+      }
+      break;
+    }
+    case HandshakeStage::SEND_T3: {
+      if (this->connection_->write_decoded("@t3\r\n")) {
+        ESP_LOGI(TAG, "Handshake finished successfully.");
+        this->handshake_stage_ = HandshakeStage::DONE;
+        this->handshake_buffer_.clear();
+        this->handshake_deadline_ = 0;
+      } else {
+        this->restart_handshake("failed to send @t3");
+      }
+      break;
+    }
+    case HandshakeStage::DONE:
+    case HandshakeStage::FAILED:
+      break;
+  }
+
+  if (this->handshake_stage_ == HandshakeStage::DONE && this->connection_ != nullptr &&
+      this->coffee_maker_ == nullptr) {
+    auto connection = std::move(this->connection_);
+    this->coffee_maker_ = std::make_unique<::jutta_proto::CoffeeMaker>(std::move(connection));
+    ESP_LOGI(TAG, "Coffee maker controller initialized.");
+  }
+}
+
+void JuraComponent::restart_handshake(const char *reason) {
+  if (reason != nullptr) {
+    ESP_LOGW(TAG, "Restarting handshake: %s", reason);
+  }
+  this->handshake_buffer_.clear();
+  this->handshake_deadline_ = 0;
+  this->handshake_stage_ = HandshakeStage::HELLO;
+}
+
+bool JuraComponent::read_handshake_bytes() {
+  if (this->connection_ == nullptr) {
+    return false;
+  }
+  bool read_any = false;
+  uint8_t byte = 0;
+  while (this->connection_->read_decoded(&byte)) {
+    read_any = true;
+    this->handshake_buffer_.push_back(static_cast<char>(byte));
+    if (this->handshake_buffer_.size() > 128) {
+      this->handshake_buffer_.erase(0, this->handshake_buffer_.size() - 128);
+    }
+  }
+  return read_any;
+}
+
+bool JuraComponent::time_reached(uint32_t now, uint32_t target) {
+  return static_cast<int32_t>(now - target) >= 0;
+}
+
+void JuraComponent::start_brew(::jutta_proto::CoffeeMaker::coffee_t coffee) {
+  if (!this->is_ready()) {
+    ESP_LOGW(TAG, "Cannot start brew - component not ready.");
+    return;
+  }
+  this->coffee_maker_->brew_coffee(coffee);
+}
+
+void JuraComponent::start_custom_brew(uint32_t grind_duration_ms, uint32_t water_duration_ms) {
+  if (!this->is_ready()) {
+    ESP_LOGW(TAG, "Cannot brew custom coffee - component not ready.");
+    return;
+  }
+  this->custom_cancel_flag_ = false;
+  this->coffee_maker_->brew_custom_coffee(&this->custom_cancel_flag_, std::chrono::milliseconds{grind_duration_ms},
+                                          std::chrono::milliseconds{water_duration_ms});
+}
+
+void JuraComponent::cancel_custom_brew() {
+  if (!this->is_ready()) {
+    ESP_LOGW(TAG, "Cannot cancel custom brew - component not ready.");
+    return;
+  }
+  if (!this->custom_cancel_flag_) {
+    ESP_LOGI(TAG, "Cancelling custom brew.");
+  }
+  this->custom_cancel_flag_ = true;
+}
+
+void JuraComponent::switch_page(uint32_t page) {
+  if (!this->is_ready()) {
+    ESP_LOGW(TAG, "Cannot switch page - component not ready.");
+    return;
+  }
+  this->coffee_maker_->switch_page(page);
+}
+
+bool JuraComponent::is_busy() const {
+  if (this->coffee_maker_ == nullptr) {
+    return false;
+  }
+  return this->coffee_maker_->is_locked();
+}
+
+}  // namespace jutta_proto
+}  // namespace esphome
+

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "esphome/core/automation.h"
+#include "esphome/core/component.h"
+#include "esphome/core/log.h"
+#include "esphome/components/uart/uart.h"
+
+#include "jutta_proto/CoffeeMaker.hpp"
+#include "jutta_proto/JuttaConnection.hpp"
+#include "jutta_proto/JuttaCommands.hpp"
+
+namespace esphome {
+namespace jutta_proto {
+
+class JuraComponent : public esphome::Component, public esphome::uart::UARTDevice {
+ public:
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+
+  void start_brew(::jutta_proto::CoffeeMaker::coffee_t coffee);
+  void start_custom_brew(uint32_t grind_duration_ms, uint32_t water_duration_ms);
+  void cancel_custom_brew();
+  void switch_page(uint32_t page);
+
+  bool is_ready() const { return this->handshake_stage_ == HandshakeStage::DONE && this->coffee_maker_ != nullptr; }
+  bool is_busy() const;
+  const std::string &device_type() const { return this->device_type_; }
+
+ protected:
+  enum class HandshakeStage { IDLE, HELLO, SEND_T1, WAIT_T2, SEND_T2, WAIT_T3, SEND_T3, DONE, FAILED };
+
+  void process_handshake();
+  void restart_handshake(const char *reason);
+  bool read_handshake_bytes();
+  static bool time_reached(uint32_t now, uint32_t target);
+
+  std::unique_ptr<::jutta_proto::JuttaConnection> connection_;
+  std::unique_ptr<::jutta_proto::CoffeeMaker> coffee_maker_;
+  HandshakeStage handshake_stage_{HandshakeStage::IDLE};
+  std::string handshake_buffer_;
+  std::string device_type_;
+  std::string handshake_t2_response_;
+  std::string handshake_t3_response_;
+  uint32_t handshake_deadline_{0};
+  bool custom_cancel_flag_{false};
+};
+
+template<typename... Ts> class StartBrewAction : public esphome::Action<Ts...> {
+ public:
+  explicit StartBrewAction(JuraComponent *parent) : parent_(parent) {}
+  void set_coffee(::jutta_proto::CoffeeMaker::coffee_t coffee) { coffee_ = coffee; }
+  void play(Ts... x) override { this->parent_->start_brew(coffee_); }
+
+ protected:
+  JuraComponent *parent_;
+  ::jutta_proto::CoffeeMaker::coffee_t coffee_{::jutta_proto::CoffeeMaker::coffee_t::ESPRESSO};
+};
+
+template<typename... Ts> class CustomBrewAction : public esphome::Action<Ts...> {
+ public:
+  explicit CustomBrewAction(JuraComponent *parent) : parent_(parent) {}
+  void set_grind_duration(uint32_t grind) { grind_duration_ms_ = grind; }
+  void set_water_duration(uint32_t water) { water_duration_ms_ = water; }
+  void play(Ts... x) override { this->parent_->start_custom_brew(grind_duration_ms_, water_duration_ms_); }
+
+ protected:
+  JuraComponent *parent_;
+  uint32_t grind_duration_ms_{3600};
+  uint32_t water_duration_ms_{40000};
+};
+
+template<typename... Ts> class CancelCustomBrewAction : public esphome::Action<Ts...> {
+ public:
+  explicit CancelCustomBrewAction(JuraComponent *parent) : parent_(parent) {}
+  void play(Ts... x) override { this->parent_->cancel_custom_brew(); }
+
+ protected:
+  JuraComponent *parent_;
+};
+
+template<typename... Ts> class SwitchPageAction : public esphome::Action<Ts...> {
+ public:
+  explicit SwitchPageAction(JuraComponent *parent) : parent_(parent) {}
+  void set_page(uint32_t page) { page_ = page; }
+  void play(Ts... x) override { this->parent_->switch_page(page_); }
+
+ protected:
+  JuraComponent *parent_;
+  uint32_t page_{0};
+};
+
+}  // namespace jutta_proto
+}  // namespace esphome
+


### PR DESCRIPTION
## Summary
- add a `JuraComponent` ESPHome wrapper around the existing Jutta protocol connection and coffee maker logic
- expose YAML configuration and automation actions for brewing, custom recipes, cancellation and page switching
- document the component with configuration and automation examples

## Testing
- python -m compileall esphome/components/jutta_proto/__init__.py


------
https://chatgpt.com/codex/tasks/task_e_68d31e5fae4883289ef858d7248fc36a