### PR TITLE
Fix XML sanitization for duplicate declarations

### DIFF
--- a/esphome/components/jutta_proto/__init__.py
+++ b/esphome/components/jutta_proto/__init__.py
@@ -439,6 +439,24 @@ def _parse_machine_data_tree_with_sanitization(path):
             break
 
     raw = raw.lstrip()
+
+    if raw.startswith(b"<?xml"):
+        decl_end = raw.find(b"?>")
+        if decl_end != -1:
+            prefix = raw[: decl_end + 2]
+            suffix = raw[decl_end + 2 :]
+
+            while True:
+                next_decl = suffix.find(b"<?xml")
+                if next_decl == -1:
+                    break
+                next_end = suffix.find(b"?>", next_decl)
+                if next_end == -1:
+                    break
+                suffix = suffix[:next_decl] + suffix[next_end + 2 :]
+
+            raw = prefix + suffix
+
     return ET.ElementTree(ET.fromstring(raw))
 
 


### PR DESCRIPTION
## Summary
- skip duplicate XML declarations while sanitizing machine data files so ElementTree can parse Joe bundle exports

## Testing
- python - <<'PY'
import codecs
import xml.etree.ElementTree as ET

_KNOWN_BOMS = (
    codecs.BOM_UTF8,
    codecs.BOM_UTF16_LE,
    codecs.BOM_UTF16_BE,
    codecs.BOM_UTF32_LE,
    codecs.BOM_UTF32_BE,
)

with open('jura_joe_xml_bundle_final/joe_codes_example.xml', 'rb') as file:
    raw = file.read()

for bom in _KNOWN_BOMS:
    if raw.startswith(bom):
        raw = raw[len(bom):]
        break
raw = raw.lstrip()
if raw.startswith(b"<?xml"):
    decl_end = raw.find(b"?>")
    if decl_end != -1:
        prefix = raw[: decl_end + 2]
        suffix = raw[decl_end + 2:]
        while True:
            next_decl = suffix.find(b"<?xml")
            if next_decl == -1:
                break
            next_end = suffix.find(b"?>", next_decl)
            if next_end == -1:
                break
            suffix = suffix[:next_decl] + suffix[next_end + 2:]
        raw = prefix + suffix

ET.fromstring(raw)
print('parse success')
PY

------
https://chatgpt.com/codex/tasks/task_e_68d9aeb8978883288864289fece6a870