### PR TITLE
Fix UART encode/decode transmission handling

### DIFF
--- a/esphome/components/jutta_proto/jutta_connection.cpp
+++ b/esphome/components/jutta_proto/jutta_connection.cpp
@@ -245,10 +245,14 @@ uint8_t JuttaConnection::decode(const std::array<uint8_t, 4>& encData) {
 }
 
 bool JuttaConnection::write_encoded_unsafe(const std::array<uint8_t, 4>& encData) const {
-    bool result = serial.write_serial(encData);
-    serial.flush();
-    wait_for_jutta_gap();
-    return result;
+    for (size_t i = 0; i < encData.size(); ++i) {
+        if (!serial.write_serial_byte(encData[i])) {
+            return false;
+        }
+        serial.flush();
+        wait_for_jutta_gap();
+    }
+    return true;
 }
 
 bool JuttaConnection::read_encoded_unsafe(std::array<uint8_t, 4>& buffer) const {
@@ -276,11 +280,6 @@ bool JuttaConnection::read_encoded_unsafe(std::array<uint8_t, 4>& buffer) const 
         }
     }
 
-    if (!this->encoded_rx_buffer_.empty() && (this->encoded_rx_buffer_.size() % buffer.size()) != 0) {
-        ESP_LOGW(TAG, "Discarding %zu stray encoded bytes.", this->encoded_rx_buffer_.size());
-        flush_serial_input();
-    }
-
     if (this->encoded_rx_buffer_.size() < buffer.size()) {
         wait_for_jutta_gap();
         std::array<uint8_t, 4> chunk{};
@@ -298,9 +297,8 @@ bool JuttaConnection::read_encoded_unsafe(std::array<uint8_t, 4>& buffer) const 
         }
 
         if (size < chunk.size()) {
-            ESP_LOGW(TAG, "Invalid amount of UART data found (%zu byte) - flushing.", size);
-            flush_serial_input();
-            return false;
+            ESP_LOGV(TAG, "Received %zu encoded byte%s - waiting for completion.", size,
+                     size == 1 ? "" : "s");
         }
 
         this->encoded_rx_buffer_.insert(this->encoded_rx_buffer_.end(), chunk.begin(), chunk.begin() + size);


### PR DESCRIPTION
## Summary
- send each encoded UART byte individually and keep the required 8 ms inter-byte delay
- preserve partial encoded frames instead of flushing the UART buffer when fewer than 4 bytes arrive

## Testing
- python -m compileall esphome

------
https://chatgpt.com/codex/tasks/task_e_68d43f4a6e3483289f0285c395825d43