### PR TITLE
Fix jutta handshake logging helpers

### DIFF
--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -16,37 +16,13 @@ static const char *const TAG = "jutta_proto";
 
 constexpr size_t HANDSHAKE_LOG_PREVIEW_LIMIT = 64;
 
-const char *handshake_stage_name(JuraComponent::HandshakeStage stage) {
-  switch (stage) {
-    case JuraComponent::HandshakeStage::IDLE:
-      return "idle";
-    case JuraComponent::HandshakeStage::HELLO:
-      return "hello";
-    case JuraComponent::HandshakeStage::SEND_T1:
-      return "send_t1";
-    case JuraComponent::HandshakeStage::WAIT_T2:
-      return "wait_t2";
-    case JuraComponent::HandshakeStage::SEND_T2:
-      return "send_t2";
-    case JuraComponent::HandshakeStage::WAIT_T3:
-      return "wait_t3";
-    case JuraComponent::HandshakeStage::SEND_T3:
-      return "send_t3";
-    case JuraComponent::HandshakeStage::DONE:
-      return "done";
-    case JuraComponent::HandshakeStage::FAILED:
-      return "failed";
-  }
-  return "unknown";
-}
-
 std::string format_printable_char(uint8_t byte) {
   switch (byte) {
-    case '\\r':
+    case '\r':
       return "\\r";
-    case '\\n':
+    case '\n':
       return "\\n";
-    case '\\t':
+    case '\t':
       return "\\t";
     default:
       break;
@@ -107,6 +83,30 @@ std::string format_buffer_hex_preview(const std::string &value) {
 
 }  // namespace
 
+const char *JuraComponent::handshake_stage_name(JuraComponent::HandshakeStage stage) {
+  switch (stage) {
+    case JuraComponent::HandshakeStage::IDLE:
+      return "idle";
+    case JuraComponent::HandshakeStage::HELLO:
+      return "hello";
+    case JuraComponent::HandshakeStage::SEND_T1:
+      return "send_t1";
+    case JuraComponent::HandshakeStage::WAIT_T2:
+      return "wait_t2";
+    case JuraComponent::HandshakeStage::SEND_T2:
+      return "send_t2";
+    case JuraComponent::HandshakeStage::WAIT_T3:
+      return "wait_t3";
+    case JuraComponent::HandshakeStage::SEND_T3:
+      return "send_t3";
+    case JuraComponent::HandshakeStage::DONE:
+      return "done";
+    case JuraComponent::HandshakeStage::FAILED:
+      return "failed";
+  }
+  return "unknown";
+}
+
 void JuraComponent::setup() {
   if (this->parent_ == nullptr) {
     ESP_LOGE(TAG, "UART parent not configured for JUTTA Proto component.");
@@ -124,8 +124,8 @@ void JuraComponent::setup() {
 void JuraComponent::loop() {
   if (this->handshake_stage_ != this->last_logged_stage_) {
     ESP_LOGI(TAG, "Handshake stage changed: %s -> %s (buffer size=%zu, preview='%s', hex %s)",
-             handshake_stage_name(this->last_logged_stage_),
-             handshake_stage_name(this->handshake_stage_), this->handshake_buffer_.size(),
+             JuraComponent::handshake_stage_name(this->last_logged_stage_),
+             JuraComponent::handshake_stage_name(this->handshake_stage_), this->handshake_buffer_.size(),
              format_buffer_preview(this->handshake_buffer_).c_str(),
              format_buffer_hex_preview(this->handshake_buffer_).c_str());
     this->last_logged_stage_ = this->handshake_stage_;

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -35,6 +35,8 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
  protected:
   enum class HandshakeStage { IDLE, HELLO, SEND_T1, WAIT_T2, SEND_T2, WAIT_T3, SEND_T3, DONE, FAILED };
 
+  static const char *handshake_stage_name(HandshakeStage stage);
+
   void process_handshake();
   void restart_handshake(const char *reason);
   bool read_handshake_bytes();


### PR DESCRIPTION
## Summary
- expose a static helper on `JuraComponent` to retrieve handshake stage names so it can be used from logging helpers
- adjust printable character formatting to use proper control character literals and avoid multi-character warnings

## Testing
- not run (platformio unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d50e97521c8328b03282f59cc4d288