### PR TITLE
Guard unique ID setter for machine data text sensors

### DIFF
--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -27,6 +27,14 @@ constexpr size_t HANDSHAKE_LOG_PREVIEW_LIMIT = 64;
 constexpr uint32_t MACHINE_DATA_QUERY_INTERVAL_MS = 30000;
 constexpr uint32_t MACHINE_DATA_REQUEST_TIMEOUT_MS = 2000;
 
+template<typename Sensor>
+auto try_set_unique_id(Sensor *sensor, const std::string &unique_id)
+    -> decltype(sensor->set_unique_id(unique_id), void()) {
+  sensor->set_unique_id(unique_id);
+}
+
+inline void try_set_unique_id(...) {}
+
 struct MachineDataCommandDefinition {
   const char *command;
   const char *section;
@@ -656,12 +664,20 @@ void JuraComponent::register_machine_data_field_sensor_(const std::string &key,
   std::string name = this->make_machine_data_field_name_(labels);
   if (existing != nullptr) {
     existing->set_name(name.c_str());
+    std::string unique_id = this->make_machine_data_field_unique_id_(key);
+    if (!unique_id.empty()) {
+      try_set_unique_id(existing, unique_id);
+    }
     existing->publish_state("");
     return;
   }
 
   auto *sensor = new text_sensor::TextSensor();
   sensor->set_name(name.c_str());
+  std::string unique_id = this->make_machine_data_field_unique_id_(key);
+  if (!unique_id.empty()) {
+    try_set_unique_id(sensor, unique_id);
+  }
   sensor->set_internal(false);
   App.register_text_sensor(sensor);
   sensor->publish_state("");
@@ -749,6 +765,25 @@ std::string JuraComponent::make_machine_data_field_name_(const std::vector<std::
     name = "Machine Data";
   }
   return name;
+}
+
+std::string JuraComponent::make_machine_data_field_unique_id_(const std::string &key) const {
+  std::string node_slug = slugify(App.get_name());
+  std::string device_slug = this->device_type_.empty() ? std::string("jura") : slugify(this->device_type_);
+
+  std::string key_slug = key;
+  std::replace(key_slug.begin(), key_slug.end(), '.', '_');
+
+  if (node_slug.empty()) {
+    node_slug = "esphome";
+  }
+
+  std::string unique_id = node_slug;
+  unique_id.append("_jutta_");
+  unique_id.append(device_slug);
+  unique_id.append("_");
+  unique_id.append(key_slug);
+  return unique_id;
 }
 
 const char *JuraComponent::handshake_stage_name(JuraComponent::HandshakeStage stage) {

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -71,6 +71,7 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   text_sensor::TextSensor *find_machine_data_field_sensor_(const std::string &key);
   void register_machine_data_field_sensor_(const std::string &key, const std::vector<std::string> &labels);
   std::string make_machine_data_field_name_(const std::vector<std::string> &labels) const;
+  std::string make_machine_data_field_unique_id_(const std::string &key) const;
   void initialize_machine_data_field_sensors_();
 
   std::unique_ptr<::jutta_proto::JuttaConnection> connection_;


### PR DESCRIPTION
## Summary
- add a helper that only invokes the text sensor unique ID setter when it exists
- fall back gracefully so machine data field registration works on builds without the setter

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68dba3d03c5c8328b0796f010b5dea0f