### PR TITLE
Add configurable machine data field mappings for auto fields

### DIFF
--- a/docs/components/jutta_proto.md
+++ b/docs/components/jutta_proto.md
@@ -179,6 +179,116 @@ jutta_proto:
 
 ```
 
+To reuse existing template sensors instead of the auto-generated entities, map specific machine data
+fields to sensor IDs with the `fields` option. The keys are dot-separated paths that use the slugified
+section, element, and field names (for example `statistic.maintenancecounter.cappuclean`). Each
+segment is case-insensitive and ignores whitespace, so you can enter either the original uppercase
+identifiers from the JURA XML or the lowercase slug equivalents. Only the mapped fields are redirected
+to the provided sensors—any remaining fields continue to use the automatically created entities.
+
+```yaml
+text_sensor:
+  - platform: template
+    name: "${devicename} CappuClean"
+    id: stat_counter_cappuclean
+  - platform: template
+    name: "${devicename} CappuRinse"
+    id: stat_counter_cappurinse
+  - platform: template
+    name: "${devicename} Cleaning"
+    id: stat_counter_cleaning
+  - platform: template
+    name: "${devicename} CoffeeRinse"
+    id: stat_counter_coffeerinse
+  - platform: template
+    name: "${devicename} Decalc"
+    id: stat_counter_decalc
+  - platform: template
+    name: "${devicename} FilterChange"
+    id: stat_counter_filterchange
+  - platform: template
+    name: "${devicename} Header"
+    id: stat_counter_header
+  - platform: template
+    name: "${devicename} Raw Hex"
+    id: stat_counter_rawhex
+  - platform: template
+    name: "${devicename} Text"
+    id: stat_counter_text
+  - platform: template
+    name: "${devicename} CappuClean Percent"
+    id: stat_percent_cappuclean_percent
+  - platform: template
+    name: "${devicename} CappuClean Raw"
+    id: stat_percent_cappuclean_raw
+  - platform: template
+    name: "${devicename} CappuRinse Percent"
+    id: stat_percent_cappurinse_percent
+  - platform: template
+    name: "${devicename} CappuRinse Raw"
+    id: stat_percent_cappurinse_raw
+  - platform: template
+    name: "${devicename} Cleaning Percent"
+    id: stat_percent_cleaning_percent
+  - platform: template
+    name: "${devicename} Cleaning Raw"
+    id: stat_percent_cleaning_raw
+  - platform: template
+    name: "${devicename} CoffeeRinse Percent"
+    id: stat_percent_coffeerinse_percent
+  - platform: template
+    name: "${devicename} CoffeeRinse Raw"
+    id: stat_percent_coffeerinse_raw
+  - platform: template
+    name: "${devicename} Decalc Percent"
+    id: stat_percent_decalc_percent
+  - platform: template
+    name: "${devicename} Decalc Raw"
+    id: stat_percent_decalc_raw
+  - platform: template
+    name: "${devicename} FilterChange Percent"
+    id: stat_percent_filterchange_percent
+  - platform: template
+    name: "${devicename} FilterChange Raw"
+    id: stat_percent_filterchange_raw
+  - platform: template
+    name: "${devicename} Header Percent"
+    id: stat_percent_header
+  - platform: template
+    name: "${devicename} Raw Hex Percent"
+    id: stat_percent_rawhex
+
+jutta_proto:
+  id: jura
+  uart_id: jura_uart
+  machine_data:
+    auto_fields: true
+    fields:
+      statistic.maintenancecounter.cappuclean: stat_counter_cappuclean
+      statistic.maintenancecounter.cappurinse: stat_counter_cappurinse
+      statistic.maintenancecounter.cleaning: stat_counter_cleaning
+      statistic.maintenancecounter.coffeerinse: stat_counter_coffeerinse
+      statistic.maintenancecounter.decalc: stat_counter_decalc
+      statistic.maintenancecounter.filterchange: stat_counter_filterchange
+      statistic.maintenancecounter.header: stat_counter_header
+      statistic.maintenancecounter.raw_hex: stat_counter_rawhex
+      statistic.maintenancecounter.text: stat_counter_text
+      statistic.maintenancepercent.cappuclean_percent: stat_percent_cappuclean_percent
+      statistic.maintenancepercent.cappuclean_raw: stat_percent_cappuclean_raw
+      statistic.maintenancepercent.cappurinse_percent: stat_percent_cappurinse_percent
+      statistic.maintenancepercent.cappurinse_raw: stat_percent_cappurinse_raw
+      statistic.maintenancepercent.cleaning_percent: stat_percent_cleaning_percent
+      statistic.maintenancepercent.cleaning_raw: stat_percent_cleaning_raw
+      statistic.maintenancepercent.coffeerinse_percent: stat_percent_coffeerinse_percent
+      statistic.maintenancepercent.coffeerinse_raw: stat_percent_coffeerinse_raw
+      statistic.maintenancepercent.decalc_percent: stat_percent_decalc_percent
+      statistic.maintenancepercent.decalc_raw: stat_percent_decalc_raw
+      statistic.maintenancepercent.filterchange_percent: stat_percent_filterchange_percent
+      statistic.maintenancepercent.filterchange_raw: stat_percent_filterchange_raw
+      statistic.maintenancepercent.header: stat_percent_header
+      statistic.maintenancepercent.raw_hex: stat_percent_rawhex
+```
+
 Inline definition example:
 
 ```yaml

