### PR TITLE
Add dynamic machine data field sensors

### DIFF
--- a/docs/components/jutta_proto.md
+++ b/docs/components/jutta_proto.md
@@ -161,6 +161,27 @@ Each formatted sensor contains a human-readable rendering of its XML section. Th
 variants that have been observed in the official firmware so mixed content and nested tags are handled automatically. If only
 the `raw` sensor is configured the untouched XML payload is published instead.
 
+### Dynamic machine data fields
+
+Set the optional `fields` block to automatically expose each XML element and attribute from the machine data response as its
+own `text_sensor`. Sensors are created on demand the first time a field appears in a response and keep publishing updates as
+new XML payloads arrive. The generated entity names are derived from the XML path; you can optionally override the common
+prefix or disable attribute reporting.
+
+```yaml
+jutta_proto:
+  id: jura
+  uart_id: jura_uart
+  machine_data:
+    fields:
+      prefix: "JURA Field"
+      include_attributes: true
+```
+
+When enabled, every leaf value in the XML tree produces a dedicated sensor with a friendly name such as `JURA Field Products
+Product[2] Coffee Strength Default`. Attributes use an `@` suffix in their path and therefore become individual sensors as
+well. Empty or missing elements publish empty strings so the Home Assistant entities remain in sync with the latest payload.
+
 ## Diagnostics
 
 The component logs handshake progress during startup. The `dump_config()` output lists the detected machine type as well as the

--- a/esphome/components/jutta_proto/__init__.py
+++ b/esphome/components/jutta_proto/__init__.py
@@ -24,6 +24,11 @@ CONF_MACHINE_DATA_ERRORS = "errors"
 CONF_MACHINE_DATA_STATUS = "status"
 CONF_MACHINE_DATA_PROCESSES = "processes"
 CONF_MACHINE_DATA_RAW = "raw"
+CONF_MACHINE_DATA_FIELDS = "fields"
+CONF_MACHINE_DATA_FIELD_PREFIX = "prefix"
+CONF_MACHINE_DATA_FIELD_INCLUDE_ATTRIBUTES = "include_attributes"
+
+DEFAULT_MACHINE_DATA_FIELD_PREFIX = "JURA Machine Data"
 
 MACHINE_DATA_SECTION_KEYS = [
     CONF_MACHINE_DATA_STATISTICS,
@@ -113,6 +118,20 @@ MACHINE_DATA_CONFIG_SCHEMA = cv.Any(
             cv.Optional(CONF_MACHINE_DATA_STATUS): MACHINE_DATA_SENSOR_SCHEMA,
             cv.Optional(CONF_MACHINE_DATA_PROCESSES): MACHINE_DATA_SENSOR_SCHEMA,
             cv.Optional(CONF_MACHINE_DATA_RAW): MACHINE_DATA_SENSOR_SCHEMA,
+            cv.Optional(
+                CONF_MACHINE_DATA_FIELDS,
+                default={},
+            ): cv.Schema(
+                {
+                    cv.Optional(
+                        CONF_MACHINE_DATA_FIELD_PREFIX,
+                        default=DEFAULT_MACHINE_DATA_FIELD_PREFIX,
+                    ): cv.string,
+                    cv.Optional(
+                        CONF_MACHINE_DATA_FIELD_INCLUDE_ATTRIBUTES, default=True
+                    ): cv.boolean,
+                }
+            ),
         }
     ),
 )
@@ -273,33 +292,48 @@ async def to_code(config):
                 return await text_sensor.new_text_sensor(cfg)
             return await cg.get_variable(cfg)
 
