### PR TITLE
Decode XML entities in machine data parser

### DIFF
--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -86,6 +86,69 @@ std::string format_buffer_hex_preview(const std::string &value) {
   return formatted_suffix;
 }
 
+bool is_valid_utf8(const std::string &value) {
+  size_t i = 0;
+  while (i < value.size()) {
+    unsigned char c = static_cast<unsigned char>(value[i]);
+    if ((c & 0x80) == 0) {
+      ++i;
+      continue;
+    }
+
+    size_t sequence_length = 0;
+    if ((c & 0xE0) == 0xC0) {
+      sequence_length = 2;
+      if ((c & 0xFE) == 0xC0) {
+        return false;  // Overlong encoding of ASCII character.
+      }
+    } else if ((c & 0xF0) == 0xE0) {
+      sequence_length = 3;
+    } else if ((c & 0xF8) == 0xF0) {
+      sequence_length = 4;
+      if (c > 0xF4) {
+        return false;  // Outside valid Unicode range.
+      }
+    } else {
+      return false;  // Invalid first byte.
+    }
+
+    if (i + sequence_length > value.size()) {
+      return false;  // Truncated sequence.
+    }
+
+    for (size_t j = 1; j < sequence_length; ++j) {
+      unsigned char continuation = static_cast<unsigned char>(value[i + j]);
+      if ((continuation & 0xC0) != 0x80) {
+        return false;  // Invalid continuation byte.
+      }
+    }
+    i += sequence_length;
+  }
+  return true;
+}
+
+std::string sanitize_text_sensor_value(const std::string &value) {
+  std::string sanitized;
+  sanitized.reserve(value.size());
+  bool has_control_characters = false;
+
+  for (unsigned char c : value) {
+    if (c == '\r' || c == '\n' || c == '\0') {
+      continue;
+    }
+    if (c < 0x20 || c == 0x7F) {
+      has_control_characters = true;
+    }
+    sanitized.push_back(static_cast<char>(c));
+  }
+
+  if (!is_valid_utf8(sanitized) || has_control_characters) {
+    return format_printable_string(sanitized);
+  }
+
+  return sanitized;
+}
+
 }  // namespace
 
 const char *JuraComponent::handshake_stage_name(JuraComponent::HandshakeStage stage) {
@@ -482,22 +545,22 @@ void JuraComponent::publish_machine_data_(const std::string &response) {
     if (this->machine_data_statistic_sensor_ != nullptr) {
       auto formatted =
           format_machine_data_section(root.find_child_case_insensitive("STATISTIC"));
-      this->machine_data_statistic_sensor_->publish_state(formatted);
+      this->machine_data_statistic_sensor_->publish_state(sanitize_text_sensor_value(formatted));
     }
     if (this->machine_data_errors_sensor_ != nullptr) {
       auto formatted =
           format_machine_data_section(root.find_child_case_insensitive("ALERTS"));
-      this->machine_data_errors_sensor_->publish_state(formatted);
+      this->machine_data_errors_sensor_->publish_state(sanitize_text_sensor_value(formatted));
     }
     if (this->machine_data_status_sensor_ != nullptr) {
       auto formatted = format_machine_data_section(
           root.find_child_case_insensitive("PROGRESS_STATE_INTAKE"));
-      this->machine_data_status_sensor_->publish_state(formatted);
+      this->machine_data_status_sensor_->publish_state(sanitize_text_sensor_value(formatted));
     }
     if (this->machine_data_processes_sensor_ != nullptr) {
       auto formatted =
           format_machine_data_section(root.find_child_case_insensitive("PROCESSES"));
-      this->machine_data_processes_sensor_->publish_state(formatted);
+      this->machine_data_processes_sensor_->publish_state(sanitize_text_sensor_value(formatted));
     }
   } else {
     if (this->machine_data_statistic_sensor_ != nullptr) {
@@ -514,10 +577,7 @@ void JuraComponent::publish_machine_data_(const std::string &response) {
     }
   }
 
-  std::string sanitized = response;
-  sanitized.erase(std::remove_if(sanitized.begin(), sanitized.end(),
-                                 [](unsigned char c) { return c == '\r' || c == '\n'; }),
-                  sanitized.end());
+  std::string sanitized = sanitize_text_sensor_value(response);
   ESP_LOGD(TAG, "Machine data response: %s", sanitized.c_str());
   if (this->machine_data_sensor_ != nullptr) {
     this->machine_data_sensor_->publish_state(sanitized);

--- a/esphome/components/jutta_proto/machine_data_parser.cpp
+++ b/esphome/components/jutta_proto/machine_data_parser.cpp
@@ -2,10 +2,121 @@
 
 #include <algorithm>
 #include <cctype>
+#include <unordered_map>
 
 namespace esphome {
 namespace jutta_component {
 namespace {
+
+std::string encode_utf8(uint32_t codepoint) {
+  std::string result;
+  if (codepoint <= 0x7F) {
+    result.push_back(static_cast<char>(codepoint));
+  } else if (codepoint <= 0x7FF) {
+    result.push_back(static_cast<char>(0xC0 | ((codepoint >> 6) & 0x1F)));
+    result.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+  } else if (codepoint <= 0xFFFF) {
+    result.push_back(static_cast<char>(0xE0 | ((codepoint >> 12) & 0x0F)));
+    result.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F)));
+    result.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+  } else if (codepoint <= 0x10FFFF) {
+    result.push_back(static_cast<char>(0xF0 | ((codepoint >> 18) & 0x07)));
+    result.push_back(static_cast<char>(0x80 | ((codepoint >> 12) & 0x3F)));
+    result.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F)));
+    result.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+  }
+  return result;
+}
+
+std::optional<uint32_t> parse_numeric_entity(const std::string &entity) {
+  if (entity.size() < 2 || entity[0] != '#') {
+    return std::nullopt;
+  }
+
+  int base = 10;
+  size_t index = 1;
+  if (entity.size() >= 3 && (entity[1] == 'x' || entity[1] == 'X')) {
+    base = 16;
+    index = 2;
+  }
+
+  if (index >= entity.size()) {
+    return std::nullopt;
+  }
+
+  uint32_t value = 0;
+  for (; index < entity.size(); ++index) {
+    unsigned char c = static_cast<unsigned char>(entity[index]);
+    int digit = -1;
+    if (std::isdigit(c)) {
+      digit = c - '0';
+    } else if (base == 16 && c >= 'a' && c <= 'f') {
+      digit = 10 + (c - 'a');
+    } else if (base == 16 && c >= 'A' && c <= 'F') {
+      digit = 10 + (c - 'A');
+    } else {
+      return std::nullopt;
+    }
+
+    value = value * base + static_cast<uint32_t>(digit);
+    if (value > 0x10FFFF) {
+      return std::nullopt;
+    }
+  }
+
+  return value;
+}
+
+std::string decode_xml_entities(const std::string &value) {
+  static const std::unordered_map<std::string, std::string> named_entities = {
+      {"amp", "&"}, {"lt", "<"}, {"gt", ">"}, {"apos", "'"}, {"quot", "\""}};
+
+  std::string result;
+  result.reserve(value.size());
+
+  for (size_t i = 0; i < value.size(); ++i) {
+    char c = value[i];
+    if (c != '&') {
+      result.push_back(c);
+      continue;
+    }
+
+    size_t end = value.find(';', i + 1);
+    if (end == std::string::npos) {
+      result.push_back('&');
+      continue;
+    }
+
+    std::string entity = value.substr(i + 1, end - i - 1);
+    if (entity.empty()) {
+      result.push_back('&');
+      i = end;
+      continue;
+    }
+
+    if (entity[0] == '#') {
+      auto numeric = parse_numeric_entity(entity);
+      if (numeric.has_value()) {
+        result.append(encode_utf8(numeric.value()));
+        i = end;
+        continue;
+      }
+    } else {
+      auto it = named_entities.find(entity);
+      if (it != named_entities.end()) {
+        result.append(it->second);
+        i = end;
+        continue;
+      }
+    }
+
+    // Unknown entity - keep original text.
+    result.append(value.substr(i, end - i + 1));
+    i = end;
+  }
+
+  return result;
+}
 
 class SimpleXmlParser {
  public:
@@ -218,7 +329,7 @@ class SimpleXmlParser {
       }
       std::string value = input_.substr(start, position_ - start);
       match("\"");
-      return value;
+      return decode_xml_entities(value);
     }
     if (match("'")) {
       size_t start = position_;
@@ -227,14 +338,14 @@ class SimpleXmlParser {
       }
       std::string value = input_.substr(start, position_ - start);
       match("'");
-      return value;
+      return decode_xml_entities(value);
     }
     // Unquoted value
     size_t start = position_;
     while (!at_end() && !std::isspace(static_cast<unsigned char>(input_[position_])) && input_[position_] != '>') {
       ++position_;
     }
-    return input_.substr(start, position_ - start);
+    return decode_xml_entities(input_.substr(start, position_ - start));
   }
 
   std::string parse_text() {
@@ -242,7 +353,7 @@ class SimpleXmlParser {
     while (!at_end() && input_[position_] != '<') {
       ++position_;
     }
-    return trim(input_.substr(start, position_ - start));
+    return decode_xml_entities(trim(input_.substr(start, position_ - start)));
   }
 
   static std::string trim(const std::string &value) {


### PR DESCRIPTION
## Summary
- decode XML entity references in machine data text and attribute values so sensors show readable text
- ensure parsed text is converted back to UTF-8 characters before sanitization and publication

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9c4d22d108328a90128b05649465d