### PR TITLE
Improve handshake device type detection

### DIFF
--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -51,6 +51,7 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   std::string handshake_t2_response_;
   std::string handshake_t3_response_;
   uint32_t handshake_deadline_{0};
+  bool handshake_hello_request_sent_{false};
   bool custom_cancel_flag_{false};
 };
 


### PR DESCRIPTION
## Summary
- send the device type probe once and parse incoming lines so echoes like `TY:` are ignored until the lowercase `ty:` payload arrives
- track whether the hello request is in flight and reset the flag when restarting the handshake to avoid redundant re-sends

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d540ba8dc88328913b5b0c2d7ad21d