### PR TITLE
Allow machine data queries without raw sensor

### DIFF
--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -1083,8 +1083,15 @@ bool JuraComponent::time_reached(uint32_t now, uint32_t target) {
   return static_cast<int32_t>(now - target) >= 0;
 }
 
+bool JuraComponent::has_machine_data_subscribers_() const {
+  return this->machine_data_sensor_ != nullptr || this->machine_data_statistic_sensor_ != nullptr ||
+         this->machine_data_errors_sensor_ != nullptr ||
+         this->machine_data_status_sensor_ != nullptr ||
+         this->machine_data_processes_sensor_ != nullptr || this->machine_data_auto_fields_;
+}
+
 void JuraComponent::process_machine_data_query() {
-  if (this->machine_data_sensor_ == nullptr) {
+  if (!this->has_machine_data_subscribers_()) {
     return;
   }
   if (!this->is_ready()) {

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -65,6 +65,7 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   bool read_handshake_bytes();
   static bool time_reached(uint32_t now, uint32_t target);
   void process_machine_data_query();
+  bool has_machine_data_subscribers_() const;
   void publish_machine_data_(const std::string &response);
   void publish_machine_data_fields_(const std::map<std::string, std::pair<std::vector<std::string>, std::string>> &fields);
   text_sensor::TextSensor *find_machine_data_field_sensor_(const std::string &key);


### PR DESCRIPTION
## Summary
- ensure the Jura component still polls machine data when only auto field or section sensors are configured
- add a helper that checks whether any machine data subscribers are present before issuing requests

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db9a0c64748328b898523b5feb2235