### PR TITLE
Handle empty device type handshake response

### DIFF
--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -240,13 +240,14 @@ void JuraComponent::process_handshake() {
 
           if (lowercase_line.rfind("ty:", 0) == 0) {
             if (line.size() <= 3) {
-              ESP_LOGW(TAG, "HELLO: ignoring empty device type response line: '%s'",
+              ESP_LOGW(TAG,
+                       "HELLO: device type response line '%s' has no payload, proceeding with unknown type.",
                        format_printable_string(line).c_str());
-              continue;
+              this->device_type_ = "TY:unknown";
+            } else {
+              this->device_type_ = line;
+              ESP_LOGI(TAG, "Detected coffee maker response: %s", this->device_type_.c_str());
             }
-
-            this->device_type_ = line;
-            ESP_LOGI(TAG, "Detected coffee maker response: %s", this->device_type_.c_str());
             this->handshake_buffer_.clear();
             this->handshake_deadline_ = 0;
             this->handshake_stage_ = HandshakeStage::SEND_T1;


### PR DESCRIPTION
## Summary
- allow the HELLO handshake to continue even when the device type line is empty
- record an unknown device type placeholder instead of restarting the handshake loop

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5448eccb883289a8546b117602d41