--- a/esphome/components/jutta_proto/__init__.py
+++ b/esphome/components/jutta_proto/__init__.py
@@ -26,6 +26,7 @@ CONF_MACHINE_DATA_PROCESSES = "processes"
 CONF_MACHINE_DATA_RAW = "raw"
 CONF_MACHINE_DATA_AUTO_FIELDS = "auto_fields"
 CONF_MACHINE_DATA_FIELD_PREFIX = "field_prefix"
+CONF_MACHINE_DATA_FIELDS = "fields"
 
 MACHINE_DATA_SECTION_KEYS = [
     CONF_MACHINE_DATA_STATISTICS,
@@ -41,6 +42,8 @@ MACHINE_DATA_SENSOR_SCHEMA = cv.Any(
     text_sensor.text_sensor_schema(),
     cv.use_id(text_sensor.TextSensor),
 )
+
+MACHINE_DATA_FIELD_MAP_SCHEMA = cv.Schema({cv.string: MACHINE_DATA_SENSOR_SCHEMA})
 
 jutta_component_ns = cg.esphome_ns.namespace("jutta_component")
 jutta_proto_ns = cg.global_ns.namespace("jutta_proto")
@@ -121,6 +124,7 @@ MACHINE_DATA_CONFIG_SCHEMA = cv.Any(
             cv.Optional(
                 CONF_MACHINE_DATA_FIELD_PREFIX, default=DEFAULT_MACHINE_DATA_FIELD_PREFIX
             ): cv.string,
+            cv.Optional(CONF_MACHINE_DATA_FIELDS, default={}): MACHINE_DATA_FIELD_MAP_SCHEMA,
         }
     ),
 )
@@ -283,6 +287,9 @@ async def to_code(config):
             field_prefix = machine_data_cfg.get(
                 CONF_MACHINE_DATA_FIELD_PREFIX, DEFAULT_MACHINE_DATA_FIELD_PREFIX
             )
+            field_mappings_cfg = machine_data_cfg.get(CONF_MACHINE_DATA_FIELDS, {})
+        else:
+            field_mappings_cfg = {}
 
         async def _resolve_machine_data_sensor(cfg):
             if isinstance(cfg, dict):
