### PR TITLE
Update jutta_proto actions to new automation API

### DIFF
--- a/esphome/components/jutta_proto/__init__.py
+++ b/esphome/components/jutta_proto/__init__.py
@@ -20,18 +20,12 @@ JuraComponent = jutta_component_ns.class_(
 )
 CoffeeType = jutta_proto_ns.enum("CoffeeMaker::coffee_t")
 
-StartBrewAction = jutta_component_ns.class_(
-    "StartBrewAction", automation.Action, template_args=automation.TEMPLATE_ARGS
-)
-CustomBrewAction = jutta_component_ns.class_(
-    "CustomBrewAction", automation.Action, template_args=automation.TEMPLATE_ARGS
-)
+StartBrewAction = jutta_component_ns.class_("StartBrewAction", automation.Action)
+CustomBrewAction = jutta_component_ns.class_("CustomBrewAction", automation.Action)
 CancelCustomBrewAction = jutta_component_ns.class_(
-    "CancelCustomBrewAction", automation.Action, template_args=automation.TEMPLATE_ARGS
+    "CancelCustomBrewAction", automation.Action
 )
-SwitchPageAction = jutta_component_ns.class_(
-    "SwitchPageAction", automation.Action, template_args=automation.TEMPLATE_ARGS
-)
+SwitchPageAction = jutta_component_ns.class_("SwitchPageAction", automation.Action)
 
 COFFEE_TYPES = {
     "espresso": CoffeeType.ESPRESSO,
@@ -119,7 +113,7 @@ async def _get_parent(config):
 @automation.register_action("jutta_proto.start_brew", StartBrewAction, _normalize_start_brew)
 async def start_brew_action_to_code(config, action_id, template_args):
     parent = await _get_parent(config)
-    var = cg.new_Pvariable(action_id, template_args, parent)
+    var = cg.new_Pvariable(action_id, parent)
     cg.add(var.set_coffee(config[CONF_COFFEE]))
     return var
 
@@ -127,7 +121,7 @@ async def start_brew_action_to_code(config, action_id, template_args):
 @automation.register_action("jutta_proto.custom_brew", CustomBrewAction, _normalize_custom_brew)
 async def custom_brew_action_to_code(config, action_id, template_args):
     parent = await _get_parent(config)
-    var = cg.new_Pvariable(action_id, template_args, parent)
+    var = cg.new_Pvariable(action_id, parent)
     grind = config[CONF_GRIND_DURATION]
     water = config[CONF_WATER_DURATION]
     cg.add(var.set_grind_duration(grind.total_milliseconds))
@@ -138,14 +132,14 @@ async def custom_brew_action_to_code(config, action_id, template_args):
 @automation.register_action("jutta_proto.cancel_custom_brew", CancelCustomBrewAction, _normalize_cancel)
 async def cancel_brew_action_to_code(config, action_id, template_args):
     parent = await _get_parent(config)
-    var = cg.new_Pvariable(action_id, template_args, parent)
+    var = cg.new_Pvariable(action_id, parent)
     return var
 
 
 @automation.register_action("jutta_proto.switch_page", SwitchPageAction, _normalize_switch_page)
 async def switch_page_action_to_code(config, action_id, template_args):
     parent = await _get_parent(config)
-    var = cg.new_Pvariable(action_id, template_args, parent)
+    var = cg.new_Pvariable(action_id, parent)
     cg.add(var.set_page(config[CONF_PAGE]))
     return var
 

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -51,23 +51,23 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   bool custom_cancel_flag_{false};
 };
 
-template<typename... Ts> class StartBrewAction : public esphome::Action<Ts...> {
+class StartBrewAction : public esphome::Action<> {
  public:
   explicit StartBrewAction(JuraComponent *parent) : parent_(parent) {}
   void set_coffee(::jutta_proto::CoffeeMaker::coffee_t coffee) { coffee_ = coffee; }
-  void play(Ts... x) override { this->parent_->start_brew(coffee_); }
+  void play() override { this->parent_->start_brew(coffee_); }
 
  protected:
   JuraComponent *parent_;
   ::jutta_proto::CoffeeMaker::coffee_t coffee_{::jutta_proto::CoffeeMaker::coffee_t::ESPRESSO};
 };
 
-template<typename... Ts> class CustomBrewAction : public esphome::Action<Ts...> {
+class CustomBrewAction : public esphome::Action<> {
  public:
   explicit CustomBrewAction(JuraComponent *parent) : parent_(parent) {}
   void set_grind_duration(uint32_t grind) { grind_duration_ms_ = grind; }
   void set_water_duration(uint32_t water) { water_duration_ms_ = water; }
-  void play(Ts... x) override { this->parent_->start_custom_brew(grind_duration_ms_, water_duration_ms_); }
+  void play() override { this->parent_->start_custom_brew(grind_duration_ms_, water_duration_ms_); }
 
  protected:
   JuraComponent *parent_;
@@ -75,20 +75,20 @@ template<typename... Ts> class CustomBrewAction : public esphome::Action<Ts...> 
   uint32_t water_duration_ms_{40000};
 };
 
-template<typename... Ts> class CancelCustomBrewAction : public esphome::Action<Ts...> {
+class CancelCustomBrewAction : public esphome::Action<> {
  public:
   explicit CancelCustomBrewAction(JuraComponent *parent) : parent_(parent) {}
-  void play(Ts... x) override { this->parent_->cancel_custom_brew(); }
+  void play() override { this->parent_->cancel_custom_brew(); }
 
  protected:
   JuraComponent *parent_;
 };
 
-template<typename... Ts> class SwitchPageAction : public esphome::Action<Ts...> {
+class SwitchPageAction : public esphome::Action<> {
  public:
   explicit SwitchPageAction(JuraComponent *parent) : parent_(parent) {}
   void set_page(uint32_t page) { page_ = page; }
-  void play(Ts... x) override { this->parent_->switch_page(page_); }
+  void play() override { this->parent_->switch_page(page_); }
 
  protected:
   JuraComponent *parent_;


### PR DESCRIPTION
## Summary
- remove deprecated automation.TEMPLATE_ARGS usage from jutta_proto actions
- migrate C++ action classes to inherit from esphome::Action<>

## Testing
- esphome config your_config.yaml *(fails: esphome command not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3b031619483289b8a20f3a9bcc714