-        if isinstance(machine_data_cfg, dict) and any(
-            key in machine_data_cfg for key in MACHINE_DATA_SECTION_KEYS
-        ):
-            if CONF_MACHINE_DATA_STATISTICS in machine_data_cfg:
-                sensor = await _resolve_machine_data_sensor(
-                    machine_data_cfg[CONF_MACHINE_DATA_STATISTICS]
+        if isinstance(machine_data_cfg, dict):
+            fields_cfg = machine_data_cfg.get(CONF_MACHINE_DATA_FIELDS)
+            if fields_cfg is not None:
+                cg.add(
+                    var.enable_machine_data_field_sensors(
+                        fields_cfg[CONF_MACHINE_DATA_FIELD_PREFIX],
+                        fields_cfg[CONF_MACHINE_DATA_FIELD_INCLUDE_ATTRIBUTES],
+                    )
                 )
-                cg.add(var.set_machine_data_statistic_sensor(sensor))
-            if CONF_MACHINE_DATA_ERRORS in machine_data_cfg:
-                sensor = await _resolve_machine_data_sensor(
-                    machine_data_cfg[CONF_MACHINE_DATA_ERRORS]
-                )
-                cg.add(var.set_machine_data_errors_sensor(sensor))
-            if CONF_MACHINE_DATA_STATUS in machine_data_cfg:
-                sensor = await _resolve_machine_data_sensor(
-                    machine_data_cfg[CONF_MACHINE_DATA_STATUS]
-                )
-                cg.add(var.set_machine_data_status_sensor(sensor))
-            if CONF_MACHINE_DATA_PROCESSES in machine_data_cfg:
-                sensor = await _resolve_machine_data_sensor(
-                    machine_data_cfg[CONF_MACHINE_DATA_PROCESSES]
-                )
-                cg.add(var.set_machine_data_processes_sensor(sensor))
-            if CONF_MACHINE_DATA_RAW in machine_data_cfg:
-                sensor = await _resolve_machine_data_sensor(
-                    machine_data_cfg[CONF_MACHINE_DATA_RAW]
-                )
+
+            section_keys_present = any(
+                key in machine_data_cfg for key in MACHINE_DATA_SECTION_KEYS
+            )
+
+            if section_keys_present:
+                if CONF_MACHINE_DATA_STATISTICS in machine_data_cfg:
+                    sensor = await _resolve_machine_data_sensor(
+                        machine_data_cfg[CONF_MACHINE_DATA_STATISTICS]
+                    )
+                    cg.add(var.set_machine_data_statistic_sensor(sensor))
+                if CONF_MACHINE_DATA_ERRORS in machine_data_cfg:
+                    sensor = await _resolve_machine_data_sensor(
+                        machine_data_cfg[CONF_MACHINE_DATA_ERRORS]
+                    )
+                    cg.add(var.set_machine_data_errors_sensor(sensor))
+                if CONF_MACHINE_DATA_STATUS in machine_data_cfg:
+                    sensor = await _resolve_machine_data_sensor(
+                        machine_data_cfg[CONF_MACHINE_DATA_STATUS]
+                    )
+                    cg.add(var.set_machine_data_status_sensor(sensor))
+                if CONF_MACHINE_DATA_PROCESSES in machine_data_cfg:
+                    sensor = await _resolve_machine_data_sensor(
+                        machine_data_cfg[CONF_MACHINE_DATA_PROCESSES]
+                    )
+                    cg.add(var.set_machine_data_processes_sensor(sensor))
+                if CONF_MACHINE_DATA_RAW in machine_data_cfg:
+                    sensor = await _resolve_machine_data_sensor(
+                        machine_data_cfg[CONF_MACHINE_DATA_RAW]
+                    )
+                    cg.add(var.set_machine_data_sensor(sensor))
+            elif fields_cfg is None:
+                sensor = await _resolve_machine_data_sensor(machine_data_cfg)
                 cg.add(var.set_machine_data_sensor(sensor))
         else:
             sensor = await _resolve_machine_data_sensor(machine_data_cfg)

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -7,8 +7,11 @@
 #include <iomanip>
 #include <optional>
 #include <sstream>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
+#include "esphome/core/application.h"
 #include "esphome/core/time.h"
 #include "machine_data_parser.h"
 
@@ -396,6 +399,119 @@ std::string sanitize_text_sensor_value(const std::string &value) {
   }
 
   return sanitized;
+}
+
+std::string canonicalize_machine_data_path(const std::string &path) {
+  std::string canonical = path;
+  std::transform(canonical.begin(), canonical.end(), canonical.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+  return canonical;
+}
+
+std::string build_machine_data_field_sensor_name(const std::string &prefix, const std::string &path) {
+  std::string readable;
+  readable.reserve(path.size());
+  bool last_was_space = true;
+
+  auto append_space = [&]() {
+    if (!last_was_space) {
+      readable.push_back(' ');
+      last_was_space = true;
+    }
+  };
+
+  for (char c : path) {
+    switch (c) {
+      case '/':
+      case '_':
+      case '-':
+      case '@':
+      case '[':
+      case ']':
+      case ':':
+        append_space();
+        break;
+      default:
+        if (std::isspace(static_cast<unsigned char>(c))) {
+          append_space();
+        } else {
+          last_was_space = false;
+          readable.push_back(c);
+        }
+        break;
+    }
+  }
+
+  if (!readable.empty() && readable.back() == ' ') {
+    readable.pop_back();
+  }
+
+  bool new_word = true;
+  for (char &c : readable) {
+    if (std::isspace(static_cast<unsigned char>(c))) {
+      new_word = true;
+      continue;
+    }
+    if (new_word) {
+      c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+      new_word = false;
+    } else {
+      c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    }
+  }
+
+  if (readable.empty()) {
+    readable = "Field";
+  }
+
+  if (prefix.empty()) {
+    return readable;
+  }
+  return prefix + " " + readable;
+}
+
+void collect_machine_data_fields(const MachineDataNode &node, const std::string &path, bool include_attributes,
+                                std::vector<std::pair<std::string, std::string>> &fields) {
+  if (node.name == "#text") {
+    if (!path.empty() && !node.text.empty()) {
+      fields.emplace_back(path, node.text);
+    }
+    return;
+  }
+
+  std::string current_path = path.empty() ? node.name : path + "/" + node.name;
+
+  if (include_attributes) {
+    for (const auto &attribute : node.attributes) {
+      if (!attribute.first.empty()) {
+        fields.emplace_back(current_path + "/@" + attribute.first, attribute.second);
+      }
+    }
+  }
+
+  if (!node.text.empty()) {
+    fields.emplace_back(current_path, node.text);
+  }
+
+  std::unordered_map<std::string, size_t> child_counts;
+  for (const auto &child : node.children) {
+    if (child.name == "#text") {
+      if (!child.text.empty()) {
+        fields.emplace_back(current_path, child.text);
+      }
+      continue;
+    }
+
+    size_t &index = child_counts[child.name];
+    std::string child_path = current_path.empty() ? child.name : current_path + "/" + child.name;
+    if (index > 0) {
+      child_path.append("[");
+      child_path.append(std::to_string(index + 1));
+      child_path.push_back(']');
+    }
+    ++index;
+    collect_machine_data_fields(child, child_path, include_attributes, fields);
+  }
 }
 
 }  // namespace
