### PR TITLE
Fix compatibility with updated EntityCategory location

### DIFF
--- a/esphome/components/jutta_proto/__init__.py
+++ b/esphome/components/jutta_proto/__init__.py
@@ -4,6 +4,13 @@ from esphome import automation
 from esphome.components import text_sensor, uart
 from esphome.const import CONF_ID
 
+if hasattr(cv, "EntityCategory"):
+    ENTITY_CATEGORY_DIAGNOSTIC = cv.EntityCategory.DIAGNOSTIC
+else:
+    from esphome.const import EntityCategory
+
+    ENTITY_CATEGORY_DIAGNOSTIC = EntityCategory.DIAGNOSTIC
+
 DEPENDENCIES = ["uart"]
 AUTO_LOAD = ["uart"]
 
@@ -92,7 +99,7 @@ CONFIG_SCHEMA = (
             cv.GenerateID(): cv.declare_id(JuraComponent),
             cv.Optional(CONF_MACHINE_DATA): text_sensor.text_sensor_schema(
                 icon="mdi:clipboard-text",
-                entity_category=cv.EntityCategory.DIAGNOSTIC,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
         }
     )


### PR DESCRIPTION
## Summary
- add backward-compatible handling for EntityCategory enum location changes
- update the jutta_proto text sensor schema to use the shared diagnostic entity category constant

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d981f2367c8328bfd64d0e6e36d5bc