### PR TITLE
Allow configuring machine data XML via machine_data key

### DIFF
--- a/esphome/components/jutta_proto/__init__.py
+++ b/esphome/components/jutta_proto/__init__.py
@@ -1,11 +1,21 @@
 import esphome.codegen as cg
+import os
+import xml.etree.ElementTree as ET
+
 import esphome.config_validation as cv
 from esphome import automation
-from esphome.components import uart
-from esphome.const import CONF_ID
+from esphome.components import text_sensor, uart
+from esphome.const import (
+    CONF_ENTITY_CATEGORY,
+    CONF_ICON,
+    CONF_ID,
+    CONF_NAME,
+    ENTITY_CATEGORY_DIAGNOSTIC,
+    ICON_INFORMATION,
+)
 
 DEPENDENCIES = ["uart"]
-AUTO_LOAD = ["uart"]
+AUTO_LOAD = ["uart", "text_sensor"]
 
 CONF_COFFEE = "coffee"
 CONF_GRIND_DURATION = "grind_duration"
@@ -18,6 +28,8 @@ CONF_SLEEP = "sleep"
 CONF_DELAY = "delay"
 CONF_TIMEOUT = "timeout"
 CONF_DESCRIPTION = "description"
+CONF_MACHINE_DATA = "machine_data"
+CONF_MACHINE_DATA_XML = "machine_data_xml"
 
 jutta_component_ns = cg.esphome_ns.namespace("jutta_component")
 jutta_proto_ns = cg.global_ns.namespace("jutta_proto")
@@ -85,11 +97,66 @@ SEQUENCE_COMMAND_EXPRESSIONS = {
 JURA_COMPONENT_IDS = []
 
 
-CONFIG_SCHEMA = (
-    cv.Schema({cv.GenerateID(): cv.declare_id(JuraComponent)})
+def _validate_config(config):
+    if CONF_MACHINE_DATA in config and CONF_MACHINE_DATA_XML in config:
+        raise cv.Invalid(
+            "Please configure only one of 'machine_data' or 'machine_data_xml'."
+        )
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(JuraComponent),
+            cv.Optional(CONF_MACHINE_DATA): cv.file_,
+            cv.Optional(CONF_MACHINE_DATA_XML): cv.file_,
+        }
+    )
     .extend(uart.UART_DEVICE_SCHEMA)
-    .extend(cv.COMPONENT_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA),
+    _validate_config,
 )
+
+
+def _qualify(tag, namespace):
+    if not namespace:
+        return tag
+    return f"{{{namespace}}}{tag}"
+
+
+def _parse_machine_data_banks(path):
+    if not os.path.exists(path):
+        raise cv.Invalid(f"Machine data XML not found: {path}")
+
+    try:
+        tree = ET.parse(path)
+    except OSError as err:
+        raise cv.Invalid(f"Failed to open machine data XML '{path}': {err}") from err
+    except ET.ParseError as err:
+        raise cv.Invalid(f"Invalid machine data XML '{path}': {err}") from err
+
+    root = tree.getroot()
+    namespace = ""
+    if root.tag.startswith("{") and "}" in root.tag:
+        namespace = root.tag[1 : root.tag.index("}")]
+
+    statistic = root.find(_qualify("STATISTIC", namespace))
+    if statistic is None:
+        return []
+
+    seen_commands = set()
+    entries = []
+    bank_path = ".//" + _qualify("BANK", namespace)
+    for bank in statistic.findall(bank_path):
+        command = bank.attrib.get("Command", "").strip()
+        if not command or command in seen_commands:
+            continue
+        seen_commands.add(command)
+        label = bank.attrib.get("Name", command).strip()
+        entries.append({"command": command, "label": label})
+
+    return entries
 
 
 def _normalize_start_brew(value):
@@ -226,6 +293,27 @@ async def to_code(config):
     JURA_COMPONENT_IDS.append(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
+
+    xml_path = None
+    if CONF_MACHINE_DATA in config:
+        xml_path = config[CONF_MACHINE_DATA]
+    elif CONF_MACHINE_DATA_XML in config:
+        xml_path = config[CONF_MACHINE_DATA_XML]
+
+    if xml_path:
+        entries = _parse_machine_data_banks(xml_path)
+        for entry in entries:
+            friendly_name = f"JURA {entry['label']}"
+            sensor_conf = text_sensor.text_sensor_schema(
+                icon=ICON_INFORMATION,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            )({CONF_NAME: friendly_name})
+            sensor = await text_sensor.new_text_sensor(sensor_conf)
+            cg.add(
+                var.add_machine_data_sensor(
+                    cg.std_string(entry["command"]), sensor, cg.std_string(entry["label"])
+                )
+            )
 
 
 async def _get_parent(config):

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -82,6 +82,18 @@ std::string format_buffer_hex_preview(const std::string &value) {
   return formatted_suffix;
 }
 
+std::string trim_ascii(const std::string &value) {
+  size_t start = 0;
+  while (start < value.size() && std::isspace(static_cast<unsigned char>(value[start])) != 0) {
+    ++start;
+  }
+  size_t end = value.size();
+  while (end > start && std::isspace(static_cast<unsigned char>(value[end - 1])) != 0) {
+    --end;
+  }
+  return value.substr(start, end - start);
+}
+
 }  // namespace
 
 const char *JuraComponent::handshake_stage_name(JuraComponent::HandshakeStage stage) {
@@ -143,6 +155,8 @@ void JuraComponent::loop() {
       this->custom_cancel_flag_ = false;
     }
   }
