### PR TITLE
Stabilize JURA component ID tracking

### DIFF
--- a/esphome/components/jutta_proto/__init__.py
+++ b/esphome/components/jutta_proto/__init__.py
@@ -1,6 +1,7 @@
 import codecs
 import logging
 import os
+from typing import Any, Dict, Hashable
 import xml.etree.ElementTree as ET
 
 import esphome.codegen as cg
@@ -115,7 +116,16 @@ SEQUENCE_COMMAND_EXPRESSIONS = {
     "water_pump_off": cg.RawExpression("::jutta_proto::JUTTA_COFFEE_WATER_PUMP_OFF"),
 }
 
-JURA_COMPONENT_IDS = []
+def _id_key(value):
+    """Create a stable dictionary key for ESPHome ID objects."""
+
+    if hasattr(value, "id"):
+        return value.id
+
+    return value
+
+
+JURA_COMPONENT_IDS: Dict[Hashable, Any] = {}
 
 
 def _iter_action_containers():
@@ -500,7 +510,7 @@ def _normalize_sequence(value):
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    JURA_COMPONENT_IDS.append(config[CONF_ID])
+    JURA_COMPONENT_IDS[_id_key(config[CONF_ID])] = config[CONF_ID]
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
 
@@ -534,7 +544,7 @@ async def _get_parent(config):
         raise cv.Invalid("No jutta_proto component configured")
     if len(JURA_COMPONENT_IDS) > 1:
         raise cv.Invalid("Multiple jutta_proto components configured, please set 'id'")
-    return await cg.get_variable(JURA_COMPONENT_IDS[0])
+    return await cg.get_variable(next(iter(JURA_COMPONENT_IDS.values())))
 
 
 @_register_action_once("jutta_proto.start_brew", StartBrewAction, _normalize_start_brew)


### PR DESCRIPTION
## Summary
- ensure repeated builds reuse the same registry entry for each JURA component
- replace the global list with a keyed map and helper for stable ID lookups

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d9a032d2488328ae0c3d56ed81f6d2