### PR TITLE
Fix missing include for Jura component

### DIFF
--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
## Summary
- include the `<set>` header so the Jura component can compile when using `std::set`

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbad3760e88328936feee5719190ae