### PR TITLE
Add fallback for missing ICON_INFORMATION constant

### DIFF
--- a/esphome/components/jutta_proto/__init__.py
+++ b/esphome/components/jutta_proto/__init__.py
@@ -11,8 +11,12 @@ from esphome.const import (
     CONF_ID,
     CONF_NAME,
     ENTITY_CATEGORY_DIAGNOSTIC,
-    ICON_INFORMATION,
 )
+
+try:
+    from esphome.const import ICON_INFORMATION
+except ImportError:
+    ICON_INFORMATION = "mdi:information"
 
 
 try:


### PR DESCRIPTION
## Summary
- add a local fallback definition for `ICON_INFORMATION` so the component can load on newer ESPHome versions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d98a80da388328a0fe829446ff7290