### PR TITLE
Add numeric machine data sensors and guard XML queries

### DIFF
--- a/docs/components/jutta_proto.md
+++ b/docs/components/jutta_proto.md
@@ -115,8 +115,9 @@ Use `raw` instead of `command` when you need to send a custom UART command strin
 ## Machine Data Sensors
 
 The Jura firmware exposes several machine data blocks (statistics, errors, status, and running processes). The component can
-publish them as individual `text_sensor` entities so the values can easily be displayed in Home Assistant dashboards or used in
-automations.
+publish them as individual sensors so the values can easily be displayed in Home Assistant dashboards or used in automations.
+Text sensors are still supported for the raw XML payload and the formatted section summaries, while all numeric fields can be
+exposed as regular `sensor` entities.
 
 !!! tip
     Each entry inside the `machine_data` block must point to a text sensor that already exists. When referencing a sensor by ID
@@ -124,10 +125,10 @@ automations.
     raise an error such as `Couldn't find ID 'jura_machine_raw'` during compilation. You can either create the sensor ahead of
     time under the `text_sensor:` key or define it inline inside `machine_data` as shown below.
 
-Add a `machine_data` section to the component configuration and register one or multiple text sensors. When a single
-`text_sensor` entry is provided the raw XML payload is published. Alternatively, the individual sections can be configured to
-receive pre-formatted text output parsed from the XML response. All sensors are optional and can be combined as needed. Each
-entry can either declare a new sensor inline or reference an existing `text_sensor` via its `id`.
+Add a `machine_data` section to the component configuration and register one or multiple sensors. When a single `text_sensor`
+entry is provided the raw XML payload is published. Alternatively, the individual sections can be configured to receive
+pre-formatted text output parsed from the XML response. All sensors are optional and can be combined as needed. Each entry can
+either declare a new sensor inline or reference an existing `text_sensor` via its `id`.
 
 ```yaml
 text_sensor:
@@ -157,10 +158,11 @@ jutta_proto:
     processes: jura_processes
     raw: jura_machine_raw
 
-To publish the built-in set of machine data field sensors, enable `auto_fields`.
-All known statistics, maintenance counters, maintenance percentages, and helper fields are
-pre-registered up front and reuse the same entity names on every boot. Each sensor name starts with
-`field_prefix` (if provided) followed by a human-readable description of the section and field. Omit
+To publish the built-in set of machine data field sensors, enable `auto_fields`. All known statistics, maintenance counters,
+maintenance percentages, and helper fields are pre-registered up front and reuse the same entity names on every boot. Numeric
+values (for example drink counters and percentage indicators) are exposed as regular sensors with the proper unit of
+measurement, while helper fields such as the header, decoded text, and raw hexadecimal payload remain text sensors. Each
+sensor name starts with `field_prefix` (if provided) followed by a human-readable description of the section and field. Omit
 `field_prefix` to keep the built-in names without an additional prefix:
 
 ```yaml
@@ -179,84 +181,37 @@ jutta_proto:
 
 ```
 
-To reuse existing template sensors instead of the auto-generated entities, map specific machine data
-fields to sensor IDs with the `fields` option. The keys are dot-separated paths that use the slugified
-section, element, and field names (for example `statistic.maintenancecounter.cappuclean`). Each
-segment is case-insensitive and ignores whitespace, so you can enter either the original uppercase
-identifiers from the JURA XML or the lowercase slug equivalents. Only the mapped fields are redirected
-to the provided sensors—any remaining fields continue to use the automatically created entities.
+To reuse existing template sensors instead of the auto-generated entities, map specific machine data fields to sensor IDs with
+the `fields` option. The keys are dot-separated paths that use the slugified section, element, and field names (for example
+`statistic.maintenancecounter.cappuclean`). Each segment is case-insensitive and ignores whitespace, so you can enter either the
+original uppercase identifiers from the JURA XML or the lowercase slug equivalents. Only the mapped fields are redirected to the
+provided sensors—any remaining fields continue to use the automatically created entities. Use the nested `sensor:` key to map a
+numeric field to a regular sensor and `text_sensor:` for text values.
 
 ```yaml
-text_sensor:
+sensor:
   - platform: template
-    name: "${devicename} CappuClean"
-    id: stat_counter_cappuclean
-  - platform: template
-    name: "${devicename} CappuRinse"
-    id: stat_counter_cappurinse
-  - platform: template
-    name: "${devicename} Cleaning"
+    name: "${devicename} Cleaning Cycles"
     id: stat_counter_cleaning
+    state_class: total_increasing
   - platform: template
-    name: "${devicename} CoffeeRinse"
-    id: stat_counter_coffeerinse
-  - platform: template
-    name: "${devicename} Decalc"
-    id: stat_counter_decalc
-  - platform: template
-    name: "${devicename} FilterChange"
-    id: stat_counter_filterchange
-  - platform: template
-    name: "${devicename} Header"
-    id: stat_counter_header
-  - platform: template
-    name: "${devicename} Raw Hex"
-    id: stat_counter_rawhex
-  - platform: template
-    name: "${devicename} Text"
-    id: stat_counter_text
-  - platform: template
-    name: "${devicename} CappuClean Percent"
-    id: stat_percent_cappuclean_percent
-  - platform: template
-    name: "${devicename} CappuClean Raw"
-    id: stat_percent_cappuclean_raw
-  - platform: template
-    name: "${devicename} CappuRinse Percent"
-    id: stat_percent_cappurinse_percent
-  - platform: template
-    name: "${devicename} CappuRinse Raw"
-    id: stat_percent_cappurinse_raw
-  - platform: template
-    name: "${devicename} Cleaning Percent"
-    id: stat_percent_cleaning_percent
+    name: "${devicename} Cleaning %"
+    id: stat_percent_cleaning
+    unit_of_measurement: "%"
+    accuracy_decimals: 1
+    state_class: measurement
   - platform: template
     name: "${devicename} Cleaning Raw"
     id: stat_percent_cleaning_raw
