### PR TITLE
Fix auto machine data text sensor registration

### DIFF
--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -651,6 +651,8 @@ text_sensor::TextSensor *JuraComponent::get_or_create_machine_data_field_sensor_
   auto *sensor = new text_sensor::TextSensor();
   std::string name = this->make_machine_data_field_name_(labels);
   sensor->set_name(name.c_str());
+  sensor->set_internal(false);
+  sensor->set_parent(this);
   App.register_text_sensor(sensor);
   this->machine_data_field_sensors_[key] = sensor;
   return sensor;


### PR DESCRIPTION
## Summary
- mark dynamically created machine data text sensors as non-internal entities and attach them to the Jura component so Home Assistant exposes them

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dae6e769f08328ae59090cb643f14d