### PR TITLE
Add dynamic machine data text sensors

### DIFF
--- a/docs/components/jutta_proto.md
+++ b/docs/components/jutta_proto.md
@@ -150,7 +150,29 @@ jutta_proto:
     status: jura_status
     processes: jura_processes
     raw: jura_machine_raw
+
+To expose every XML field as its own dynamically generated text sensor, enable `auto_fields`.
+Each discovered field is published with a sensor name that starts with `field_prefix` followed
+by a human-readable representation of the XML path:
+
+```yaml
+text_sensor:
+  - platform: template
+    name: "JURA Machine Data Raw"
+    id: jura_machine_raw
+
+jutta_proto:
+  id: jura
+  uart_id: jura_uart
+  machine_data:
+    raw: jura_machine_raw
+    auto_fields: true
+    field_prefix: "JURA Machine"
 ```
+
+With `auto_fields` enabled, the component creates `text_sensor` entities for every attribute and
+leaf node in the machine data response (for example, individual product counters or maintenance
+percentages). The sensors update automatically whenever the coffee maker reports new values.
 
 !!! note
     The repository includes a `joe_codes_example.xml` file under `jura_joe_xml_bundle_final/`. Copy it to your ESPHome config

--- a/esphome/components/jutta_proto/__init__.py
+++ b/esphome/components/jutta_proto/__init__.py
@@ -24,6 +24,8 @@ CONF_MACHINE_DATA_ERRORS = "errors"
 CONF_MACHINE_DATA_STATUS = "status"
 CONF_MACHINE_DATA_PROCESSES = "processes"
 CONF_MACHINE_DATA_RAW = "raw"
+CONF_MACHINE_DATA_AUTO_FIELDS = "auto_fields"
+CONF_MACHINE_DATA_FIELD_PREFIX = "field_prefix"
 
 MACHINE_DATA_SECTION_KEYS = [
     CONF_MACHINE_DATA_STATISTICS,
@@ -32,6 +34,8 @@ MACHINE_DATA_SECTION_KEYS = [
     CONF_MACHINE_DATA_PROCESSES,
     CONF_MACHINE_DATA_RAW,
 ]
+
+DEFAULT_MACHINE_DATA_FIELD_PREFIX = "JURA Machine Data"
 
 MACHINE_DATA_SENSOR_SCHEMA = cv.Any(
     text_sensor.text_sensor_schema(),
@@ -113,6 +117,10 @@ MACHINE_DATA_CONFIG_SCHEMA = cv.Any(
             cv.Optional(CONF_MACHINE_DATA_STATUS): MACHINE_DATA_SENSOR_SCHEMA,
             cv.Optional(CONF_MACHINE_DATA_PROCESSES): MACHINE_DATA_SENSOR_SCHEMA,
             cv.Optional(CONF_MACHINE_DATA_RAW): MACHINE_DATA_SENSOR_SCHEMA,
+            cv.Optional(CONF_MACHINE_DATA_AUTO_FIELDS, default=False): cv.boolean,
+            cv.Optional(
+                CONF_MACHINE_DATA_FIELD_PREFIX, default=DEFAULT_MACHINE_DATA_FIELD_PREFIX
+            ): cv.string,
         }
     ),
 )
@@ -268,6 +276,14 @@ async def to_code(config):
     if CONF_MACHINE_DATA in config:
         machine_data_cfg = config[CONF_MACHINE_DATA]
 
+        auto_fields = False
+        field_prefix = DEFAULT_MACHINE_DATA_FIELD_PREFIX
+        if isinstance(machine_data_cfg, dict):
+            auto_fields = machine_data_cfg.get(CONF_MACHINE_DATA_AUTO_FIELDS, False)
+            field_prefix = machine_data_cfg.get(
+                CONF_MACHINE_DATA_FIELD_PREFIX, DEFAULT_MACHINE_DATA_FIELD_PREFIX
+            )
+
         async def _resolve_machine_data_sensor(cfg):
             if isinstance(cfg, dict):
                 return await text_sensor.new_text_sensor(cfg)
@@ -304,6 +320,9 @@ async def to_code(config):
         else:
             sensor = await _resolve_machine_data_sensor(machine_data_cfg)
             cg.add(var.set_machine_data_sensor(sensor))
+
+        cg.add(var.set_machine_data_auto_fields(auto_fields))
+        cg.add(var.set_machine_data_field_prefix(cg.std_string(field_prefix)))
 
 
 async def _get_parent(config):

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -5,10 +5,14 @@
 #include <cctype>
 #include <cstdint>
 #include <iomanip>
