### PR TITLE
Allow referencing existing machine data sensors

### DIFF
--- a/docs/components/jutta_proto.md
+++ b/docs/components/jutta_proto.md
@@ -120,7 +120,8 @@ automations.
 
 Add a `machine_data` section to the component configuration and register one or multiple text sensors. When a single
 `text_sensor` entry is provided the raw XML payload is published. Alternatively, the individual sections can be configured to
-receive pre-formatted text output parsed from the XML response. All sensors are optional and can be combined as needed.
+receive pre-formatted text output parsed from the XML response. All sensors are optional and can be combined as needed. Each
+entry can either declare a new sensor inline or reference an existing `text_sensor` via its `id`.
 
 ```yaml
 text_sensor:
@@ -150,6 +151,11 @@ jutta_proto:
     processes: jura_processes
     raw: jura_machine_raw
 ```
+
+!!! note
+    The repository includes a `joe_codes_example.xml` file under `jura_joe_xml_bundle_final/`. Copy it to your ESPHome config
+    folder and import it with `!include` if you want quick access to the original J.O.E. machine data layout while testing the
+    parsed sensor output.
 
 Each formatted sensor contains a human-readable rendering of its XML section. The parser supports the different response
 variants that have been observed in the official firmware so mixed content and nested tags are handled automatically. If only

--- a/esphome/components/jutta_proto/__init__.py
+++ b/esphome/components/jutta_proto/__init__.py
@@ -33,6 +33,11 @@ MACHINE_DATA_SECTION_KEYS = [
     CONF_MACHINE_DATA_RAW,
 ]
 
+MACHINE_DATA_SENSOR_SCHEMA = cv.Any(
+    text_sensor.text_sensor_schema(),
+    cv.use_id(text_sensor.TextSensor),
+)
+
 jutta_component_ns = cg.esphome_ns.namespace("jutta_component")
 jutta_proto_ns = cg.global_ns.namespace("jutta_proto")
 
@@ -100,14 +105,14 @@ JURA_COMPONENT_IDS = []
 
 
 MACHINE_DATA_CONFIG_SCHEMA = cv.Any(
-    text_sensor.text_sensor_schema(),
+    MACHINE_DATA_SENSOR_SCHEMA,
     cv.Schema(
         {
-            cv.Optional(CONF_MACHINE_DATA_STATISTICS): text_sensor.text_sensor_schema(),
-            cv.Optional(CONF_MACHINE_DATA_ERRORS): text_sensor.text_sensor_schema(),
-            cv.Optional(CONF_MACHINE_DATA_STATUS): text_sensor.text_sensor_schema(),
-            cv.Optional(CONF_MACHINE_DATA_PROCESSES): text_sensor.text_sensor_schema(),
-            cv.Optional(CONF_MACHINE_DATA_RAW): text_sensor.text_sensor_schema(),
+            cv.Optional(CONF_MACHINE_DATA_STATISTICS): MACHINE_DATA_SENSOR_SCHEMA,
+            cv.Optional(CONF_MACHINE_DATA_ERRORS): MACHINE_DATA_SENSOR_SCHEMA,
+            cv.Optional(CONF_MACHINE_DATA_STATUS): MACHINE_DATA_SENSOR_SCHEMA,
+            cv.Optional(CONF_MACHINE_DATA_PROCESSES): MACHINE_DATA_SENSOR_SCHEMA,
+            cv.Optional(CONF_MACHINE_DATA_RAW): MACHINE_DATA_SENSOR_SCHEMA,
         }
     ),
 )
@@ -262,26 +267,42 @@ async def to_code(config):
 
     if CONF_MACHINE_DATA in config:
         machine_data_cfg = config[CONF_MACHINE_DATA]
+
+        async def _resolve_machine_data_sensor(cfg):
+            if isinstance(cfg, dict):
+                return await text_sensor.new_text_sensor(cfg)
+            return await cg.get_variable(cfg)
+
         if isinstance(machine_data_cfg, dict) and any(
             key in machine_data_cfg for key in MACHINE_DATA_SECTION_KEYS
         ):
             if CONF_MACHINE_DATA_STATISTICS in machine_data_cfg:
-                sensor = await text_sensor.new_text_sensor(machine_data_cfg[CONF_MACHINE_DATA_STATISTICS])
+                sensor = await _resolve_machine_data_sensor(
+                    machine_data_cfg[CONF_MACHINE_DATA_STATISTICS]
+                )
                 cg.add(var.set_machine_data_statistic_sensor(sensor))
             if CONF_MACHINE_DATA_ERRORS in machine_data_cfg:
-                sensor = await text_sensor.new_text_sensor(machine_data_cfg[CONF_MACHINE_DATA_ERRORS])
+                sensor = await _resolve_machine_data_sensor(
+                    machine_data_cfg[CONF_MACHINE_DATA_ERRORS]
+                )
                 cg.add(var.set_machine_data_errors_sensor(sensor))
             if CONF_MACHINE_DATA_STATUS in machine_data_cfg:
-                sensor = await text_sensor.new_text_sensor(machine_data_cfg[CONF_MACHINE_DATA_STATUS])
+                sensor = await _resolve_machine_data_sensor(
+                    machine_data_cfg[CONF_MACHINE_DATA_STATUS]
+                )
                 cg.add(var.set_machine_data_status_sensor(sensor))
             if CONF_MACHINE_DATA_PROCESSES in machine_data_cfg:
-                sensor = await text_sensor.new_text_sensor(machine_data_cfg[CONF_MACHINE_DATA_PROCESSES])
+                sensor = await _resolve_machine_data_sensor(
+                    machine_data_cfg[CONF_MACHINE_DATA_PROCESSES]
+                )
                 cg.add(var.set_machine_data_processes_sensor(sensor))
             if CONF_MACHINE_DATA_RAW in machine_data_cfg:
-                sensor = await text_sensor.new_text_sensor(machine_data_cfg[CONF_MACHINE_DATA_RAW])
+                sensor = await _resolve_machine_data_sensor(
+                    machine_data_cfg[CONF_MACHINE_DATA_RAW]
+                )
                 cg.add(var.set_machine_data_sensor(sensor))
         else:
-            sensor = await text_sensor.new_text_sensor(machine_data_cfg)
+            sensor = await _resolve_machine_data_sensor(machine_data_cfg)
             cg.add(var.set_machine_data_sensor(sensor))
 
 


### PR DESCRIPTION
## Summary
- allow the jutta_proto `machine_data` options to accept references to existing text sensors
- document the new configuration flexibility and add a hint about importing the bundled XML helper file

## Testing
- python -m compileall esphome/components/jutta_proto/__init__.py

------
https://chatgpt.com/codex/tasks/task_e_68d9b9acdc148328aab972c8ecb5ed03