### PR TITLE
Add programmable sequence automation for Jutta Proto component

### DIFF
--- a/docs/components/jutta_proto.md
+++ b/docs/components/jutta_proto.md
@@ -74,6 +74,44 @@ script:
           page: 1
 ```
 
+### Run a manual command sequence
+
+```yaml
+script:
+  - id: brew_manual_recipe
+    mode: restart
+    then:
+      - jutta_proto.run_sequence:
+          id: jura
+          sequence:
+            - command: grinder_on
+              description: "Grind on"
+            - delay: 3s
+              description: "Let the grinder run"
+            - command: grinder_off
+            - command: brew_group_to_brewing_position
+            - command: coffee_press_on
+            - delay: 500ms
+              description: "Compress the coffee"
+            - command: coffee_press_off
+            - command: water_heater_on
+            - command: water_pump_on
+            - delay: 2s
+              description: "Pre-brew"
+            - command: water_pump_off
+            - command: water_heater_off
+            - delay: 2s
+            - command: water_heater_on
+            - command: water_pump_on
+            - delay: 40s
+              description: "Dispense water"
+            - command: water_pump_off
+            - command: water_heater_off
+            - command: brew_group_reset
+```
+
+Use `raw` instead of `command` when you need to send a custom UART command string. Raw commands automatically append `\r\n` if it is missing.
+
 ## Diagnostics
 
 The component logs handshake progress during startup. The `dump_config()` output lists the detected machine type as well as the

--- a/esphome/components/jutta_proto/__init__.py
+++ b/esphome/components/jutta_proto/__init__.py
@@ -11,6 +11,13 @@ CONF_COFFEE = "coffee"
 CONF_GRIND_DURATION = "grind_duration"
 CONF_WATER_DURATION = "water_duration"
 CONF_PAGE = "page"
+CONF_SEQUENCE = "sequence"
+CONF_COMMAND = "command"
+CONF_RAW = "raw"
+CONF_SLEEP = "sleep"
+CONF_DELAY = "delay"
+CONF_TIMEOUT = "timeout"
+CONF_DESCRIPTION = "description"
 
 jutta_component_ns = cg.esphome_ns.namespace("jutta_component")
 jutta_proto_ns = cg.global_ns.namespace("jutta_proto")
@@ -26,6 +33,7 @@ CancelCustomBrewAction = jutta_component_ns.class_(
     "CancelCustomBrewAction", automation.Action
 )
 SwitchPageAction = jutta_component_ns.class_("SwitchPageAction", automation.Action)
+RunSequenceAction = jutta_component_ns.class_("RunSequenceAction", automation.Action)
 
 COFFEE_TYPES = {
     "espresso": CoffeeType.ESPRESSO,
@@ -40,6 +48,33 @@ COFFEE_TYPES = {
 
 DEFAULT_GRIND_DURATION = cv.TimePeriod(milliseconds=3600)
 DEFAULT_WATER_DURATION = cv.TimePeriod(milliseconds=40000)
+DEFAULT_COMMAND_TIMEOUT = cv.TimePeriod(milliseconds=5000)
+
+SEQUENCE_COMMAND_KEYS = {
+    "grinder_on": "grinder_on",
+    "grinder_off": "grinder_off",
+    "brew_group_to_brewing_position": "brew_group_to_brewing_position",
+    "brew_group_reset": "brew_group_reset",
+    "coffee_press_on": "coffee_press_on",
+    "coffee_press_off": "coffee_press_off",
+    "water_heater_on": "water_heater_on",
+    "water_heater_off": "water_heater_off",
+    "water_pump_on": "water_pump_on",
+    "water_pump_off": "water_pump_off",
+}
+
+SEQUENCE_COMMAND_EXPRESSIONS = {
+    "grinder_on": cg.RawExpression("::jutta_proto::JUTTA_GRINDER_ON"),
+    "grinder_off": cg.RawExpression("::jutta_proto::JUTTA_GRINDER_OFF"),
+    "brew_group_to_brewing_position": cg.RawExpression("::jutta_proto::JUTTA_BREW_GROUP_TO_BREWING_POSITION"),
+    "brew_group_reset": cg.RawExpression("::jutta_proto::JUTTA_BREW_GROUP_RESET"),
+    "coffee_press_on": cg.RawExpression("::jutta_proto::JUTTA_COFFEE_PRESS_ON"),
+    "coffee_press_off": cg.RawExpression("::jutta_proto::JUTTA_COFFEE_PRESS_OFF"),
+    "water_heater_on": cg.RawExpression("::jutta_proto::JUTTA_COFFEE_WATER_HEATER_ON"),
+    "water_heater_off": cg.RawExpression("::jutta_proto::JUTTA_COFFEE_WATER_HEATER_OFF"),
+    "water_pump_on": cg.RawExpression("::jutta_proto::JUTTA_COFFEE_WATER_PUMP_ON"),
+    "water_pump_off": cg.RawExpression("::jutta_proto::JUTTA_COFFEE_WATER_PUMP_OFF"),
+}
 
 JURA_COMPONENT_IDS = []
 
@@ -89,6 +124,93 @@ def _normalize_switch_page(value):
         {
             cv.Optional(CONF_ID): cv.use_id(JuraComponent),
             cv.Required(CONF_PAGE): cv.int_range(min=0),
+        }
+    )(value)
+
+
+def _validate_sequence_step(value):
+    if isinstance(value, str):
+        value = {CONF_COMMAND: value}
+
+    if not isinstance(value, dict):
+        raise cv.Invalid("Sequence step must be a dictionary or string")
+
+    step = value.copy()
+    description = step.pop(CONF_DESCRIPTION, "")
+    description = cv.string(description)
+
+    if CONF_SLEEP in step or CONF_DELAY in step:
+        if CONF_COMMAND in step or CONF_RAW in step:
+            raise cv.Invalid("Delay step cannot include a command")
+        duration = step.pop(CONF_SLEEP, step.pop(CONF_DELAY, None))
+        if duration is None:
+            raise cv.Invalid("Delay step requires 'sleep' or 'delay'")
+        duration = cv.positive_time_period_milliseconds(duration)
+        if step:
+            raise cv.Invalid("Unknown keys in delay step: {}".format(", ".join(step.keys())))
+        return {
+            "type": "delay",
+            CONF_DELAY: duration,
+            CONF_DESCRIPTION: description,
+        }
+
+    if CONF_COMMAND in step or CONF_RAW in step:
+        command_value = step.pop(CONF_COMMAND, None)
+        raw_value = step.pop(CONF_RAW, None)
+        if command_value is not None and raw_value is not None:
+            raise cv.Invalid("Specify either 'command' or 'raw'")
+
+        delay = cv.time_period(step.pop(CONF_DELAY, cv.TimePeriod(milliseconds=0)))
+        timeout = cv.positive_time_period_milliseconds(step.pop(CONF_TIMEOUT, DEFAULT_COMMAND_TIMEOUT))
+
+        if step:
+            raise cv.Invalid("Unknown keys in command step: {}".format(", ".join(step.keys())))
+
+        if command_value is not None:
+            command_key = cv.enum(SEQUENCE_COMMAND_KEYS, lower=True)(command_value)
+            return {
+                "type": "command",
+                CONF_COMMAND: command_key,
+                CONF_DELAY: delay,
+                CONF_TIMEOUT: timeout,
+                CONF_DESCRIPTION: description,
+            }
+
+        if raw_value is None:
+            raise cv.Invalid("Command step requires either 'command' or 'raw'")
+        raw_value = cv.string(raw_value)
+        return {
+            "type": "command",
+            CONF_RAW: raw_value,
+            CONF_DELAY: delay,
+            CONF_TIMEOUT: timeout,
+            CONF_DESCRIPTION: description,
+        }
+
+    raise cv.Invalid("Sequence step must define a command/raw or delay/sleep")
+
+
+def _normalize_sequence(value):
+    if isinstance(value, list):
+        value = {CONF_SEQUENCE: value}
+    elif isinstance(value, dict):
+        base = {}
+        if CONF_ID in value:
+            base[CONF_ID] = value[CONF_ID]
+        if CONF_SEQUENCE in value:
+            base[CONF_SEQUENCE] = value[CONF_SEQUENCE]
+        else:
+            step = value.copy()
+            step.pop(CONF_ID, None)
+            base[CONF_SEQUENCE] = [step]
+        value = base
+    else:
+        raise cv.Invalid("Sequence action requires a list of steps")
+
+    return cv.Schema(
+        {
+            cv.Optional(CONF_ID): cv.use_id(JuraComponent),
+            cv.Required(CONF_SEQUENCE): cv.All(cv.ensure_list(_validate_sequence_step)),
         }
     )(value)
 
@@ -145,5 +267,31 @@ async def switch_page_action_to_code(config, action_id, template_args, args):
     parent = await _get_parent(config)
     var = cg.new_Pvariable(action_id, parent)
     cg.add(var.set_page(config[CONF_PAGE]))
+    return var
+
+
+@automation.register_action("jutta_proto.run_sequence", RunSequenceAction, _normalize_sequence)
+async def run_sequence_action_to_code(config, action_id, template_args, args):
+    _ = args
+    parent = await _get_parent(config)
+    var = cg.new_Pvariable(action_id, parent)
+
+    for step in config[CONF_SEQUENCE]:
+        description = cg.std_string(step.get(CONF_DESCRIPTION, ""))
+        if step["type"] == "command":
+            delay_ms = step[CONF_DELAY].total_milliseconds
+            timeout_ms = step[CONF_TIMEOUT].total_milliseconds
+            if CONF_COMMAND in step:
+                command_expr = SEQUENCE_COMMAND_EXPRESSIONS[step[CONF_COMMAND]]
+                cg.add(var.add_command_step(command_expr, delay_ms, timeout_ms, description))
+            else:
+                raw_command = step[CONF_RAW]
+                if not raw_command.endswith("\r\n"):
+                    raw_command = f"{raw_command}\r\n"
+                cg.add(var.add_command_step(cg.std_string(raw_command), delay_ms, timeout_ms, description))
+        else:
+            delay_ms = step[CONF_DELAY].total_milliseconds
+            cg.add(var.add_delay_step(delay_ms, description))
+
     return var
 

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -273,6 +273,18 @@ void JuraComponent::switch_page(uint32_t page) {
   this->coffee_maker_->switch_page(page);
 }
 
+void JuraComponent::run_sequence(const std::vector<::jutta_proto::CoffeeMaker::SequenceStep> &steps) {
+  if (!this->is_ready()) {
+    ESP_LOGW(TAG, "Cannot run sequence - component not ready.");
+    return;
+  }
+  if (this->coffee_maker_->is_locked()) {
+    ESP_LOGW(TAG, "Cannot run sequence - coffee maker busy.");
+    return;
+  }
+  this->coffee_maker_->run_sequence(steps);
+}
+
 bool JuraComponent::is_busy() const {
   if (this->coffee_maker_ == nullptr) {
     return false;

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
@@ -27,6 +28,7 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   void start_custom_brew(uint32_t grind_duration_ms, uint32_t water_duration_ms);
   void cancel_custom_brew();
   void switch_page(uint32_t page);
+  void run_sequence(const std::vector<::jutta_proto::CoffeeMaker::SequenceStep> &steps);
 
   bool is_ready() const { return this->handshake_stage_ == HandshakeStage::DONE && this->coffee_maker_ != nullptr; }
   bool is_busy() const;
@@ -93,6 +95,33 @@ class SwitchPageAction : public esphome::Action<> {
  protected:
   JuraComponent *parent_;
   uint32_t page_{0};
+};
+
+class RunSequenceAction : public esphome::Action<> {
+ public:
+  explicit RunSequenceAction(JuraComponent *parent) : parent_(parent) {}
+  void add_command_step(const std::string &command, uint32_t delay_ms, uint32_t timeout_ms,
+                        const std::string &description) {
+    ::jutta_proto::CoffeeMaker::SequenceStep step;
+    step.type = ::jutta_proto::CoffeeMaker::SequenceStep::Type::Command;
+    step.command = command;
+    step.delay_ms = delay_ms;
+    step.timeout = std::chrono::milliseconds{timeout_ms};
+    step.description = description;
+    steps_.push_back(step);
+  }
+  void add_delay_step(uint32_t delay_ms, const std::string &description) {
+    ::jutta_proto::CoffeeMaker::SequenceStep step;
+    step.type = ::jutta_proto::CoffeeMaker::SequenceStep::Type::Delay;
+    step.delay_ms = delay_ms;
+    step.description = description;
+    steps_.push_back(step);
+  }
+  void play() override { this->parent_->run_sequence(steps_); }
+
+ protected:
+  JuraComponent *parent_;
+  std::vector<::jutta_proto::CoffeeMaker::SequenceStep> steps_{};
 };
 
 }  // namespace jutta_component


### PR DESCRIPTION
## Summary
- add a `jutta_proto.run_sequence` automation action with schema validation and command aliases
- extend the coffee maker controller to execute arbitrary command/delay sequences safely
- document the new sequence capability with an example recipe

## Testing
- python -m compileall esphome/components/jutta_proto/__init__.py

------
https://chatgpt.com/codex/tasks/task_e_68d6fcbccaec832896a53f921e7033fc