### PR TITLE
Fix missing brace in read_encoded_unsafe

### DIFF
--- a/esphome/components/jutta_proto/jutta_connection.cpp
+++ b/esphome/components/jutta_proto/jutta_connection.cpp
@@ -274,7 +274,8 @@ bool JuttaConnection::read_encoded_unsafe(std::array<uint8_t, 4>& buffer) const 
         if (!align_encoded_rx_buffer()) {
             return false;
         }
-      
+    }
+
     if (!this->encoded_rx_buffer_.empty() && (this->encoded_rx_buffer_.size() % buffer.size()) != 0) {
         ESP_LOGW(TAG, "Discarding %zu stray encoded bytes.", this->encoded_rx_buffer_.size());
         flush_serial_input();


### PR DESCRIPTION
## Summary
- close the early alignment block in `JuttaConnection::read_encoded_unsafe`
- restore proper function boundaries so later methods compile again

## Testing
- `pio run -e jura-e6` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4078909f88328a38f3d00dd7520da