### PR TITLE
Improve jutta_proto duplicate detection

### DIFF
--- a/esphome/components/jutta_proto/__init__.py
+++ b/esphome/components/jutta_proto/__init__.py
@@ -1,6 +1,8 @@
 import codecs
 import logging
 import os
+from collections.abc import MutableMapping
+from typing import Any, Dict, Hashable
 import xml.etree.ElementTree as ET
 
 import esphome.codegen as cg
@@ -115,7 +117,16 @@ SEQUENCE_COMMAND_EXPRESSIONS = {
     "water_pump_off": cg.RawExpression("::jutta_proto::JUTTA_COFFEE_WATER_PUMP_OFF"),
 }
 
-JURA_COMPONENT_IDS = []
+def _id_key(value):
+    """Create a stable dictionary key for ESPHome ID objects."""
+
+    if hasattr(value, "id"):
+        return value.id
+
+    return value
+
+
+JURA_COMPONENT_IDS: Dict[Hashable, Any] = {}
 
 
 def _iter_action_containers():
@@ -136,10 +147,46 @@ def _iter_action_containers():
         seen.add(ident)
         containers.append(candidate)
 
-        for attr in ("registry", "_registry", "registrations"):
+        if isinstance(candidate, MutableMapping):
+            queue.extend(candidate.values())
+        elif isinstance(candidate, (list, tuple, set)):
+            queue.extend(candidate)
+
+        for attr in (
+            "registry",
+            "_registry",
+            "registrations",
+            "_registrations",
+            "entries",
+            "_entries",
+            "items",
+            "_items",
+            "data",
+            "_data",
+            "values",
+            "_values",
+        ):
             nested = getattr(candidate, attr, None)
-            if nested is not None:
+            if nested is None:
+                continue
+            if callable(nested):
+                continue
+            if isinstance(nested, MutableMapping):
+                queue.extend(nested.values())
                 queue.append(nested)
+            elif isinstance(nested, (list, tuple, set)):
+                queue.extend(nested)
+            else:
+                queue.append(nested)
+
+        if hasattr(candidate, "__dict__"):
+            for nested in candidate.__dict__.values():
+                if callable(nested):
+                    continue
+                if isinstance(nested, (MutableMapping, list, tuple, set)):
+                    queue.append(nested)
+                elif nested is not None:
+                    queue.append(nested)
 
     return containers
 
@@ -148,6 +195,22 @@ def _is_action_registered(name):
     """Best-effort detection if an action registration already exists."""
 
     for container in _iter_action_containers():
+        if container is None or callable(container):
+            continue
+
+        if isinstance(container, MutableMapping):
+            try:
+                if name in container:
+                    return True
+            except TypeError:
+                pass
+            try:
+                container[name]
+            except (KeyError, TypeError):
+                pass
+            else:
+                return True
+
         for method_name in ("is_registered", "has", "contains"):
             method = getattr(container, method_name, None)
             if method is None:
@@ -185,6 +248,17 @@ def _unregister_action(name):
         return False
 
     for container in containers:
+        if container is None or callable(container):
+            continue
+
+        if isinstance(container, MutableMapping):
+            try:
+                if name in container:
+                    del container[name]
+                    return True
+            except (KeyError, TypeError):
+                pass
+
         for method_name in ("unregister", "deregister", "pop", "remove"):
             method = getattr(container, method_name, None)
             if method is None:
@@ -224,21 +298,12 @@ def _register_action_once(name, action_cls, schema):
     def _register():
         return automation.register_action(name, action_cls, schema)
 
-    if _is_action_registered(name):
-        if _unregister_action(name):
-            _LOGGER.debug(
-                "Action '%s' already registered, replacing existing registration", name
-            )
-        else:
-            _LOGGER.debug(
-                "Action '%s' already registered and cannot be replaced, skipping second registration",
-                name,
-            )
-
-            def decorator(func):
-                return func
-
-            return decorator
+    duplicate_detected = _is_action_registered(name)
+    if duplicate_detected and _unregister_action(name):
+        _LOGGER.debug(
+            "Action '%s' already registered, replacing existing registration", name
+        )
+        duplicate_detected = False
 
     def _wrap_duplicate_safe_decorator(decorator):
         def _decorator(func):
@@ -263,6 +328,13 @@ def _register_action_once(name, action_cls, schema):
         message = str(err)
         if "already registered" not in message.lower():
             raise
+
+        if not duplicate_detected and _unregister_action(name):
+            _LOGGER.debug(
+                "Action '%s' duplicate detected during registration, retrying after unregister",
+                name,
+            )
+            return _wrap_duplicate_safe_decorator(_register())
 
         _LOGGER.debug(
             "Action '%s' registration raised duplicate error, skipping second registration",
@@ -500,7 +572,7 @@ def _normalize_sequence(value):
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    JURA_COMPONENT_IDS.append(config[CONF_ID])
+    JURA_COMPONENT_IDS[_id_key(config[CONF_ID])] = config[CONF_ID]
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
 
@@ -534,7 +606,7 @@ async def _get_parent(config):
         raise cv.Invalid("No jutta_proto component configured")
     if len(JURA_COMPONENT_IDS) > 1:
         raise cv.Invalid("Multiple jutta_proto components configured, please set 'id'")
-    return await cg.get_variable(JURA_COMPONENT_IDS[0])
+    return await cg.get_variable(next(iter(JURA_COMPONENT_IDS.values())))
 
 
 @_register_action_once("jutta_proto.start_brew", StartBrewAction, _normalize_start_brew)


### PR DESCRIPTION
## Summary
- broaden the automation registry traversal to cover nested mappings when locating existing action registrations
- harden duplicate detection and unregister helpers against non-mapping containers so duplicate entries can be removed reliably

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d9a032d2488328ae0c3d56ed81f6d2