### PR TITLE
Add decoded RX buffer to Jutta connection

### DIFF
--- a/esphome/components/jutta_proto/jutta_connection.hpp
+++ b/esphome/components/jutta_proto/jutta_connection.hpp
@@ -259,6 +259,8 @@ class JuttaConnection {
     // decoded data byte yet.
     mutable std::vector<uint8_t> encoded_rx_buffer_{};
 
+    // Buffer for decoded bytes that were read ahead of the consumer.
+    mutable std::deque<uint8_t> decoded_rx_buffer_{};
 
     void reinject_decoded_front(const std::string& data) const;
 


### PR DESCRIPTION
## Summary
- add a buffer for decoded bytes in `JuttaConnection`

## Testing
- `pio run -e jura-e6` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3e49126308328a8b83c238a0bd72c