### PR TITLE
Ensure 8ms gap between encoded bytes

### DIFF
--- a/esphome/components/jutta_proto/jutta_connection.cpp
+++ b/esphome/components/jutta_proto/jutta_connection.cpp
@@ -245,10 +245,14 @@ uint8_t JuttaConnection::decode(const std::array<uint8_t, 4>& encData) {
 }
 
 bool JuttaConnection::write_encoded_unsafe(const std::array<uint8_t, 4>& encData) const {
-    bool result = serial.write_serial(encData);
-    serial.flush();
-    wait_for_jutta_gap();
-    return result;
+    for (size_t i = 0; i < encData.size(); ++i) {
+        if (!serial.write_serial_byte(encData[i])) {
+            return false;
+        }
+        serial.flush();
+        wait_for_jutta_gap();
+    }
+    return true;
 }
 
 bool JuttaConnection::read_encoded_unsafe(std::array<uint8_t, 4>& buffer) const {

--- a/esphome/components/jutta_proto/serial_connection.cpp
+++ b/esphome/components/jutta_proto/serial_connection.cpp
@@ -38,6 +38,16 @@ bool SerialConnection::write_serial(const std::array<uint8_t, 4>& data) const {
     return true;
 }
 
+bool SerialConnection::write_serial_byte(uint8_t byte) const {
+    if (this->parent_ == nullptr) {
+        ESP_LOGE(TAG, "UART component not configured for serial connection.");
+        return false;
+    }
+    auto* self = const_cast<SerialConnection*>(this);
+    self->write_byte(byte);
+    return true;
+}
+
 void SerialConnection::flush() const {
     if (this->parent_ != nullptr) {
         this->parent_->flush();

--- a/esphome/components/jutta_proto/serial_connection.hpp
+++ b/esphome/components/jutta_proto/serial_connection.hpp
@@ -29,6 +29,11 @@ class SerialConnection : public esphome::uart::UARTDevice {
      * Returns true on success.
      **/
     [[nodiscard]] bool write_serial(const std::array<uint8_t, 4>& data) const;
+    /**
+     * Writes a single byte to the serial connection.
+     * Returns true on success.
+     **/
+    [[nodiscard]] bool write_serial_byte(uint8_t byte) const;
     void flush() const;
 
     /**


### PR DESCRIPTION
## Summary
- add a UART helper to send single bytes through the serial connection
- ensure each encoded JUTTA byte is sent with the required 8 ms gap to match the device timing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d40a5b55888328923f6c32e615645c