### PR TITLE
Add machine data text sensor support

### DIFF
--- a/esphome/components/jutta_proto/__init__.py
+++ b/esphome/components/jutta_proto/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
-from esphome.components import uart
+from esphome.components import text_sensor, uart
 from esphome.const import CONF_ID
 
 DEPENDENCIES = ["uart"]
@@ -18,6 +18,7 @@ CONF_SLEEP = "sleep"
 CONF_DELAY = "delay"
 CONF_TIMEOUT = "timeout"
 CONF_DESCRIPTION = "description"
+CONF_MACHINE_DATA = "machine_data"
 
 jutta_component_ns = cg.esphome_ns.namespace("jutta_component")
 jutta_proto_ns = cg.global_ns.namespace("jutta_proto")
@@ -86,7 +87,15 @@ JURA_COMPONENT_IDS = []
 
 
 CONFIG_SCHEMA = (
-    cv.Schema({cv.GenerateID(): cv.declare_id(JuraComponent)})
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(JuraComponent),
+            cv.Optional(CONF_MACHINE_DATA): text_sensor.text_sensor_schema(
+                icon="mdi:clipboard-text",
+                entity_category=cv.EntityCategory.DIAGNOSTIC,
+            ),
+        }
+    )
     .extend(uart.UART_DEVICE_SCHEMA)
     .extend(cv.COMPONENT_SCHEMA)
 )
@@ -226,6 +235,10 @@ async def to_code(config):
     JURA_COMPONENT_IDS.append(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
+
+    if CONF_MACHINE_DATA in config:
+        sens = await text_sensor.new_text_sensor(config[CONF_MACHINE_DATA])
+        cg.add(var.set_machine_data_sensor(sens))
 
 
 async def _get_parent(config):

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -1,6 +1,7 @@
 #include "esphome/components/jutta_proto/jutta_proto.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cctype>
 #include <iomanip>
 #include <sstream>
@@ -16,6 +17,9 @@ namespace {
 static const char *const TAG = "jutta_proto";
 
 constexpr size_t HANDSHAKE_LOG_PREVIEW_LIMIT = 64;
+constexpr uint32_t MACHINE_DATA_QUERY_INTERVAL_MS = 60000;
+constexpr uint32_t MACHINE_DATA_RETRY_DELAY_MS = 10000;
+constexpr uint32_t MACHINE_DATA_COMMAND_TIMEOUT_MS = 4000;
 
 std::string format_printable_char(uint8_t byte) {
   switch (byte) {
@@ -143,6 +147,10 @@ void JuraComponent::loop() {
       this->custom_cancel_flag_ = false;
     }
   }
+
+  if (this->handshake_stage_ == HandshakeStage::DONE) {
+    this->process_machine_data_query();
+  }
 }
 
 void JuraComponent::dump_config() {
@@ -196,6 +204,11 @@ void JuraComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "  Coffee maker ready: %s", YESNO(true));
   } else {
     ESP_LOGCONFIG(TAG, "  Coffee maker ready: %s", YESNO(false));
+  }
+
+  if (this->machine_data_sensor_ != nullptr) {
+    ESP_LOGCONFIG(TAG, "  Machine data sensor configured: %s",
+                  this->machine_data_sensor_->get_name().c_str());
   }
 }
 
@@ -457,6 +470,47 @@ void JuraComponent::run_sequence(const std::vector<::jutta_proto::CoffeeMaker::S
     return;
   }
   this->coffee_maker_->run_sequence(steps);
+}
+
+void JuraComponent::process_machine_data_query() {
+  if (this->machine_data_sensor_ == nullptr || this->connection_ == nullptr) {
+    return;
+  }
+
+  uint32_t now = esphome::millis();
+
+  if (!this->machine_data_query_active_) {
+    if (this->machine_data_next_query_ != 0 &&
+        !JuraComponent::time_reached(now, this->machine_data_next_query_)) {
+      return;
+    }
+
+    this->machine_data_query_active_ = true;
+    this->machine_data_request_deadline_ = now + MACHINE_DATA_COMMAND_TIMEOUT_MS;
+    ESP_LOGI(TAG, "Requesting machine data using command '%s'", this->machine_data_command_.c_str());
+  }
+
+  auto response = this->connection_->write_decoded_with_response(
+      this->machine_data_command_, std::chrono::milliseconds{MACHINE_DATA_COMMAND_TIMEOUT_MS});
+  if (response != nullptr) {
+    std::string payload = *response;
+    ESP_LOGI(TAG, "Received machine data response: '%s'", payload.c_str());
+    this->machine_data_sensor_->publish_state(payload);
+
+    this->machine_data_query_active_ = false;
+    this->machine_data_request_deadline_ = 0;
+    this->machine_data_next_query_ = now + MACHINE_DATA_QUERY_INTERVAL_MS;
+    return;
+  }
+
+  if (this->machine_data_request_deadline_ != 0 &&
+      JuraComponent::time_reached(now, this->machine_data_request_deadline_)) {
+    ESP_LOGW(TAG, "Machine data query timed out, will retry after %u ms.",
+             MACHINE_DATA_RETRY_DELAY_MS);
+    this->machine_data_query_active_ = false;
+    this->machine_data_request_deadline_ = 0;
+    this->machine_data_next_query_ = now + MACHINE_DATA_RETRY_DELAY_MS;
+  }
 }
 
 bool JuraComponent::is_busy() const {

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -9,6 +9,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/log.h"
+#include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/uart/uart.h"
 
 #include "coffee_maker.hpp"
@@ -34,6 +35,8 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   bool is_busy() const;
   const std::string &device_type() const { return this->device_type_; }
 
+  void set_machine_data_sensor(text_sensor::TextSensor *sensor) { this->machine_data_sensor_ = sensor; }
+
  protected:
   enum class HandshakeStage { IDLE, HELLO, SEND_T1, WAIT_T2, SEND_T2, WAIT_T3, SEND_T3, DONE, FAILED };
 
@@ -43,6 +46,8 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   void restart_handshake(const char *reason);
   bool read_handshake_bytes();
   static bool time_reached(uint32_t now, uint32_t target);
+
+  void process_machine_data_query();
 
   std::unique_ptr<::jutta_proto::JuttaConnection> connection_;
   std::unique_ptr<::jutta_proto::CoffeeMaker> coffee_maker_;
@@ -55,6 +60,12 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   uint32_t handshake_deadline_{0};
   bool handshake_hello_request_sent_{false};
   bool custom_cancel_flag_{false};
+
+  text_sensor::TextSensor *machine_data_sensor_{nullptr};
+  bool machine_data_query_active_{false};
+  uint32_t machine_data_request_deadline_{0};
+  uint32_t machine_data_next_query_{0};
+  std::string machine_data_command_{"@TM:00,FC\r\n"};
 };
 
 class StartBrewAction : public esphome::Action<> {

--- a/sample.yaml
+++ b/sample.yaml
@@ -22,6 +22,8 @@ uart:
 jutta_proto:
   id: jura
   uart_id: jura_uart
+  machine_data:
+    name: "JURA Machine Data"
 
 # Convenience switches to remotely power the machine on/off
 switch:


### PR DESCRIPTION
## Summary
- add optional machine data text sensor configuration to the Jutta component
- poll the coffee maker for machine data once the handshake completes and publish it to the sensor
- document the new sensor in the sample configuration

## Testing
- python -m py_compile esphome/components/jutta_proto/__init__.py

------
https://chatgpt.com/codex/tasks/task_e_68d95be784988328a37a5f6fe5963799