### PR TITLE
Align encoded write timing with reference implementation

### DIFF
--- a/esphome/components/jutta_proto/jutta_connection.cpp
+++ b/esphome/components/jutta_proto/jutta_connection.cpp
@@ -245,16 +245,12 @@ uint8_t JuttaConnection::decode(const std::array<uint8_t, 4>& encData) {
 }
 
 bool JuttaConnection::write_encoded_unsafe(const std::array<uint8_t, 4>& encData) const {
-    bool result = true;
-    for (uint8_t byte : encData) {
-        if (!serial.write_serial_byte(byte)) {
-            result = false;
-            break;
-        }
-        serial.flush();
-        wait_for_jutta_gap();
+    if (!serial.write_serial(encData)) {
+        return false;
     }
-    return result;
+    serial.flush();
+    wait_for_jutta_gap();
+    return true;
 }
 
 bool JuttaConnection::read_encoded_unsafe(std::array<uint8_t, 4>& buffer) const {


### PR DESCRIPTION
## Summary
- send all four encoded bytes in a single serial write like the reference implementation
- flush once and insert a single 8 ms gap between successive protocol bytes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d446cbd6288328b09d69967076a895