@@ -841,6 +957,9 @@ void JuraComponent::publish_machine_data_(const std::string &response) {
           format_machine_data_section(root.find_child_case_insensitive("PROCESSES"));
       this->machine_data_processes_sensor_->publish_state(sanitize_text_sensor_value(formatted));
     }
+    if (this->machine_data_fields_enabled_) {
+      this->publish_machine_data_fields_(root);
+    }
   } else {
     if (this->machine_data_statistic_sensor_ != nullptr) {
       this->machine_data_statistic_sensor_->publish_state("");
@@ -854,12 +973,71 @@ void JuraComponent::publish_machine_data_(const std::string &response) {
     if (this->machine_data_processes_sensor_ != nullptr) {
       this->machine_data_processes_sensor_->publish_state("");
     }
+    if (this->machine_data_fields_enabled_) {
+      this->clear_machine_data_field_sensors_();
+    }
   }
 
   std::string sanitized = sanitize_text_sensor_value(response);
   ESP_LOGD(TAG, "Machine data response: %s", sanitized.c_str());
   if (this->machine_data_sensor_ != nullptr) {
     this->machine_data_sensor_->publish_state(sanitized);
+  }
+}
+
+void JuraComponent::enable_machine_data_field_sensors(const std::string &prefix, bool include_attributes) {
+  this->machine_data_fields_enabled_ = true;
+  this->machine_data_field_prefix_ = prefix;
+  this->machine_data_field_include_attributes_ = include_attributes;
+}
+
+text_sensor::TextSensor *JuraComponent::get_or_create_machine_data_field_sensor_(const std::string &key,
+                                                                                const std::string &path) {
+  auto it = this->machine_data_field_sensors_.find(key);
+  if (it != this->machine_data_field_sensors_.end()) {
+    return it->second;
+  }
+
+  auto sensor = std::make_unique<text_sensor::TextSensor>();
+  sensor->set_name(build_machine_data_field_sensor_name(this->machine_data_field_prefix_, path));
+  auto *raw_sensor = sensor.get();
+  App.register_text_sensor(raw_sensor);
+  this->machine_data_field_sensor_storage_.push_back(std::move(sensor));
+  this->machine_data_field_sensors_.emplace(key, raw_sensor);
+  return raw_sensor;
+}
+
+void JuraComponent::publish_machine_data_fields_(const MachineDataNode &root) {
+  std::vector<std::pair<std::string, std::string>> fields;
+  collect_machine_data_fields(root, "", this->machine_data_field_include_attributes_, fields);
+
+  std::unordered_set<std::string> seen;
+  seen.reserve(fields.size());
+
+  for (auto &field : fields) {
+    if (field.first.empty()) {
+      continue;
+    }
+    std::string key = canonicalize_machine_data_path(field.first);
+    auto *sensor = this->get_or_create_machine_data_field_sensor_(key, field.first);
+    if (sensor != nullptr) {
+      sensor->publish_state(sanitize_text_sensor_value(field.second));
+      seen.insert(std::move(key));
+    }
+  }
+
+  for (auto &entry : this->machine_data_field_sensors_) {
+    if (seen.find(entry.first) == seen.end() && entry.second != nullptr) {
+      entry.second->publish_state("");
+    }
+  }
+}
+
+void JuraComponent::clear_machine_data_field_sensors_() {
+  for (auto &entry : this->machine_data_field_sensors_) {
+    if (entry.second != nullptr) {
+      entry.second->publish_state("");
+    }
   }
 }
 

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "esphome/core/automation.h"
@@ -18,6 +19,8 @@
 
 namespace esphome {
 namespace jutta_component {
+
+struct MachineDataNode;
 
 class JuraComponent : public esphome::Component, public esphome::uart::UARTDevice {
  public:
@@ -48,6 +51,7 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   void set_machine_data_processes_sensor(text_sensor::TextSensor *sensor) {
     this->machine_data_processes_sensor_ = sensor;
   }
+  void enable_machine_data_field_sensors(const std::string &prefix, bool include_attributes);
 
  protected:
   enum class HandshakeStage { IDLE, HELLO, SEND_T1, WAIT_T2, SEND_T2, WAIT_T3, SEND_T3, DONE, FAILED };
@@ -60,6 +64,10 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   static bool time_reached(uint32_t now, uint32_t target);
   void process_machine_data_query();
   void publish_machine_data_(const std::string &response);
+  void publish_machine_data_fields_(const MachineDataNode &root);
+  void clear_machine_data_field_sensors_();
+  text_sensor::TextSensor *get_or_create_machine_data_field_sensor_(const std::string &key,
+                                                                   const std::string &path);
 
   std::unique_ptr<::jutta_proto::JuttaConnection> connection_;
   std::unique_ptr<::jutta_proto::CoffeeMaker> coffee_maker_;
@@ -77,6 +85,11 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   text_sensor::TextSensor *machine_data_errors_sensor_{nullptr};
   text_sensor::TextSensor *machine_data_status_sensor_{nullptr};
   text_sensor::TextSensor *machine_data_processes_sensor_{nullptr};
+  bool machine_data_fields_enabled_{false};
+  bool machine_data_field_include_attributes_{true};
+  std::string machine_data_field_prefix_{};
+  std::unordered_map<std::string, text_sensor::TextSensor *> machine_data_field_sensors_;
+  std::vector<std::unique_ptr<text_sensor::TextSensor>> machine_data_field_sensor_storage_;
   uint32_t machine_data_query_next_{0};
   bool machine_data_request_pending_{false};
   uint32_t machine_data_request_start_{0};


### PR DESCRIPTION
## Summary
- add configuration for dynamically generating machine data text sensors from XML fields
- implement runtime creation and publishing of per-field sensors in the Jura component
- document the new machine_data.fields option and usage

## Testing
- python -m compileall esphome/components/jutta_proto/__init__.py

------
https://chatgpt.com/codex/tasks/task_e_68dad968ca008328a78d9ccb656aeca0