### PR TITLE
Fix action registration for jutta_proto

### DIFF
--- a/esphome/components/jutta_proto/__init__.py
+++ b/esphome/components/jutta_proto/__init__.py
@@ -131,11 +131,11 @@ def _register_action_once(name, action_cls, schema):
     if registry is not None:
         if hasattr(registry, "get"):
             try:
-                registry.get(name)
+                existing = registry.get(name)
             except (KeyError, TypeError, ValueError, AttributeError):
                 pass
             else:
-                already_registered = True
+                already_registered = existing is not None
         elif hasattr(registry, "__contains__"):
             try:
                 already_registered = name in registry


### PR DESCRIPTION
## Summary
- ensure action registration checks only treat existing entries as registered when a value is returned

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d991c7707c83289d2130fac4035d98