### PR TITLE
Fix namespace collision with global jutta_proto

### DIFF
--- a/esphome/components/jutta_proto/__init__.py
+++ b/esphome/components/jutta_proto/__init__.py
@@ -12,7 +12,7 @@ CONF_GRIND_DURATION = "grind_duration"
 CONF_WATER_DURATION = "water_duration"
 CONF_PAGE = "page"
 
-jutta_component_ns = cg.esphome_ns.namespace("esphome").namespace("jutta_proto")
+jutta_component_ns = cg.esphome_ns.namespace("jutta_component")
 jutta_proto_ns = cg.global_ns.namespace("jutta_proto")
 
 JuraComponent = jutta_component_ns.class_(

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -5,7 +5,7 @@
 #include "esphome/core/time.h"
 
 namespace esphome {
-namespace jutta_proto {
+namespace jutta_component {
 
 static const char *const TAG = "jutta_proto";
 
@@ -280,6 +280,6 @@ bool JuraComponent::is_busy() const {
   return this->coffee_maker_->is_locked();
 }
 
-}  // namespace jutta_proto
+}  // namespace jutta_component
 }  // namespace esphome
 

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -15,7 +15,7 @@
 #include "jutta_commands.hpp"
 
 namespace esphome {
-namespace jutta_proto {
+namespace jutta_component {
 
 class JuraComponent : public esphome::Component, public esphome::uart::UARTDevice {
  public:
@@ -95,6 +95,6 @@ class SwitchPageAction : public esphome::Action<> {
   uint32_t page_{0};
 };
 
-}  // namespace jutta_proto
+}  // namespace jutta_component
 }  // namespace esphome
 


### PR DESCRIPTION
## Summary
- move the ESPHome component implementation into a dedicated `esphome::jutta_component` namespace to avoid the global `::jutta_proto` collision
- update the Python code generator to reference the renamed namespace

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3caefde9083288cac0a8b856b0d7f