### PR TITLE
Attach auto field text sensors to Jura component

### DIFF
--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -655,6 +655,7 @@ void JuraComponent::register_machine_data_field_sensor_(const std::string &key,
   auto *existing = this->find_machine_data_field_sensor_(key);
   std::string name = this->make_machine_data_field_name_(labels);
   if (existing != nullptr) {
+    existing->set_parent(this);
     existing->set_name(name.c_str());
     existing->publish_state("");
     return;
@@ -663,6 +664,7 @@ void JuraComponent::register_machine_data_field_sensor_(const std::string &key,
   auto *sensor = new text_sensor::TextSensor();
   sensor->set_name(name.c_str());
   sensor->set_internal(false);
+  sensor->set_parent(this);
   App.register_text_sensor(sensor);
   sensor->publish_state("");
   this->machine_data_field_sensors_[key] = sensor;


### PR DESCRIPTION
## Summary
- ensure automatically generated machine data text sensors are registered with the Jura component so Home Assistant assigns them to the device
- reattach cached field sensors to the component before updating their metadata

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dba3d03c5c8328b0796f010b5dea0f