+#include <map>
 #include <optional>
+#include <set>
 #include <sstream>
 #include <utility>
+#include <vector>
 
+#include "esphome/core/application.h"
 #include "esphome/core/time.h"
 #include "machine_data_parser.h"
 
@@ -32,6 +36,79 @@ struct MachineDataCommandDefinition {
 constexpr std::array<MachineDataCommandDefinition, 3> MACHINE_DATA_COMMANDS = {{{"@TR:32", "STATISTIC", "PRODUCTCOUNTER"},
                                                                               {"@TG:43", "STATISTIC", "MAINTENANCECOUNTER"},
                                                                               {"@TG:C0", "STATISTIC", "MAINTENANCEPERCENT"}}};
+
+std::string slugify(const std::string &value) {
+  std::string result;
+  result.reserve(value.size());
+  bool last_was_separator = true;
+  for (unsigned char c : value) {
+    if (std::isalnum(c) != 0) {
+      result.push_back(static_cast<char>(std::tolower(c)));
+      last_was_separator = false;
+    } else {
+      if (!last_was_separator && !result.empty()) {
+        result.push_back('_');
+        last_was_separator = true;
+      }
+    }
+  }
+  while (!result.empty() && result.back() == '_') {
+    result.pop_back();
+  }
+  if (result.empty()) {
+    result = "field";
+  }
+  return result;
+}
+
+std::string prettify_identifier(const std::string &identifier) {
+  if (identifier == "PRODUCTCOUNTER") {
+    return "Product Counter";
+  }
+  if (identifier == "MAINTENANCECOUNTER") {
+    return "Maintenance Counter";
+  }
+  if (identifier == "MAINTENANCEPERCENT") {
+    return "Maintenance Percent";
+  }
+  if (identifier == "STATISTIC") {
+    return "Statistic";
+  }
+  std::string lowered;
+  lowered.reserve(identifier.size());
+  for (unsigned char c : identifier) {
+    if (c == '_' || c == '-' || c == '.' || c == ' ') {
+      lowered.push_back(' ');
+    } else {
+      lowered.push_back(static_cast<char>(std::tolower(c)));
+    }
+  }
+  std::string result;
+  result.reserve(lowered.size());
+  bool capitalize_next = true;
+  for (unsigned char c : lowered) {
+    if (std::isspace(c) != 0) {
+      if (!result.empty() && result.back() != ' ') {
+        result.push_back(' ');
+      }
+      capitalize_next = true;
+      continue;
+    }
+    if (capitalize_next) {
+      result.push_back(static_cast<char>(std::toupper(c)));
+      capitalize_next = false;
+    } else {
+      result.push_back(static_cast<char>(c));
+    }
+  }
+  if (!result.empty() && result.back() == ' ') {
+    result.pop_back();
+  }
+  return result;
+}
+
+using MachineDataFieldList = std::vector<std::pair<std::string, std::string>>;
+using MachineDataFieldMap = std::map<std::string, std::pair<std::vector<std::string>, std::string>>;
 
 struct ProductCounterDefinition {
   const char *name;
@@ -89,6 +166,28 @@ std::optional<std::string> format_product_counter_payload(const std::string &pay
   return stream.str();
 }
 
+MachineDataFieldList parse_product_counter_fields(const std::string &payload) {
+  MachineDataFieldList fields;
+  if (payload.size() != 21) {
+    return fields;
+  }
+
+  const auto *data = reinterpret_cast<const uint8_t *>(payload.data());
+  uint8_t header = data[0];
+
+  std::ostringstream header_stream;
+  header_stream << "0x" << std::uppercase << std::hex << std::setfill('0') << std::setw(2)
+                << static_cast<int>(header);
+  fields.emplace_back("Header", header_stream.str());
+
+  for (size_t i = 0; i < PRODUCT_COUNTER_DEFINITIONS.size(); ++i) {
+    uint16_t value = read_u16_le(&data[1 + i * 2]);
+    fields.emplace_back(PRODUCT_COUNTER_DEFINITIONS[i].name, std::to_string(value));
+  }
+
+  return fields;
+}
+
 std::optional<std::string> format_maintenance_counter_payload(const std::string &payload) {
   if (payload.size() != 13) {
     return std::nullopt;
@@ -107,6 +206,28 @@ std::optional<std::string> format_maintenance_counter_payload(const std::string 
   }
 
   return stream.str();
+}
+
+MachineDataFieldList parse_maintenance_counter_fields(const std::string &payload) {
+  MachineDataFieldList fields;
+  if (payload.size() != 13) {
+    return fields;
+  }
+
+  const auto *data = reinterpret_cast<const uint8_t *>(payload.data());
+  uint8_t header = data[0];
+
+  std::ostringstream header_stream;
+  header_stream << "0x" << std::uppercase << std::hex << std::setfill('0') << std::setw(2)
+                << static_cast<int>(header);
+  fields.emplace_back("Header", header_stream.str());
+
+  for (size_t i = 0; i < MAINTENANCE_COUNTER_NAMES.size(); ++i) {
+    uint16_t value = read_u16_le(&data[1 + i * 2]);
+    fields.emplace_back(MAINTENANCE_COUNTER_NAMES[i], std::to_string(value));
+  }
+
+  return fields;
 }
 
 std::optional<std::string> format_maintenance_percent_payload(const std::string &payload) {
@@ -147,6 +268,41 @@ std::optional<std::string> format_maintenance_percent_payload(const std::string 
   return stream.str();
 }
 
+MachineDataFieldList parse_maintenance_percent_fields(const std::string &payload) {
+  MachineDataFieldList fields;
+  if (payload.size() != 13 && payload.size() != 14) {
+    return fields;
+  }
+
+  const auto *data = reinterpret_cast<const uint8_t *>(payload.data());
+  size_t header_size = payload.size() == 14 ? 2 : 1;
+  uint16_t header = header_size == 2 ? read_u16_le(data) : static_cast<uint16_t>(data[0]);
+  size_t value_offset = header_size;
+
+  std::ostringstream header_stream;
+  header_stream << "0x" << std::uppercase << std::hex << std::setfill('0')
+                << std::setw(static_cast<int>(header_size * 2)) << header;
+  fields.emplace_back("Header", header_stream.str());
+
+  for (size_t i = 0; i < MAINTENANCE_PERCENT_NAMES.size(); ++i) {
+    size_t index = value_offset + i * 2;
+    if (index + 1 >= payload.size()) {
+      break;
+    }
+    uint16_t raw_value = read_u16_le(&data[index]);
+    std::ostringstream raw_stream;
+    raw_stream << raw_value;
+    fields.emplace_back(std::string(MAINTENANCE_PERCENT_NAMES[i]) + " Raw", raw_stream.str());
+
+    std::ostringstream percent_stream;
+    percent_stream << std::fixed << std::setprecision(2)
+                   << (static_cast<double>(raw_value) * 100.0 / 65535.0);
+    fields.emplace_back(std::string(MAINTENANCE_PERCENT_NAMES[i]) + " Percent", percent_stream.str());
+  }
+
+  return fields;
+}
+
 std::optional<std::string> parse_machine_data_response(const std::string &command, const std::string &payload) {
   if (command == std::string("@TR:32")) {
     return format_product_counter_payload(payload);
@@ -158,6 +314,19 @@ std::optional<std::string> parse_machine_data_response(const std::string &comman
     return format_maintenance_percent_payload(payload);
   }
   return std::nullopt;
+}
+
+MachineDataFieldList parse_machine_data_fields(const std::string &command, const std::string &payload) {
+  if (command == std::string("@TR:32")) {
+    return parse_product_counter_fields(payload);
+  }
+  if (command == std::string("@TG:43")) {
+    return parse_maintenance_counter_fields(payload);
+  }
+  if (command == std::string("@TG:C0")) {
+    return parse_maintenance_percent_fields(payload);
+  }
+  return {};
 }
 
 std::string to_upper_hex(const std::string &value) {
@@ -224,7 +393,8 @@ std::string xml_escape(const std::string &value) {
   return stream.str();
 }
 
-std::string build_machine_data_payload(const std::vector<std::string> &responses) {
+std::string build_machine_data_payload(const std::vector<std::string> &responses,
+                                       MachineDataFieldMap *field_map = nullptr) {
   std::ostringstream stream;
   stream << "<MACHINE_DATA>";
 
@@ -245,10 +415,13 @@ std::string build_machine_data_payload(const std::vector<std::string> &responses
     }
 
     std::string response = i < responses.size() ? responses[i] : std::string{};
+    std::optional<std::string> parsed_text;
+    if (!response.empty()) {
+      parsed_text = parse_machine_data_response(definition.command, response);
+    }
     stream << '<' << definition.element << " command=\"" << definition.command << "\"";
     if (!response.empty()) {
       stream << " raw_hex=\"" << to_upper_hex(response) << "\"";
-      auto parsed_text = parse_machine_data_response(definition.command, response);
       if (parsed_text.has_value()) {
         stream << " encoding=\"text\">" << xml_escape(parsed_text.value()) << "</" << definition.element << ">";
       } else if (is_safe_xml_text(response)) {
@@ -258,6 +431,47 @@ std::string build_machine_data_payload(const std::vector<std::string> &responses
       }
     } else {
       stream << "/>";
+    }
+
+    if (field_map != nullptr) {
+      std::vector<std::string> base_labels;
+      base_labels.push_back(prettify_identifier(definition.section));
+      base_labels.push_back(prettify_identifier(definition.element));
+      std::string key_prefix = slugify(definition.section);
+      std::string element_slug = slugify(definition.element);
+      if (!element_slug.empty()) {
+        if (!key_prefix.empty()) {
+          key_prefix.push_back('.');
+        }
+        key_prefix.append(element_slug);
+      }
+      if (!response.empty()) {
+        MachineDataFieldList fields = parse_machine_data_fields(definition.command, response);
+        for (const auto &field : fields) {
+          std::vector<std::string> labels = base_labels;
+          labels.push_back(field.first);
+          std::string value_slug = slugify(field.first);
+          std::string field_key = key_prefix.empty() ? value_slug : key_prefix + '.' + value_slug;
+          (*field_map)[field_key] = {labels, field.second};
+        }
+
+        std::vector<std::string> raw_labels = base_labels;
+        raw_labels.push_back("Raw Hex");
+        std::string raw_key = key_prefix.empty() ? std::string("raw_hex") : key_prefix + ".raw_hex";
+        (*field_map)[raw_key] = {raw_labels, to_upper_hex(response)};
+
+        if (parsed_text.has_value()) {
+          std::vector<std::string> text_labels = base_labels;
+          text_labels.push_back("Text");
+          std::string text_key = key_prefix.empty() ? std::string("text") : key_prefix + ".text";
+          (*field_map)[text_key] = {text_labels, parsed_text.value()};
+        } else if (is_safe_xml_text(response)) {
+          std::vector<std::string> text_labels = base_labels;
+          text_labels.push_back("Text");
+          std::string text_key = key_prefix.empty() ? std::string("text") : key_prefix + ".text";
+          (*field_map)[text_key] = {text_labels, response};
+        }
+      }
     }
   }
 
@@ -396,6 +610,63 @@ std::string sanitize_text_sensor_value(const std::string &value) {
   }
 
   return sanitized;
+}
+
+void JuraComponent::publish_machine_data_fields_(const MachineDataFieldMap &fields) {
+  if (!this->machine_data_auto_fields_) {
+    return;
+  }
+
+  std::set<std::string> seen;
+  for (const auto &entry : fields) {
+    auto *sensor = this->get_or_create_machine_data_field_sensor_(entry.first, entry.second.first);
+    if (sensor == nullptr) {
+      continue;
+    }
+    sensor->set_name(this->make_machine_data_field_name_(entry.second.first));
+    sensor->publish_state(sanitize_text_sensor_value(entry.second.second));
+    seen.insert(entry.first);
+  }
+
+  for (const auto &existing : this->machine_data_field_sensors_) {
+    if (seen.count(existing.first) == 0) {
+      existing.second->publish_state("");
+    }
+  }
+}
+
+text_sensor::TextSensor *JuraComponent::get_or_create_machine_data_field_sensor_(
+    const std::string &key, const std::vector<std::string> &labels) {
+  auto it = this->machine_data_field_sensors_.find(key);
+  if (it != this->machine_data_field_sensors_.end()) {
+    return it->second;
+  }
+  if (!this->machine_data_auto_fields_) {
+    return nullptr;
+  }
+
+  auto *sensor = new text_sensor::TextSensor();
+  sensor->set_name(this->make_machine_data_field_name_(labels));
+  App.register_text_sensor(sensor);
+  this->machine_data_field_sensors_[key] = sensor;
+  return sensor;
+}
+
+std::string JuraComponent::make_machine_data_field_name_(const std::vector<std::string> &labels) const {
+  std::string name = this->machine_data_field_prefix_;
+  for (const auto &label : labels) {
+    if (label.empty()) {
+      continue;
+    }
+    if (!name.empty()) {
+      name.append(" ");
+    }
+    name.append(label);
+  }
+  if (name.empty()) {
+    name = "Machine Data";
+  }
+  return name;
 }
 
 }  // namespace
@@ -770,6 +1041,9 @@ void JuraComponent::process_machine_data_query() {
           this->machine_data_request_start_ = 0;
           this->machine_data_command_index_ = 0;
           this->machine_data_responses_.clear();
+          if (this->machine_data_auto_fields_) {
+            this->machine_data_field_values_.clear();
+          }
           this->machine_data_query_next_ = now + MACHINE_DATA_QUERY_INTERVAL_MS;
         }
         return;
@@ -803,7 +1077,12 @@ void JuraComponent::process_machine_data_query() {
   }
 
   if (this->machine_data_command_index_ >= MACHINE_DATA_COMMANDS.size()) {
-    std::string payload = build_machine_data_payload(this->machine_data_responses_);
+    MachineDataFieldMap field_values;
+    std::string payload = build_machine_data_payload(
+        this->machine_data_responses_, this->machine_data_auto_fields_ ? &field_values : nullptr);
+    if (this->machine_data_auto_fields_) {
+      this->machine_data_field_values_ = std::move(field_values);
+    }
     this->publish_machine_data_(payload);
     this->machine_data_responses_.clear();
     this->machine_data_request_pending_ = false;
@@ -817,6 +1096,9 @@ void JuraComponent::publish_machine_data_(const std::string &response) {
   auto parsed = MachineDataParser::parse(response);
   if (!parsed.has_value()) {
     ESP_LOGW(TAG, "Failed to parse machine data XML response.");
+    if (this->machine_data_auto_fields_) {
+      this->machine_data_field_values_.clear();
+    }
   }
 
   if (parsed.has_value()) {
@@ -858,6 +1140,9 @@ void JuraComponent::publish_machine_data_(const std::string &response) {
 
   std::string sanitized = sanitize_text_sensor_value(response);
   ESP_LOGD(TAG, "Machine data response: %s", sanitized.c_str());
+  if (this->machine_data_auto_fields_) {
+    this->publish_machine_data_fields_(this->machine_data_field_values_);
+  }
   if (this->machine_data_sensor_ != nullptr) {
     this->machine_data_sensor_->publish_state(sanitized);
   }

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -2,8 +2,10 @@
 
 #include <chrono>
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "esphome/core/automation.h"
@@ -48,6 +50,10 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   void set_machine_data_processes_sensor(text_sensor::TextSensor *sensor) {
     this->machine_data_processes_sensor_ = sensor;
   }
+  void set_machine_data_auto_fields(bool enable) { this->machine_data_auto_fields_ = enable; }
+  void set_machine_data_field_prefix(const std::string &prefix) {
+    this->machine_data_field_prefix_ = prefix;
+  }
 
  protected:
   enum class HandshakeStage { IDLE, HELLO, SEND_T1, WAIT_T2, SEND_T2, WAIT_T3, SEND_T3, DONE, FAILED };
@@ -60,6 +66,10 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   static bool time_reached(uint32_t now, uint32_t target);
   void process_machine_data_query();
   void publish_machine_data_(const std::string &response);
+  void publish_machine_data_fields_(const std::map<std::string, std::pair<std::vector<std::string>, std::string>> &fields);
+  text_sensor::TextSensor *get_or_create_machine_data_field_sensor_(
+      const std::string &key, const std::vector<std::string> &labels);
+  std::string make_machine_data_field_name_(const std::vector<std::string> &labels) const;
 
   std::unique_ptr<::jutta_proto::JuttaConnection> connection_;
   std::unique_ptr<::jutta_proto::CoffeeMaker> coffee_maker_;
@@ -77,6 +87,10 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   text_sensor::TextSensor *machine_data_errors_sensor_{nullptr};
   text_sensor::TextSensor *machine_data_status_sensor_{nullptr};
   text_sensor::TextSensor *machine_data_processes_sensor_{nullptr};
+  bool machine_data_auto_fields_{false};
+  std::string machine_data_field_prefix_{"JURA Machine Data"};
+  std::map<std::string, text_sensor::TextSensor *> machine_data_field_sensors_;
+  std::map<std::string, std::pair<std::vector<std::string>, std::string>> machine_data_field_values_;
   uint32_t machine_data_query_next_{0};
   bool machine_data_request_pending_{false};
   uint32_t machine_data_request_start_{0};


### PR DESCRIPTION
## Summary
- add configuration options to enable auto-generated machine data text sensors with custom prefixes
- parse machine data payloads into individual field values and publish them through dynamically created text sensors
- document the new `auto_fields` feature in the component guide

## Testing
- python -m compileall esphome/components/jutta_proto/__init__.py

------
https://chatgpt.com/codex/tasks/task_e_68dad968ca008328a78d9ccb656aeca0