### PR TITLE
Add machine data text sensor polling

### DIFF
--- a/esphome/components/jutta_proto/__init__.py
+++ b/esphome/components/jutta_proto/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
-from esphome.components import uart
+from esphome.components import text_sensor, uart
 from esphome.const import CONF_ID
 
 DEPENDENCIES = ["uart"]
@@ -18,6 +18,7 @@ CONF_SLEEP = "sleep"
 CONF_DELAY = "delay"
 CONF_TIMEOUT = "timeout"
 CONF_DESCRIPTION = "description"
+CONF_MACHINE_DATA = "machine_data"
 
 jutta_component_ns = cg.esphome_ns.namespace("jutta_component")
 jutta_proto_ns = cg.global_ns.namespace("jutta_proto")
@@ -86,7 +87,12 @@ JURA_COMPONENT_IDS = []
 
 
 CONFIG_SCHEMA = (
-    cv.Schema({cv.GenerateID(): cv.declare_id(JuraComponent)})
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(JuraComponent),
+            cv.Optional(CONF_MACHINE_DATA): text_sensor.text_sensor_schema(),
+        }
+    )
     .extend(uart.UART_DEVICE_SCHEMA)
     .extend(cv.COMPONENT_SCHEMA)
 )
@@ -226,6 +232,10 @@ async def to_code(config):
     JURA_COMPONENT_IDS.append(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
+
+    if CONF_MACHINE_DATA in config:
+        sensor = await text_sensor.new_text_sensor(config[CONF_MACHINE_DATA])
+        cg.add(var.set_machine_data_sensor(sensor))
 
 
 async def _get_parent(config):

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -16,6 +16,9 @@ namespace {
 static const char *const TAG = "jutta_proto";
 
 constexpr size_t HANDSHAKE_LOG_PREVIEW_LIMIT = 64;
+constexpr uint32_t MACHINE_DATA_QUERY_INTERVAL_MS = 30000;
+constexpr uint32_t MACHINE_DATA_REQUEST_TIMEOUT_MS = 2000;
+const char *const MACHINE_DATA_COMMAND = "&STAT?\r\n";
 
 std::string format_printable_char(uint8_t byte) {
   switch (byte) {
@@ -143,6 +146,8 @@ void JuraComponent::loop() {
       this->custom_cancel_flag_ = false;
     }
   }
+
+  this->process_machine_data_query();
 }
 
 void JuraComponent::dump_config() {
@@ -408,6 +413,72 @@ bool JuraComponent::read_handshake_bytes() {
 
 bool JuraComponent::time_reached(uint32_t now, uint32_t target) {
   return static_cast<int32_t>(now - target) >= 0;
+}
+
+void JuraComponent::process_machine_data_query() {
+  if (this->machine_data_sensor_ == nullptr) {
+    return;
+  }
+  if (!this->is_ready()) {
+    return;
+  }
+  if (this->coffee_maker_ == nullptr || this->coffee_maker_->connection == nullptr) {
+    return;
+  }
+  if (this->is_busy()) {
+    return;
+  }
+
+  uint32_t now = esphome::millis();
+
+  auto handle_response = [&](const std::shared_ptr<std::string> &response) {
+    if (response != nullptr) {
+      this->publish_machine_data_(*response);
+      this->machine_data_query_next_ = now + MACHINE_DATA_QUERY_INTERVAL_MS;
+      this->machine_data_request_pending_ = false;
+      return true;
+    }
+    return false;
+  };
+
+  if (this->machine_data_request_pending_) {
+    auto response = this->coffee_maker_->connection->write_decoded_with_response(
+        MACHINE_DATA_COMMAND, std::chrono::milliseconds{MACHINE_DATA_REQUEST_TIMEOUT_MS});
+    if (handle_response(response)) {
+      return;
+    }
+    if (time_reached(now, this->machine_data_request_start_ + MACHINE_DATA_REQUEST_TIMEOUT_MS)) {
+      ESP_LOGW(TAG, "Timeout while waiting for machine data response.");
+      this->machine_data_request_pending_ = false;
+      this->machine_data_query_next_ = now + MACHINE_DATA_QUERY_INTERVAL_MS;
+    }
+    return;
+  }
+
+  if (this->machine_data_query_next_ != 0 &&
+      !time_reached(now, this->machine_data_query_next_)) {
+    return;
+  }
+
+  this->machine_data_request_start_ = now;
+  auto response = this->coffee_maker_->connection->write_decoded_with_response(
+      MACHINE_DATA_COMMAND, std::chrono::milliseconds{MACHINE_DATA_REQUEST_TIMEOUT_MS});
+  if (handle_response(response)) {
+    return;
+  }
+
+  this->machine_data_request_pending_ = true;
+}
+
+void JuraComponent::publish_machine_data_(const std::string &response) {
+  std::string sanitized = response;
+  sanitized.erase(std::remove_if(sanitized.begin(), sanitized.end(),
+                                 [](unsigned char c) { return c == '\r' || c == '\n'; }),
+                  sanitized.end());
+  ESP_LOGD(TAG, "Machine data response: %s", sanitized.c_str());
+  if (this->machine_data_sensor_ != nullptr) {
+    this->machine_data_sensor_->publish_state(sanitized);
+  }
 }
 
 void JuraComponent::start_brew(::jutta_proto::CoffeeMaker::coffee_t coffee) {

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -9,6 +9,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/log.h"
+#include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/uart/uart.h"
 
 #include "coffee_maker.hpp"
@@ -34,6 +35,8 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   bool is_busy() const;
   const std::string &device_type() const { return this->device_type_; }
 
+  void set_machine_data_sensor(text_sensor::TextSensor *sensor) { this->machine_data_sensor_ = sensor; }
+
  protected:
   enum class HandshakeStage { IDLE, HELLO, SEND_T1, WAIT_T2, SEND_T2, WAIT_T3, SEND_T3, DONE, FAILED };
 
@@ -43,6 +46,8 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   void restart_handshake(const char *reason);
   bool read_handshake_bytes();
   static bool time_reached(uint32_t now, uint32_t target);
+  void process_machine_data_query();
+  void publish_machine_data_(const std::string &response);
 
   std::unique_ptr<::jutta_proto::JuttaConnection> connection_;
   std::unique_ptr<::jutta_proto::CoffeeMaker> coffee_maker_;
@@ -55,6 +60,10 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   uint32_t handshake_deadline_{0};
   bool handshake_hello_request_sent_{false};
   bool custom_cancel_flag_{false};
+  text_sensor::TextSensor *machine_data_sensor_{nullptr};
+  uint32_t machine_data_query_next_{0};
+  bool machine_data_request_pending_{false};
+  uint32_t machine_data_request_start_{0};
 };
 
 class StartBrewAction : public esphome::Action<> {


### PR DESCRIPTION
## Summary
- add an optional `machine_data` text sensor to the jutta_proto component configuration
- poll the Jura machine with the plain `&STAT?` request once the handshake finished and publish the response via the sensor

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d942fb38448328b498078f9b761213