@@ -294,6 +301,7 @@ async def to_code(config):
             excluded_sensor_keys = set(MACHINE_DATA_SECTION_KEYS) | {
                 CONF_MACHINE_DATA_AUTO_FIELDS,
                 CONF_MACHINE_DATA_FIELD_PREFIX,
+                CONF_MACHINE_DATA_FIELDS,
             }
             machine_data_sensor_cfg = {
                 key: value
@@ -338,6 +346,10 @@ async def to_code(config):
 
         cg.add(var.set_machine_data_auto_fields(auto_fields))
         cg.add(var.set_machine_data_field_prefix(cg.std_string(field_prefix)))
+
+        for key, sensor_cfg in field_mappings_cfg.items():
+            sensor = await _resolve_machine_data_sensor(sensor_cfg)
+            cg.add(var.add_machine_data_field_sensor(cg.std_string(key), sensor))
 
 
 async def _get_parent(config):

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -115,6 +115,47 @@ std::string prettify_identifier(const std::string &identifier) {
   return result;
 }
 
+bool contains_alnum(const std::string &value) {
+  for (unsigned char c : value) {
+    if (std::isalnum(c) != 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::string normalize_machine_data_field_key(const std::string &key) {
+  if (key.empty()) {
+    return "";
+  }
+
+  std::string normalized;
+  size_t start = 0;
+  while (start <= key.size()) {
+    size_t end = key.find('.', start);
+    std::string segment = key.substr(start, end - start);
+    if (contains_alnum(segment)) {
+      std::string slug = slugify(segment);
+      if (!slug.empty()) {
+        if (!normalized.empty()) {
+          normalized.push_back('.');
+        }
+        normalized.append(slug);
+      }
+    }
+    if (end == std::string::npos) {
+      break;
+    }
+    start = end + 1;
+  }
+
+  if (normalized.empty() && contains_alnum(key)) {
+    normalized = slugify(key);
+  }
+
+  return normalized;
+}
+
 using MachineDataFieldList = std::vector<std::pair<std::string, std::string>>;
 using MachineDataFieldMap = std::map<std::string, std::pair<std::vector<std::string>, std::string>>;
 
@@ -654,6 +695,20 @@ text_sensor::TextSensor *JuraComponent::find_machine_data_field_sensor_(const st
   return it->second;
 }
 
+void JuraComponent::add_machine_data_field_sensor(const std::string &key,
+                                                  text_sensor::TextSensor *sensor) {
+  if (sensor == nullptr) {
+    return;
+  }
+  std::string normalized = normalize_machine_data_field_key(key);
+  if (normalized.empty()) {
+    ESP_LOGW(TAG, "Ignoring machine data field mapping with empty key '%s'.", key.c_str());
+    return;
+  }
+  this->machine_data_field_sensors_[normalized] = sensor;
+  this->machine_data_field_user_keys_.insert(normalized);
+}
+
 void JuraComponent::register_machine_data_field_sensor_(const std::string &key,
                                                         const std::vector<std::string> &labels) {
   if (!this->machine_data_auto_fields_ || key.empty()) {
@@ -663,12 +718,14 @@ void JuraComponent::register_machine_data_field_sensor_(const std::string &key,
   auto *existing = this->find_machine_data_field_sensor_(key);
   std::string name = this->make_machine_data_field_name_(labels);
   if (existing != nullptr) {
-    existing->set_name(name.c_str());
-    std::string unique_id = this->make_machine_data_field_unique_id_(key);
-    if (!unique_id.empty()) {
+    if (this->machine_data_field_user_keys_.count(key) == 0) {
+      existing->set_name(name.c_str());
+      std::string unique_id = this->make_machine_data_field_unique_id_(key);
+      if (!unique_id.empty()) {
 
-      try_set_unique_id(existing, unique_id);
+        try_set_unique_id(existing, unique_id);
 
+      }
     }
     existing->publish_state("");
     return;

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -54,6 +54,7 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   void set_machine_data_field_prefix(const std::string &prefix) {
     this->machine_data_field_prefix_ = prefix;
   }
+  void add_machine_data_field_sensor(const std::string &key, text_sensor::TextSensor *sensor);
 
  protected:
   enum class HandshakeStage { IDLE, HELLO, SEND_T1, WAIT_T2, SEND_T2, WAIT_T3, SEND_T3, DONE, FAILED };
@@ -93,6 +94,7 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   bool machine_data_auto_fields_{false};
   std::string machine_data_field_prefix_{""};
   std::map<std::string, text_sensor::TextSensor *> machine_data_field_sensors_;
+  std::set<std::string> machine_data_field_user_keys_;
   std::map<std::string, std::pair<std::vector<std::string>, std::string>> machine_data_field_values_;
   uint32_t machine_data_query_next_{0};
   bool machine_data_request_pending_{false};


### PR DESCRIPTION
## Summary
- add a `fields` mapping that wires machine data auto field output into existing text sensors
- normalize mapped field keys and avoid overwriting user-provided sensor names while keeping auto entities
- document how to configure the new field mappings with an extended YAML example

## Testing
- python -m compileall esphome/components/jutta_proto/__init__.py


------
https://chatgpt.com/codex/tasks/task_e_68dba9f9fbdc83288b7a604fa6a88b24