+    state_class: measurement
+
+text_sensor:
   - platform: template
-    name: "${devicename} CoffeeRinse Percent"
-    id: stat_percent_coffeerinse_percent
+    name: "${devicename} Maintenance Header"
+    id: stat_counter_header
   - platform: template
-    name: "${devicename} CoffeeRinse Raw"
-    id: stat_percent_coffeerinse_raw
-  - platform: template
-    name: "${devicename} Decalc Percent"
-    id: stat_percent_decalc_percent
-  - platform: template
-    name: "${devicename} Decalc Raw"
-    id: stat_percent_decalc_raw
-  - platform: template
-    name: "${devicename} FilterChange Percent"
-    id: stat_percent_filterchange_percent
-  - platform: template
-    name: "${devicename} FilterChange Raw"
-    id: stat_percent_filterchange_raw
-  - platform: template
-    name: "${devicename} Header Percent"
-    id: stat_percent_header
-  - platform: template
-    name: "${devicename} Raw Hex Percent"
-    id: stat_percent_rawhex
+    name: "${devicename} Maintenance Text"
+    id: stat_counter_text
 
 jutta_proto:
   id: jura
@@ -264,29 +219,16 @@ jutta_proto:
   machine_data:
     auto_fields: true
     fields:
-      statistic.maintenancecounter.cappuclean: stat_counter_cappuclean
-      statistic.maintenancecounter.cappurinse: stat_counter_cappurinse
-      statistic.maintenancecounter.cleaning: stat_counter_cleaning
-      statistic.maintenancecounter.coffeerinse: stat_counter_coffeerinse
-      statistic.maintenancecounter.decalc: stat_counter_decalc
-      statistic.maintenancecounter.filterchange: stat_counter_filterchange
-      statistic.maintenancecounter.header: stat_counter_header
-      statistic.maintenancecounter.raw_hex: stat_counter_rawhex
-      statistic.maintenancecounter.text: stat_counter_text
-      statistic.maintenancepercent.cappuclean_percent: stat_percent_cappuclean_percent
-      statistic.maintenancepercent.cappuclean_raw: stat_percent_cappuclean_raw
-      statistic.maintenancepercent.cappurinse_percent: stat_percent_cappurinse_percent
-      statistic.maintenancepercent.cappurinse_raw: stat_percent_cappurinse_raw
-      statistic.maintenancepercent.cleaning_percent: stat_percent_cleaning_percent
-      statistic.maintenancepercent.cleaning_raw: stat_percent_cleaning_raw
-      statistic.maintenancepercent.coffeerinse_percent: stat_percent_coffeerinse_percent
-      statistic.maintenancepercent.coffeerinse_raw: stat_percent_coffeerinse_raw
-      statistic.maintenancepercent.decalc_percent: stat_percent_decalc_percent
-      statistic.maintenancepercent.decalc_raw: stat_percent_decalc_raw
-      statistic.maintenancepercent.filterchange_percent: stat_percent_filterchange_percent
-      statistic.maintenancepercent.filterchange_raw: stat_percent_filterchange_raw
-      statistic.maintenancepercent.header: stat_percent_header
-      statistic.maintenancepercent.raw_hex: stat_percent_rawhex
+      statistic.maintenancecounter.cleaning:
+        sensor: stat_counter_cleaning
+      statistic.maintenancecounter.header:
+        text_sensor: stat_counter_header
+      statistic.maintenancecounter.text:
+        text_sensor: stat_counter_text
+      statistic.maintenancepercent.cleaning_percent:
+        sensor: stat_percent_cleaning
+      statistic.maintenancepercent.cleaning_raw:
+        sensor: stat_percent_cleaning_raw
 ```
 
 Inline definition example:

--- a/esphome/components/jutta_proto/__init__.py
+++ b/esphome/components/jutta_proto/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
-from esphome.components import text_sensor, uart
+from esphome.components import sensor, text_sensor, uart
 from esphome.const import CONF_ID
 
 DEPENDENCIES = ["uart"]
@@ -19,6 +19,8 @@ CONF_DELAY = "delay"
 CONF_TIMEOUT = "timeout"
 CONF_DESCRIPTION = "description"
 CONF_MACHINE_DATA = "machine_data"
+CONF_MACHINE_DATA_SENSOR = "sensor"
+CONF_MACHINE_DATA_TEXT_SENSOR = "text_sensor"
 CONF_MACHINE_DATA_STATISTICS = "statistics"
 CONF_MACHINE_DATA_ERRORS = "errors"
 CONF_MACHINE_DATA_STATUS = "status"
@@ -38,12 +40,25 @@ MACHINE_DATA_SECTION_KEYS = [
 
 DEFAULT_MACHINE_DATA_FIELD_PREFIX = ""
 
-MACHINE_DATA_SENSOR_SCHEMA = cv.Any(
+MACHINE_DATA_TEXT_SENSOR_SCHEMA = cv.Any(
     text_sensor.text_sensor_schema(),
     cv.use_id(text_sensor.TextSensor),
 )
 
-MACHINE_DATA_FIELD_MAP_SCHEMA = cv.Schema({cv.string: MACHINE_DATA_SENSOR_SCHEMA})
+MACHINE_DATA_NUMERIC_SENSOR_SCHEMA = cv.Any(
+    sensor.sensor_schema(),
+    cv.use_id(sensor.Sensor),
+)
+
+MACHINE_DATA_FIELD_MAP_SCHEMA = cv.Schema(
+    {
+        cv.string: cv.Any(
+            cv.Schema({cv.Required(CONF_MACHINE_DATA_SENSOR): MACHINE_DATA_NUMERIC_SENSOR_SCHEMA}),
+            cv.Schema({cv.Required(CONF_MACHINE_DATA_TEXT_SENSOR): MACHINE_DATA_TEXT_SENSOR_SCHEMA}),
+            MACHINE_DATA_TEXT_SENSOR_SCHEMA,
+        )
+    }
+)
 
 jutta_component_ns = cg.esphome_ns.namespace("jutta_component")
 jutta_proto_ns = cg.global_ns.namespace("jutta_proto")
@@ -112,14 +127,14 @@ JURA_COMPONENT_IDS = []
 
 
 MACHINE_DATA_CONFIG_SCHEMA = cv.Any(
-    MACHINE_DATA_SENSOR_SCHEMA,
+    MACHINE_DATA_TEXT_SENSOR_SCHEMA,
     cv.Schema(
         {
-            cv.Optional(CONF_MACHINE_DATA_STATISTICS): MACHINE_DATA_SENSOR_SCHEMA,
-            cv.Optional(CONF_MACHINE_DATA_ERRORS): MACHINE_DATA_SENSOR_SCHEMA,
-            cv.Optional(CONF_MACHINE_DATA_STATUS): MACHINE_DATA_SENSOR_SCHEMA,
-            cv.Optional(CONF_MACHINE_DATA_PROCESSES): MACHINE_DATA_SENSOR_SCHEMA,
-            cv.Optional(CONF_MACHINE_DATA_RAW): MACHINE_DATA_SENSOR_SCHEMA,
+            cv.Optional(CONF_MACHINE_DATA_STATISTICS): MACHINE_DATA_TEXT_SENSOR_SCHEMA,
+            cv.Optional(CONF_MACHINE_DATA_ERRORS): MACHINE_DATA_TEXT_SENSOR_SCHEMA,
+            cv.Optional(CONF_MACHINE_DATA_STATUS): MACHINE_DATA_TEXT_SENSOR_SCHEMA,
+            cv.Optional(CONF_MACHINE_DATA_PROCESSES): MACHINE_DATA_TEXT_SENSOR_SCHEMA,
+            cv.Optional(CONF_MACHINE_DATA_RAW): MACHINE_DATA_TEXT_SENSOR_SCHEMA,
             cv.Optional(CONF_MACHINE_DATA_AUTO_FIELDS, default=False): cv.boolean,
             cv.Optional(
                 CONF_MACHINE_DATA_FIELD_PREFIX, default=DEFAULT_MACHINE_DATA_FIELD_PREFIX
@@ -291,10 +306,28 @@ async def to_code(config):
         else:
             field_mappings_cfg = {}
 
-        async def _resolve_machine_data_sensor(cfg):
+        async def _resolve_machine_data_text_sensor(cfg):
             if isinstance(cfg, dict):
                 return await text_sensor.new_text_sensor(cfg)
             return await cg.get_variable(cfg)
+
+        async def _resolve_machine_data_field_sensor(cfg):
+            if isinstance(cfg, dict):
+                if CONF_MACHINE_DATA_SENSOR in cfg:
+                    inner = cfg[CONF_MACHINE_DATA_SENSOR]
+                    if isinstance(inner, dict):
+                        return await sensor.new_sensor(inner), True
+                    return await cg.get_variable(inner), True
+                if CONF_MACHINE_DATA_TEXT_SENSOR in cfg:
+                    inner = cfg[CONF_MACHINE_DATA_TEXT_SENSOR]
+                    if isinstance(inner, dict):
+                        return await text_sensor.new_text_sensor(inner), False
+                    return await cg.get_variable(inner), False
+                try:
+                    return await text_sensor.new_text_sensor(cfg), False
+                except cv.Invalid:
+                    return await sensor.new_sensor(cfg), True
+            return await cg.get_variable(cfg), False
 
         machine_data_sensor_cfg = None
         if isinstance(machine_data_cfg, dict):
@@ -313,43 +346,46 @@ async def to_code(config):
             key in machine_data_cfg for key in MACHINE_DATA_SECTION_KEYS
         ):
             if CONF_MACHINE_DATA_STATISTICS in machine_data_cfg:
-                sensor = await _resolve_machine_data_sensor(
+                sensor = await _resolve_machine_data_text_sensor(
                     machine_data_cfg[CONF_MACHINE_DATA_STATISTICS]
                 )
                 cg.add(var.set_machine_data_statistic_sensor(sensor))
             if CONF_MACHINE_DATA_ERRORS in machine_data_cfg:
-                sensor = await _resolve_machine_data_sensor(
+                sensor = await _resolve_machine_data_text_sensor(
                     machine_data_cfg[CONF_MACHINE_DATA_ERRORS]
                 )
                 cg.add(var.set_machine_data_errors_sensor(sensor))
             if CONF_MACHINE_DATA_STATUS in machine_data_cfg:
-                sensor = await _resolve_machine_data_sensor(
+                sensor = await _resolve_machine_data_text_sensor(
                     machine_data_cfg[CONF_MACHINE_DATA_STATUS]
                 )
                 cg.add(var.set_machine_data_status_sensor(sensor))
             if CONF_MACHINE_DATA_PROCESSES in machine_data_cfg:
-                sensor = await _resolve_machine_data_sensor(
+                sensor = await _resolve_machine_data_text_sensor(
                     machine_data_cfg[CONF_MACHINE_DATA_PROCESSES]
                 )
                 cg.add(var.set_machine_data_processes_sensor(sensor))
             if CONF_MACHINE_DATA_RAW in machine_data_cfg:
-                sensor = await _resolve_machine_data_sensor(
+                sensor = await _resolve_machine_data_text_sensor(
                     machine_data_cfg[CONF_MACHINE_DATA_RAW]
                 )
                 cg.add(var.set_machine_data_sensor(sensor))
         elif not isinstance(machine_data_cfg, dict):
-            sensor = await _resolve_machine_data_sensor(machine_data_cfg)
+            sensor = await _resolve_machine_data_text_sensor(machine_data_cfg)
             cg.add(var.set_machine_data_sensor(sensor))
         elif machine_data_sensor_cfg:
-            sensor = await _resolve_machine_data_sensor(machine_data_sensor_cfg)
+            sensor = await _resolve_machine_data_text_sensor(machine_data_sensor_cfg)
             cg.add(var.set_machine_data_sensor(sensor))
 
         cg.add(var.set_machine_data_auto_fields(auto_fields))
         cg.add(var.set_machine_data_field_prefix(cg.std_string(field_prefix)))
 
         for key, sensor_cfg in field_mappings_cfg.items():
-            sensor = await _resolve_machine_data_sensor(sensor_cfg)
-            cg.add(var.add_machine_data_field_sensor(cg.std_string(key), sensor))
+            sensor_var, is_numeric = await _resolve_machine_data_field_sensor(sensor_cfg)
+            if is_numeric:
+                cg.add(var.add_machine_data_field_sensor(cg.std_string(key), sensor_var))
+            else:
+                cg.add(var.add_machine_data_field_sensor(cg.std_string(key), sensor_var))
 
 
 async def _get_parent(config):

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -4,6 +4,7 @@
 #include <array>
 #include <cctype>
 #include <cstdint>
+#include <cmath>
 #include <iomanip>
 #include <map>
 #include <optional>
@@ -156,8 +157,14 @@ std::string normalize_machine_data_field_key(const std::string &key) {
   return normalized;
 }
 
-using MachineDataFieldList = std::vector<std::pair<std::string, std::string>>;
-using MachineDataFieldMap = std::map<std::string, std::pair<std::vector<std::string>, std::string>>;
+struct MachineDataFieldEntry {
+  std::string name;
+  std::string text_value;
+  std::optional<float> numeric_value;
+  std::string unit;
+};
+
+using MachineDataFieldList = std::vector<MachineDataFieldEntry>;
 
 struct ProductCounterDefinition {
   const char *name;
@@ -227,11 +234,12 @@ MachineDataFieldList parse_product_counter_fields(const std::string &payload) {
   std::ostringstream header_stream;
   header_stream << "0x" << std::uppercase << std::hex << std::setfill('0') << std::setw(2)
                 << static_cast<int>(header);
-  fields.emplace_back("Header", header_stream.str());
+  fields.push_back({"Header", header_stream.str(), std::nullopt, ""});
 
   for (size_t i = 0; i < PRODUCT_COUNTER_DEFINITIONS.size(); ++i) {
     uint16_t value = read_u16_le(&data[1 + i * 2]);
-    fields.emplace_back(PRODUCT_COUNTER_DEFINITIONS[i].name, std::to_string(value));
+    fields.push_back({PRODUCT_COUNTER_DEFINITIONS[i].name, std::to_string(value),
+                      static_cast<float>(value), ""});
   }
 
   return fields;
@@ -269,11 +277,12 @@ MachineDataFieldList parse_maintenance_counter_fields(const std::string &payload
   std::ostringstream header_stream;
   header_stream << "0x" << std::uppercase << std::hex << std::setfill('0') << std::setw(2)
                 << static_cast<int>(header);
-  fields.emplace_back("Header", header_stream.str());
+  fields.push_back({"Header", header_stream.str(), std::nullopt, ""});
 
   for (size_t i = 0; i < MAINTENANCE_COUNTER_NAMES.size(); ++i) {
     uint16_t value = read_u16_le(&data[1 + i * 2]);
-    fields.emplace_back(MAINTENANCE_COUNTER_NAMES[i], std::to_string(value));
+    fields.push_back({MAINTENANCE_COUNTER_NAMES[i], std::to_string(value), static_cast<float>(value),
+                      ""});
   }
 
   return fields;
@@ -331,7 +340,7 @@ MachineDataFieldList parse_maintenance_percent_fields(const std::string &payload
   std::ostringstream header_stream;
   header_stream << "0x" << std::uppercase << std::hex << std::setfill('0')
                 << std::setw(static_cast<int>(header_size * 2)) << header;
-  fields.emplace_back("Header", header_stream.str());
+  fields.push_back({"Header", header_stream.str(), std::nullopt, ""});
 
   for (size_t i = 0; i < MAINTENANCE_PERCENT_NAMES.size(); ++i) {
     size_t index = value_offset + i * 2;
@@ -341,12 +350,14 @@ MachineDataFieldList parse_maintenance_percent_fields(const std::string &payload
     uint16_t raw_value = read_u16_le(&data[index]);
     std::ostringstream raw_stream;
     raw_stream << raw_value;
-    fields.emplace_back(std::string(MAINTENANCE_PERCENT_NAMES[i]) + " Raw", raw_stream.str());
+    fields.push_back({std::string(MAINTENANCE_PERCENT_NAMES[i]) + " Raw", raw_stream.str(),
+                      static_cast<float>(raw_value), ""});
 
     std::ostringstream percent_stream;
     percent_stream << std::fixed << std::setprecision(2)
                    << (static_cast<double>(raw_value) * 100.0 / 65535.0);
-    fields.emplace_back(std::string(MAINTENANCE_PERCENT_NAMES[i]) + " Percent", percent_stream.str());
+    fields.push_back({std::string(MAINTENANCE_PERCENT_NAMES[i]) + " Percent", percent_stream.str(),
+                      static_cast<float>(static_cast<double>(raw_value) * 100.0 / 65535.0), "%"});
   }
 
   return fields;
@@ -442,6 +453,9 @@ std::string xml_escape(const std::string &value) {
   return stream.str();
 }
 
+using MachineDataFieldMap = JuraComponent::MachineDataFieldMap;
+using MachineDataFieldValue = JuraComponent::MachineDataFieldValue;
+
 std::string build_machine_data_payload(const std::vector<std::string> &responses,
                                        MachineDataFieldMap *field_map = nullptr) {
   std::ostringstream stream;
@@ -498,27 +512,41 @@ std::string build_machine_data_payload(const std::vector<std::string> &responses
         MachineDataFieldList fields = parse_machine_data_fields(definition.command, response);
         for (const auto &field : fields) {
           std::vector<std::string> labels = base_labels;
-          labels.push_back(field.first);
-          std::string value_slug = slugify(field.first);
+          labels.push_back(field.name);
+          std::string value_slug = slugify(field.name);
           std::string field_key = key_prefix.empty() ? value_slug : key_prefix + '.' + value_slug;
-          (*field_map)[field_key] = {labels, field.second};
+          MachineDataFieldValue value;
+          value.labels = std::move(labels);
+          value.text_value = field.text_value;
+          value.numeric_value = field.numeric_value;
+          value.unit = field.unit;
+          (*field_map)[field_key] = std::move(value);
         }
 
         std::vector<std::string> raw_labels = base_labels;
         raw_labels.push_back("Raw Hex");
         std::string raw_key = key_prefix.empty() ? std::string("raw_hex") : key_prefix + ".raw_hex";
-        (*field_map)[raw_key] = {raw_labels, to_upper_hex(response)};
+        MachineDataFieldValue raw_value;
+        raw_value.labels = std::move(raw_labels);
+        raw_value.text_value = to_upper_hex(response);
+        (*field_map)[raw_key] = std::move(raw_value);
 
         if (parsed_text.has_value()) {
           std::vector<std::string> text_labels = base_labels;
           text_labels.push_back("Text");
           std::string text_key = key_prefix.empty() ? std::string("text") : key_prefix + ".text";
-          (*field_map)[text_key] = {text_labels, parsed_text.value()};
+          MachineDataFieldValue text_value;
+          text_value.labels = std::move(text_labels);
+          text_value.text_value = parsed_text.value();
+          (*field_map)[text_key] = std::move(text_value);
         } else if (is_safe_xml_text(response)) {
           std::vector<std::string> text_labels = base_labels;
           text_labels.push_back("Text");
           std::string text_key = key_prefix.empty() ? std::string("text") : key_prefix + ".text";
-          (*field_map)[text_key] = {text_labels, response};
+          MachineDataFieldValue text_value;
+          text_value.labels = std::move(text_labels);
+          text_value.text_value = response;
+          (*field_map)[text_key] = std::move(text_value);
         }
       }
     }
@@ -664,25 +692,55 @@ std::string sanitize_text_sensor_value(const std::string &value) {
 }  // namespace
 
 void JuraComponent::publish_machine_data_fields_(const MachineDataFieldMap &fields) {
-  if (!this->machine_data_auto_fields_) {
+  if (fields.empty() && this->machine_data_field_sensors_.empty() &&
+      this->machine_data_numeric_field_sensors_.empty()) {
     return;
   }
 
-  std::set<std::string> seen;
+  std::set<std::string> seen_text;
+  std::set<std::string> seen_numeric;
   for (const auto &entry : fields) {
-    auto *sensor = this->find_machine_data_field_sensor_(entry.first);
-    if (sensor == nullptr) {
-      continue;
+    const auto &value = entry.second;
+    auto *text_sensor = this->find_machine_data_field_sensor_(entry.first);
+    if (text_sensor != nullptr) {
+      if (this->machine_data_auto_fields_ && this->machine_data_field_user_keys_.count(entry.first) == 0) {
+        std::string name = this->make_machine_data_field_name_(value.labels);
+        text_sensor->set_name(name.c_str());
+      }
+      text_sensor->publish_state(sanitize_text_sensor_value(value.text_value));
+      seen_text.insert(entry.first);
     }
-    std::string name = this->make_machine_data_field_name_(entry.second.first);
-    sensor->set_name(name.c_str());
-    sensor->publish_state(sanitize_text_sensor_value(entry.second.second));
-    seen.insert(entry.first);
+
+    auto *numeric_sensor = this->find_machine_data_numeric_sensor_(entry.first);
+    if (numeric_sensor != nullptr) {
+      if (this->machine_data_auto_fields_ &&
+          this->machine_data_numeric_field_user_keys_.count(entry.first) == 0) {
+        std::string name = this->make_machine_data_field_name_(value.labels);
+        numeric_sensor->set_name(name.c_str());
+        if (!value.unit.empty()) {
+          numeric_sensor->set_unit_of_measurement(value.unit.c_str());
+        } else {
+          numeric_sensor->set_unit_of_measurement(nullptr);
+        }
+      }
+      if (value.numeric_value.has_value()) {
+        numeric_sensor->publish_state(*value.numeric_value);
+      } else {
+        numeric_sensor->publish_state(NAN);
+      }
+      seen_numeric.insert(entry.first);
+    }
   }
 
   for (const auto &existing : this->machine_data_field_sensors_) {
-    if (seen.count(existing.first) == 0) {
+    if (seen_text.count(existing.first) == 0) {
       existing.second->publish_state("");
+    }
+  }
+
+  for (const auto &existing : this->machine_data_numeric_field_sensors_) {
+    if (seen_numeric.count(existing.first) == 0) {
+      existing.second->publish_state(NAN);
     }
   }
 }
@@ -709,8 +767,29 @@ void JuraComponent::add_machine_data_field_sensor(const std::string &key,
   this->machine_data_field_user_keys_.insert(normalized);
 }
 
-void JuraComponent::register_machine_data_field_sensor_(const std::string &key,
-                                                        const std::vector<std::string> &labels) {
+sensor::Sensor *JuraComponent::find_machine_data_numeric_sensor_(const std::string &key) {
+  auto it = this->machine_data_numeric_field_sensors_.find(key);
+  if (it == this->machine_data_numeric_field_sensors_.end()) {
+    return nullptr;
+  }
+  return it->second;
+}
+
+void JuraComponent::add_machine_data_field_sensor(const std::string &key, sensor::Sensor *sensor) {
+  if (sensor == nullptr) {
+    return;
+  }
+  std::string normalized = normalize_machine_data_field_key(key);
+  if (normalized.empty()) {
+    ESP_LOGW(TAG, "Ignoring machine data field mapping with empty key '%s'.", key.c_str());
+    return;
+  }
+  this->machine_data_numeric_field_sensors_[normalized] = sensor;
+  this->machine_data_numeric_field_user_keys_.insert(normalized);
+}
+
+void JuraComponent::register_machine_data_text_sensor_(const std::string &key,
+                                                       const std::vector<std::string> &labels) {
   if (!this->machine_data_auto_fields_ || key.empty()) {
     return;
   }
@@ -745,6 +824,47 @@ void JuraComponent::register_machine_data_field_sensor_(const std::string &key,
   this->machine_data_field_sensors_[key] = sensor;
 }
 
+void JuraComponent::register_machine_data_numeric_sensor_(const std::string &key,
+                                                          const std::vector<std::string> &labels,
+                                                          const std::string &unit) {
+  if (!this->machine_data_auto_fields_ || key.empty()) {
+    return;
+  }
+
+  auto *existing = this->find_machine_data_numeric_sensor_(key);
+  std::string name = this->make_machine_data_field_name_(labels);
+  if (existing != nullptr) {
+    if (this->machine_data_numeric_field_user_keys_.count(key) == 0) {
+      existing->set_name(name.c_str());
+      if (!unit.empty()) {
+        existing->set_unit_of_measurement(unit.c_str());
+      } else {
+        existing->set_unit_of_measurement(nullptr);
+      }
+      std::string unique_id = this->make_machine_data_field_unique_id_(key);
+      if (!unique_id.empty()) {
+        try_set_unique_id(existing, unique_id);
+      }
+    }
+    existing->publish_state(NAN);
+    return;
+  }
+
+  auto *sensor = new sensor::Sensor();
+  sensor->set_name(name.c_str());
+  if (!unit.empty()) {
+    sensor->set_unit_of_measurement(unit.c_str());
+  }
+  std::string unique_id = this->make_machine_data_field_unique_id_(key);
+  if (!unique_id.empty()) {
+    try_set_unique_id(sensor, unique_id);
+  }
+  sensor->set_internal(false);
+  App.register_sensor(sensor);
+  sensor->publish_state(NAN);
+  this->machine_data_numeric_field_sensors_[key] = sensor;
+}
+
 void JuraComponent::initialize_machine_data_field_sensors_() {
   if (!this->machine_data_auto_fields_) {
     return;
@@ -764,7 +884,7 @@ void JuraComponent::initialize_machine_data_field_sensors_() {
       key_prefix.append(element_slug);
     }
 
-    auto register_field = [&](const std::string &field_name, const std::string &slug) {
+    auto register_text_field = [&](const std::string &field_name, const std::string &slug) {
       if (field_name.empty() || slug.empty()) {
         return;
       }
@@ -776,38 +896,46 @@ void JuraComponent::initialize_machine_data_field_sensors_() {
       } else {
         field_key = key_prefix + '.' + slug;
       }
-      this->register_machine_data_field_sensor_(field_key, labels);
+      this->register_machine_data_text_sensor_(field_key, labels);
     };
 
-    auto register_fields_from_list = [&](const std::vector<std::string> &names) {
-      for (const auto &name : names) {
-        register_field(name, slugify(name));
+    auto register_numeric_field = [&](const std::string &field_name, const std::string &slug,
+                                      const std::string &unit) {
+      if (field_name.empty() || slug.empty()) {
+        return;
       }
+      std::vector<std::string> labels = base_labels;
+      labels.push_back(field_name);
+      std::string field_key;
+      if (key_prefix.empty()) {
+        field_key = slug;
+      } else {
+        field_key = key_prefix + '.' + slug;
+      }
+      this->register_machine_data_numeric_sensor_(field_key, labels, unit);
     };
 
     if (definition.command == std::string("@TR:32")) {
-      std::vector<std::string> names = {"Header"};
+      register_text_field("Header", slugify("Header"));
       for (const auto &entry : PRODUCT_COUNTER_DEFINITIONS) {
-        names.emplace_back(entry.name);
+        register_numeric_field(entry.name, slugify(entry.name), "");
       }
-      register_fields_from_list(names);
     } else if (definition.command == std::string("@TG:43")) {
-      std::vector<std::string> names = {"Header"};
+      register_text_field("Header", slugify("Header"));
       for (const auto *name : MAINTENANCE_COUNTER_NAMES) {
-        names.emplace_back(name);
+        register_numeric_field(name, slugify(name), "");
       }
-      register_fields_from_list(names);
     } else if (definition.command == std::string("@TG:C0")) {
-      std::vector<std::string> names = {"Header"};
+      register_text_field("Header", slugify("Header"));
       for (const auto *name : MAINTENANCE_PERCENT_NAMES) {
-        names.emplace_back(std::string(name) + " Raw");
-        names.emplace_back(std::string(name) + " Percent");
+        register_numeric_field(std::string(name) + " Raw", slugify(std::string(name) + " Raw"), "");
+        register_numeric_field(std::string(name) + " Percent",
+                               slugify(std::string(name) + " Percent"), "%");
       }
-      register_fields_from_list(names);
     }
 
-    register_field("Raw Hex", "raw_hex");
-    register_field("Text", "text");
+    register_text_field("Raw Hex", "raw_hex");
+    register_text_field("Text", "text");
   }
 }
 
@@ -1183,7 +1311,8 @@ bool JuraComponent::has_machine_data_subscribers_() const {
   return this->machine_data_sensor_ != nullptr || this->machine_data_statistic_sensor_ != nullptr ||
          this->machine_data_errors_sensor_ != nullptr ||
          this->machine_data_status_sensor_ != nullptr ||
-         this->machine_data_processes_sensor_ != nullptr || this->machine_data_auto_fields_;
+         this->machine_data_processes_sensor_ != nullptr || this->machine_data_auto_fields_ ||
+         !this->machine_data_field_sensors_.empty() || !this->machine_data_numeric_field_sensors_.empty();
 }
 
 void JuraComponent::process_machine_data_query() {
@@ -1191,6 +1320,9 @@ void JuraComponent::process_machine_data_query() {
     return;
   }
   if (!this->is_ready()) {
+    this->machine_data_request_pending_ = false;
+    this->machine_data_request_start_ = 0;
+    this->machine_data_command_index_ = 0;
     return;
   }
   if (this->coffee_maker_ == nullptr || this->coffee_maker_->connection == nullptr) {
@@ -1228,7 +1360,8 @@ void JuraComponent::process_machine_data_query() {
           this->machine_data_request_start_ = 0;
           this->machine_data_command_index_ = 0;
           this->machine_data_responses_.clear();
-          if (this->machine_data_auto_fields_) {
+          if (this->machine_data_auto_fields_ || !this->machine_data_field_sensors_.empty() ||
+              !this->machine_data_numeric_field_sensors_.empty()) {
             this->machine_data_field_values_.clear();
           }
           this->machine_data_query_next_ = now + MACHINE_DATA_QUERY_INTERVAL_MS;
@@ -1264,10 +1397,12 @@ void JuraComponent::process_machine_data_query() {
   }
 
   if (this->machine_data_command_index_ >= MACHINE_DATA_COMMANDS.size()) {
+    bool collect_fields = this->machine_data_auto_fields_ || !this->machine_data_field_sensors_.empty() ||
+                          !this->machine_data_numeric_field_sensors_.empty();
     MachineDataFieldMap field_values;
-    std::string payload = build_machine_data_payload(
-        this->machine_data_responses_, this->machine_data_auto_fields_ ? &field_values : nullptr);
-    if (this->machine_data_auto_fields_) {
+    std::string payload = build_machine_data_payload(this->machine_data_responses_,
+                                                     collect_fields ? &field_values : nullptr);
+    if (collect_fields) {
       this->machine_data_field_values_ = std::move(field_values);
     }
     this->publish_machine_data_(payload);
@@ -1280,10 +1415,13 @@ void JuraComponent::process_machine_data_query() {
 }
 
 void JuraComponent::publish_machine_data_(const std::string &response) {
+  bool has_field_subscribers = this->machine_data_auto_fields_ || !this->machine_data_field_sensors_.empty() ||
+                               !this->machine_data_numeric_field_sensors_.empty();
+
   auto parsed = MachineDataParser::parse(response);
   if (!parsed.has_value()) {
     ESP_LOGW(TAG, "Failed to parse machine data XML response.");
-    if (this->machine_data_auto_fields_) {
+    if (has_field_subscribers) {
       this->machine_data_field_values_.clear();
     }
   }
@@ -1327,7 +1465,7 @@ void JuraComponent::publish_machine_data_(const std::string &response) {
 
   std::string sanitized = sanitize_text_sensor_value(response);
   ESP_LOGD(TAG, "Machine data response: %s", sanitized.c_str());
-  if (this->machine_data_auto_fields_) {
+  if (has_field_subscribers) {
     this->publish_machine_data_fields_(this->machine_data_field_values_);
   }
   if (this->machine_data_sensor_ != nullptr) {

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
 #include <utility>
@@ -12,6 +13,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/log.h"
+#include "esphome/components/sensor/sensor.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/uart/uart.h"
 
@@ -56,6 +58,7 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
     this->machine_data_field_prefix_ = prefix;
   }
   void add_machine_data_field_sensor(const std::string &key, text_sensor::TextSensor *sensor);
+  void add_machine_data_field_sensor(const std::string &key, sensor::Sensor *sensor);
 
  protected:
   enum class HandshakeStage { IDLE, HELLO, SEND_T1, WAIT_T2, SEND_T2, WAIT_T3, SEND_T3, DONE, FAILED };
@@ -69,9 +72,20 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   void process_machine_data_query();
   bool has_machine_data_subscribers_() const;
   void publish_machine_data_(const std::string &response);
-  void publish_machine_data_fields_(const std::map<std::string, std::pair<std::vector<std::string>, std::string>> &fields);
+  struct MachineDataFieldValue {
+    std::vector<std::string> labels;
+    std::string text_value;
+    std::optional<float> numeric_value;
+    std::string unit;
+  };
+  using MachineDataFieldMap = std::map<std::string, MachineDataFieldValue>;
+
+  void publish_machine_data_fields_(const MachineDataFieldMap &fields);
   text_sensor::TextSensor *find_machine_data_field_sensor_(const std::string &key);
-  void register_machine_data_field_sensor_(const std::string &key, const std::vector<std::string> &labels);
+  sensor::Sensor *find_machine_data_numeric_sensor_(const std::string &key);
+  void register_machine_data_text_sensor_(const std::string &key, const std::vector<std::string> &labels);
+  void register_machine_data_numeric_sensor_(const std::string &key, const std::vector<std::string> &labels,
+                                             const std::string &unit);
   std::string make_machine_data_field_name_(const std::vector<std::string> &labels) const;
   std::string make_machine_data_field_unique_id_(const std::string &key) const;
   void initialize_machine_data_field_sensors_();
@@ -95,8 +109,10 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   bool machine_data_auto_fields_{false};
   std::string machine_data_field_prefix_{""};
   std::map<std::string, text_sensor::TextSensor *> machine_data_field_sensors_;
+  std::map<std::string, sensor::Sensor *> machine_data_numeric_field_sensors_;
   std::set<std::string> machine_data_field_user_keys_;
-  std::map<std::string, std::pair<std::vector<std::string>, std::string>> machine_data_field_values_;
+  std::set<std::string> machine_data_numeric_field_user_keys_;
+  MachineDataFieldMap machine_data_field_values_;
   uint32_t machine_data_query_next_{0};
   bool machine_data_request_pending_{false};
   uint32_t machine_data_request_start_{0};

--- a/sample.yaml
+++ b/sample.yaml
@@ -26,11 +26,28 @@ jutta_proto:
     raw: jura_machine_raw
     auto_fields: true
     field_prefix: "JURA Machine"
+    fields:
+      statistic.maintenancepercent.cleaning_percent:
+        sensor: jura_cleaning_percent
+      statistic.productcounter.espresso:
+        sensor: jura_espresso_counter
 
 text_sensor:
   - platform: template
     id: jura_machine_raw
     name: "JURA Machine Data Raw"
+
+sensor:
+  - platform: template
+    id: jura_cleaning_percent
+    name: "JURA Cleaning Percent"
+    unit_of_measurement: "%"
+    accuracy_decimals: 1
+    state_class: measurement
+  - platform: template
+    id: jura_espresso_counter
+    name: "JURA Espresso Counter"
+    state_class: total_increasing
 
 # Convenience switches to remotely power the machine on/off
 switch:


### PR DESCRIPTION
## Summary
- ensure machine data polling resets until the JURA handshake completes before issuing XML commands
- expose machine data field values as numeric sensors with optional units and keep text sensors for helper fields
- document the new sensor capabilities and extend the sample configuration with sensor mappings

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68dbba7cf1808328bc9f46b1ecd21bcc