### PR TITLE
Fix namespace conflicts for machine data parser

### DIFF
--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -472,7 +472,7 @@ void JuraComponent::process_machine_data_query() {
 }
 
 void JuraComponent::publish_machine_data_(const std::string &response) {
-  auto parsed = ::jutta_component::MachineDataParser::parse(response);
+  auto parsed = MachineDataParser::parse(response);
   if (!parsed.has_value()) {
     ESP_LOGW(TAG, "Failed to parse machine data XML response.");
   }
@@ -481,22 +481,22 @@ void JuraComponent::publish_machine_data_(const std::string &response) {
     const auto &root = parsed.value();
     if (this->machine_data_statistic_sensor_ != nullptr) {
       auto formatted =
-          ::jutta_component::format_machine_data_section(root.find_child_case_insensitive("STATISTIC"));
+          format_machine_data_section(root.find_child_case_insensitive("STATISTIC"));
       this->machine_data_statistic_sensor_->publish_state(formatted);
     }
     if (this->machine_data_errors_sensor_ != nullptr) {
       auto formatted =
-          ::jutta_component::format_machine_data_section(root.find_child_case_insensitive("ALERTS"));
+          format_machine_data_section(root.find_child_case_insensitive("ALERTS"));
       this->machine_data_errors_sensor_->publish_state(formatted);
     }
     if (this->machine_data_status_sensor_ != nullptr) {
-      auto formatted = ::jutta_component::format_machine_data_section(
+      auto formatted = format_machine_data_section(
           root.find_child_case_insensitive("PROGRESS_STATE_INTAKE"));
       this->machine_data_status_sensor_->publish_state(formatted);
     }
     if (this->machine_data_processes_sensor_ != nullptr) {
       auto formatted =
-          ::jutta_component::format_machine_data_section(root.find_child_case_insensitive("PROCESSES"));
+          format_machine_data_section(root.find_child_case_insensitive("PROCESSES"));
       this->machine_data_processes_sensor_->publish_state(formatted);
     }
   } else {

--- a/esphome/components/jutta_proto/machine_data_parser.cpp
+++ b/esphome/components/jutta_proto/machine_data_parser.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cctype>
 
+namespace esphome {
 namespace jutta_component {
 namespace {
 
@@ -342,4 +343,5 @@ std::string format_machine_data_section(const MachineDataNode *node) {
 }
 
 }  // namespace jutta_component
+}  // namespace esphome
 

--- a/esphome/components/jutta_proto/machine_data_parser.h
+++ b/esphome/components/jutta_proto/machine_data_parser.h
@@ -5,6 +5,7 @@
 #include <utility>
 #include <vector>
 
+namespace esphome {
 namespace jutta_component {
 
 struct MachineDataNode {
@@ -25,4 +26,5 @@ std::string format_machine_data_tree(const MachineDataNode &node);
 std::string format_machine_data_section(const MachineDataNode *node);
 
 }  // namespace jutta_component
+}  // namespace esphome
 


### PR DESCRIPTION
## Summary
- scope the machine data parser types inside the esphome::jutta_component namespace
- update Jura component code to call the parser helpers without relying on a global namespace

## Testing
- ⚠️ `pio run -e jura-e6` *(command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c1a943448328869263e6c54a4820