### PR TITLE
Fix sensor name assignment

### DIFF
--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -999,7 +999,9 @@ text_sensor::TextSensor *JuraComponent::get_or_create_machine_data_field_sensor_
   }
 
   auto sensor = std::make_unique<text_sensor::TextSensor>();
-  sensor->set_name(build_machine_data_field_sensor_name(this->machine_data_field_prefix_, path));
+  auto sensor_name =
+      build_machine_data_field_sensor_name(this->machine_data_field_prefix_, path);
+  sensor->set_name(sensor_name.c_str());
   auto *raw_sensor = sensor.get();
   App.register_text_sensor(raw_sensor);
   this->machine_data_field_sensor_storage_.push_back(std::move(sensor));


### PR DESCRIPTION
## Summary
- ensure the machine data field text sensor name is provided as a C string when registering the sensor

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dae0f465a48328b4a4b70f6f6b4ce0