### PR TITLE
Handle automation registry type errors

### DIFF
--- a/esphome/components/jutta_proto/__init__.py
+++ b/esphome/components/jutta_proto/__init__.py
@@ -132,12 +132,15 @@ def _register_action_once(name, action_cls, schema):
         if hasattr(registry, "get"):
             try:
                 registry.get(name)
-            except KeyError:
+            except (KeyError, TypeError, ValueError, AttributeError):
                 pass
             else:
                 already_registered = True
         elif hasattr(registry, "__contains__"):
-            already_registered = name in registry
+            try:
+                already_registered = name in registry
+            except TypeError:
+                already_registered = False
 
     if already_registered:
         def decorator(func):


### PR DESCRIPTION
## Summary
- guard the jutta_proto action registration duplicate check against new automation registry key types

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d98f8cc8d08328a87d26f4a8ed4fb8