### PR TITLE
Fix EntityCategory import for jutta_proto

### DIFF
--- a/esphome/components/jutta_proto/__init__.py
+++ b/esphome/components/jutta_proto/__init__.py
@@ -4,12 +4,15 @@ from esphome import automation
 from esphome.components import text_sensor, uart
 from esphome.const import CONF_ID
 
-if hasattr(cv, "EntityCategory"):
-    ENTITY_CATEGORY_DIAGNOSTIC = cv.EntityCategory.DIAGNOSTIC
-else:
-    from esphome.const import EntityCategory
+try:
+    from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
+except ImportError:
+    if hasattr(cv, "EntityCategory"):
+        ENTITY_CATEGORY_DIAGNOSTIC = cv.EntityCategory.DIAGNOSTIC
+    else:
+        from esphome.const import EntityCategory
 
-    ENTITY_CATEGORY_DIAGNOSTIC = EntityCategory.DIAGNOSTIC
+        ENTITY_CATEGORY_DIAGNOSTIC = EntityCategory.DIAGNOSTIC
 
 DEPENDENCIES = ["uart"]
 AUTO_LOAD = ["uart"]


### PR DESCRIPTION
## Summary
- import `ENTITY_CATEGORY_DIAGNOSTIC` when available to support newer ESPHome releases
- retain fallback to the legacy `EntityCategory` enum for older versions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d98317d7908328896a28d795d05f72