+
+  this->process_machine_data_queries();
 }
 
 void JuraComponent::dump_config() {
@@ -196,6 +210,14 @@ void JuraComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "  Coffee maker ready: %s", YESNO(true));
   } else {
     ESP_LOGCONFIG(TAG, "  Coffee maker ready: %s", YESNO(false));
+  }
+
+  if (!this->machine_data_sensors_.empty()) {
+    ESP_LOGCONFIG(TAG, "  Machine data sensors:");
+    for (const auto &entry : this->machine_data_sensors_) {
+      std::string normalized_command = trim_ascii(entry.command);
+      ESP_LOGCONFIG(TAG, "    %s (%s)", entry.label.c_str(), normalized_command.c_str());
+    }
   }
 }
 
@@ -382,6 +404,14 @@ void JuraComponent::restart_handshake(const char *reason) {
   if (this->connection_ != nullptr) {
     this->connection_->reset_response_line_buffer();
   }
+  this->machine_data_request_active_ = false;
+  this->machine_data_active_command_.clear();
+  this->machine_data_query_deadline_ = 0;
+  this->machine_data_next_index_ = 0;
+  this->machine_data_active_index_ = 0;
+  for (auto &entry : this->machine_data_sensors_) {
+    entry.completed = false;
+  }
 }
 
 bool JuraComponent::read_handshake_bytes() {
@@ -408,6 +438,119 @@ bool JuraComponent::read_handshake_bytes() {
 
 bool JuraComponent::time_reached(uint32_t now, uint32_t target) {
   return static_cast<int32_t>(now - target) >= 0;
+}
+
+void JuraComponent::add_machine_data_sensor(const std::string &command, text_sensor::TextSensor *sensor,
+                                            const std::string &label) {
+  MachineDataSensorEntry entry;
+  entry.command = trim_ascii(command);
+  if (entry.command.size() < 2 || entry.command.substr(entry.command.size() - 2) != "\r\n") {
+    entry.command.append("\r\n");
+  }
+  entry.label = label;
+  entry.sensor = sensor;
+  entry.completed = false;
+  this->machine_data_sensors_.push_back(entry);
+}
+
+void JuraComponent::process_machine_data_queries() {
+  if (this->machine_data_sensors_.empty()) {
+    return;
+  }
+  if (!this->is_ready()) {
+    return;
+  }
+  if (this->coffee_maker_ == nullptr || this->coffee_maker_->connection == nullptr) {
+    return;
+  }
+  if (this->coffee_maker_->is_locked()) {
+    return;
+  }
+
+  if (!this->machine_data_request_active_ && this->machine_data_next_index_ >= this->machine_data_sensors_.size()) {
+    return;
+  }
+
+  uint32_t now = esphome::millis();
+  auto &connection = *this->coffee_maker_->connection;
+
+  auto handle_timeout = [&](size_t index) {
+    if (index >= this->machine_data_sensors_.size()) {
+      return;
+    }
+    auto &entry = this->machine_data_sensors_[index];
+    ESP_LOGW(TAG, "Machine data query for '%s' (%s) timed out.", entry.label.c_str(),
+             format_printable_string(entry.command).c_str());
+    if (entry.sensor != nullptr) {
+      entry.sensor->publish_state("");
+    }
+    entry.completed = true;
+  };
+
+  if (this->machine_data_request_active_) {
+    auto response = connection.write_decoded_with_response(
+        this->machine_data_active_command_, std::chrono::milliseconds{this->machine_data_query_timeout_ms_});
+    if (response == nullptr) {
+      if (this->machine_data_query_deadline_ != 0 && time_reached(now, this->machine_data_query_deadline_)) {
+        handle_timeout(this->machine_data_active_index_);
+        this->machine_data_request_active_ = false;
+        this->machine_data_active_command_.clear();
+        this->machine_data_query_deadline_ = 0;
+        this->machine_data_next_index_ = this->machine_data_active_index_ + 1;
+      }
+      return;
+    }
+
+    this->handle_machine_data_response(this->machine_data_active_index_, *response);
+    this->machine_data_request_active_ = false;
+    this->machine_data_active_command_.clear();
+    this->machine_data_query_deadline_ = 0;
+    this->machine_data_next_index_ = this->machine_data_active_index_ + 1;
+    return;
+  }
+
+  if (this->machine_data_next_index_ >= this->machine_data_sensors_.size()) {
+    return;
+  }
+
+  auto &entry = this->machine_data_sensors_[this->machine_data_next_index_];
+  if (entry.completed) {
+    ++this->machine_data_next_index_;
+    return;
+  }
+  if (entry.sensor == nullptr) {
+    entry.completed = true;
+    ++this->machine_data_next_index_;
+    return;
+  }
+
+  this->machine_data_active_index_ = this->machine_data_next_index_;
+  this->machine_data_active_command_ = entry.command;
+  auto response = connection.write_decoded_with_response(
+      this->machine_data_active_command_, std::chrono::milliseconds{this->machine_data_query_timeout_ms_});
+  if (response == nullptr) {
+    this->machine_data_request_active_ = true;
+    this->machine_data_query_deadline_ = now + this->machine_data_query_timeout_ms_;
+    return;
+  }
+
+  this->handle_machine_data_response(this->machine_data_active_index_, *response);
+  ++this->machine_data_next_index_;
+}
+
+void JuraComponent::handle_machine_data_response(size_t index, const std::string &response) {
+  if (index >= this->machine_data_sensors_.size()) {
+    return;
+  }
+  auto &entry = this->machine_data_sensors_[index];
+  std::string trimmed_response = trim_ascii(response);
+  entry.completed = true;
+  if (entry.sensor != nullptr) {
+    entry.sensor->publish_state(trimmed_response);
+  }
+  std::string normalized_command = trim_ascii(entry.command);
+  ESP_LOGI(TAG, "Machine data '%s' (%s) -> '%s'", entry.label.c_str(), normalized_command.c_str(),
+           format_printable_string(trimmed_response).c_str());
 }
 
 void JuraComponent::start_brew(::jutta_proto::CoffeeMaker::coffee_t coffee) {

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -10,6 +10,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/log.h"
 #include "esphome/components/uart/uart.h"
+#include "esphome/components/text_sensor/text_sensor.h"
 
 #include "coffee_maker.hpp"
 #include "jutta_connection.hpp"
@@ -29,6 +30,8 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   void cancel_custom_brew();
   void switch_page(uint32_t page);
   void run_sequence(const std::vector<::jutta_proto::CoffeeMaker::SequenceStep> &steps);
+  void add_machine_data_sensor(const std::string &command, text_sensor::TextSensor *sensor,
+                               const std::string &label);
 
   bool is_ready() const { return this->handshake_stage_ == HandshakeStage::DONE && this->coffee_maker_ != nullptr; }
   bool is_busy() const;
@@ -43,6 +46,8 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   void restart_handshake(const char *reason);
   bool read_handshake_bytes();
   static bool time_reached(uint32_t now, uint32_t target);
+  void process_machine_data_queries();
+  void handle_machine_data_response(size_t index, const std::string &response);
 
   std::unique_ptr<::jutta_proto::JuttaConnection> connection_;
   std::unique_ptr<::jutta_proto::CoffeeMaker> coffee_maker_;
@@ -55,6 +60,21 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   uint32_t handshake_deadline_{0};
   bool handshake_hello_request_sent_{false};
   bool custom_cancel_flag_{false};
+
+  struct MachineDataSensorEntry {
+    std::string command;
+    std::string label;
+    text_sensor::TextSensor *sensor{nullptr};
+    bool completed{false};
+  };
+
+  std::vector<MachineDataSensorEntry> machine_data_sensors_{};
+  size_t machine_data_next_index_{0};
+  size_t machine_data_active_index_{0};
+  bool machine_data_request_active_{false};
+  uint32_t machine_data_query_deadline_{0};
+  std::string machine_data_active_command_{};
+  uint32_t machine_data_query_timeout_ms_{1500};
 };
 
 class StartBrewAction : public esphome::Action<> {


### PR DESCRIPTION
## Summary
- allow the Jura component to load machine data sensors via a new `machine_data` option
- prevent ambiguous configuration by validating that only one XML path option is supplied

## Testing
- python -m compileall esphome/components/jutta_proto/__init__.py

------
https://chatgpt.com/codex/tasks/task_e_68d95be784988328a37a5f6fe5963799