### PR TITLE
Fix missing declarations and buffer handling

### DIFF
--- a/esphome/components/jutta_proto/jutta_connection.hpp
+++ b/esphome/components/jutta_proto/jutta_connection.hpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <deque>
 
 #include "serial_connection.hpp"
 
@@ -198,6 +199,9 @@ class JuttaConnection {
      * Not thread safe!
      **/
     [[nodiscard]] bool read_decoded_unsafe(std::vector<uint8_t>& data) const;
+
+    [[nodiscard]] bool align_encoded_rx_buffer() const;
+    void flush_serial_input() const;
 
     /**
      * Encodes the given byte into 4 JUTTA bytes and writes them to the coffee maker.


### PR DESCRIPTION
## Summary
- include the missing `<deque>` header and declare the helper methods used by the connection implementation
- rework encoded read handling to avoid shadowed variables and to copy data out of the buffered queue safely

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4f77d53808328aa1246bc5233c888