### PR TITLE
Fix machine data frame handling

### DIFF
--- a/esphome/components/jutta_proto/jutta_connection.cpp
+++ b/esphome/components/jutta_proto/jutta_connection.cpp
@@ -22,6 +22,42 @@ constexpr uint8_t JUTTA_ENCODE_BASE = 0xFF;
 constexpr uint8_t JUTTA_BIT0_MASK = static_cast<uint8_t>(1u << 2);
 constexpr uint8_t JUTTA_BIT1_MASK = static_cast<uint8_t>(1u << 5);
 constexpr std::array<uint8_t, 8> JUTTA_XML_TERMINATOR = {0xDF, 0xFF, 0xDB, 0xDB, 0xFB, 0xFB, 0xDB, 0xDB};
+
+void db_unescape(const std::vector<uint8_t>& in, std::vector<uint8_t>& out) {
+    out.clear();
+    out.reserve(in.size());
+    for (size_t i = 0; i < in.size(); ++i) {
+        uint8_t byte = in[i];
+        if (byte == 0xDB) {
+            if (i + 1 >= in.size()) {
+                ESP_LOGW(TAG, "Incomplete DB escape at end of frame - dropping trailing 0xDB.");
+                break;
+            }
+            ++i;
+            out.push_back(static_cast<uint8_t>(in[i] ^ 0x20));
+        } else {
+            out.push_back(byte);
+        }
+    }
+}
+
+bool try_extract_db_frame(std::vector<uint8_t>& buffer, std::vector<uint8_t>& frame) {
+    if (buffer.size() < JUTTA_XML_TERMINATOR.size()) {
+        return false;
+    }
+
+    auto terminator_it = std::search(buffer.begin(), buffer.end(), JUTTA_XML_TERMINATOR.begin(),
+                                     JUTTA_XML_TERMINATOR.end());
+    if (terminator_it == buffer.end()) {
+        return false;
+    }
+
+    frame.assign(buffer.begin(), terminator_it);
+
+    std::vector<uint8_t> remainder(terminator_it + JUTTA_XML_TERMINATOR.size(), buffer.end());
+    buffer.assign(remainder.begin(), remainder.end());
+    return true;
+}
 std::string format_hex(const uint8_t* data, size_t length) {
     if (length == 0) {
         return "[]";
@@ -136,18 +172,6 @@ inline void wait_for_jutta_gap() {
     if (JUTTA_SERIAL_GAP_MS > 0) {
         esphome::delay(JUTTA_SERIAL_GAP_MS);
     }
-}
-
-inline bool has_xml_terminator_tail(const std::vector<uint8_t>& buffer) {
-    if (buffer.size() < JUTTA_XML_TERMINATOR.size()) {
-        return false;
-    }
-    size_t payload_size = buffer.size() - JUTTA_XML_TERMINATOR.size();
-    if (payload_size % 4 != 0) {
-        return false;
-    }
-    return std::equal(JUTTA_XML_TERMINATOR.begin(), JUTTA_XML_TERMINATOR.end(),
-                      buffer.end() - JUTTA_XML_TERMINATOR.size());
 }
 
 }  // namespace
@@ -675,7 +699,7 @@ std::shared_ptr<std::string> JuttaConnection::write_xml_with_response(
     }
     if (!this->xml_wait_context_.active) {
         flush_serial_input();
-        this->xml_wait_context_.encoded_buffer.clear();
+        this->xml_wait_context_.frame_buffer.clear();
         std::vector<uint8_t> bytes(data.begin(), data.end());
         if (!write_xml_unsafe(bytes)) {
             return nullptr;
@@ -885,31 +909,25 @@ std::shared_ptr<std::string> JuttaConnection::wait_for_xml_response_unsafe(
         this->xml_wait_context_.active = true;
         this->xml_wait_context_.timeout = timeout;
         this->xml_wait_context_.start_time = esphome::millis();
-        this->xml_wait_context_.encoded_buffer.clear();
+        this->xml_wait_context_.frame_buffer.clear();
         ESP_LOGD(TAG, "Waiting for XML response (timeout=%lld ms).", static_cast<long long>(timeout.count()));
     }
 
     auto try_complete = [&]() -> std::shared_ptr<std::string> {
-        if (!has_xml_terminator_tail(this->xml_wait_context_.encoded_buffer)) {
+        std::vector<uint8_t> frame;
+        if (!try_extract_db_frame(this->xml_wait_context_.frame_buffer, frame)) {
             return nullptr;
         }
 
-        std::vector<uint8_t> payload(this->xml_wait_context_.encoded_buffer.begin(),
-                                     this->xml_wait_context_.encoded_buffer.end() - JUTTA_XML_TERMINATOR.size());
-        this->xml_wait_context_.encoded_buffer.clear();
+        std::vector<uint8_t> decoded;
+        db_unescape(frame, decoded);
+
         this->xml_wait_context_.active = false;
 
-        std::vector<uint8_t> decoded;
-        decoded.reserve(payload.size() / 4);
-        for (size_t i = 0; i < payload.size(); i += 4) {
-            std::array<uint8_t, 4> frame{payload[i], payload[i + 1], payload[i + 2], payload[i + 3]};
-            decoded.push_back(decode_xml_byte(frame));
-        }
-
-        std::string response = vec_to_string(decoded);
+        std::string response(decoded.begin(), decoded.end());
         auto shared_response = std::make_shared<std::string>(response);
-        ESP_LOGD(TAG, "Received XML response (%zu decoded byte%s): '%s' (hex %s)", decoded.size(),
-                 decoded.size() == 1 ? "" : "s", format_printable(response).c_str(), format_hex(decoded).c_str());
+        ESP_LOGD(TAG, "Received XML response (%zu byte%s): hex %s", decoded.size(),
+                 decoded.size() == 1 ? "" : "s", format_hex(decoded).c_str());
         return shared_response;
     };
 
@@ -917,28 +935,19 @@ std::shared_ptr<std::string> JuttaConnection::wait_for_xml_response_unsafe(
         return ready;
     }
 
-    wait_for_jutta_gap();
-    std::array<uint8_t, 4> chunk{};
-    size_t read = serial.read_serial(chunk);
-    if (read > chunk.size()) {
-        ESP_LOGW(TAG, "Invalid amount of UART data found while reading XML response (%zu byte).", read);
-        read = chunk.size();
-    }
-
-    if (read > 0) {
-        this->xml_wait_context_.encoded_buffer.insert(this->xml_wait_context_.encoded_buffer.end(), chunk.begin(),
-                                                     chunk.begin() + read);
-        std::vector<uint8_t> chunk_vec(chunk.begin(), chunk.begin() + read);
-        ESP_LOGVV(TAG, "Read %zu XML encoded byte%s from UART: %s (buffer now %zu bytes)", read,
-                  read == 1 ? "" : "s", format_hex(chunk_vec).c_str(),
-                  this->xml_wait_context_.encoded_buffer.size());
+    std::vector<uint8_t> decoded_chunk;
+    if (read_decoded_unsafe(decoded_chunk) && !decoded_chunk.empty()) {
+        this->xml_wait_context_.frame_buffer.insert(this->xml_wait_context_.frame_buffer.end(), decoded_chunk.begin(),
+                                                   decoded_chunk.end());
+        ESP_LOGVV(TAG, "Buffered %zu DB byte%s while waiting for response: %s (buffer now %zu bytes)",
+                  decoded_chunk.size(), decoded_chunk.size() == 1 ? "" : "s",
+                  format_hex(decoded_chunk).c_str(), this->xml_wait_context_.frame_buffer.size());
 
         if (auto ready = try_complete(); ready != nullptr) {
             return ready;
         }
     } else {
-        ESP_LOGVV(TAG, "No XML encoded data found (buffer size=%zu).",
-                  this->xml_wait_context_.encoded_buffer.size());
+        wait_for_jutta_gap();
     }
 
     if (timeout.count() > 0) {
@@ -946,7 +955,7 @@ std::shared_ptr<std::string> JuttaConnection::wait_for_xml_response_unsafe(
         uint32_t elapsed = now - this->xml_wait_context_.start_time;
         if (elapsed >= static_cast<uint32_t>(timeout.count())) {
             this->xml_wait_context_.active = false;
-            this->xml_wait_context_.encoded_buffer.clear();
+            this->xml_wait_context_.frame_buffer.clear();
             ESP_LOGW(TAG, "Timeout while waiting for XML response after %u ms.", elapsed);
         }
     }

--- a/esphome/components/jutta_proto/jutta_connection.hpp
+++ b/esphome/components/jutta_proto/jutta_connection.hpp
@@ -300,7 +300,7 @@ class JuttaConnection {
         bool active{false};
         std::chrono::milliseconds timeout{std::chrono::milliseconds{5000}};
         uint32_t start_time{0};
-        std::vector<uint8_t> encoded_buffer{};
+        std::vector<uint8_t> frame_buffer{};
     };
 
     XmlWaitContext xml_wait_context_{};

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -187,6 +187,19 @@ constexpr std::array<const char *, 6> MAINTENANCE_COUNTER_NAMES = {{"Cleaning", 
 
 constexpr std::array<const char *, 3> MAINTENANCE_PERCENT_NAMES = {{"Cleaning", "FilterChange", "Decalc"}};
 
+std::optional<size_t> expected_machine_data_payload_size(const std::string &command) {
+  if (command == std::string("@TR:32")) {
+    return 21;
+  }
+  if (command == std::string("@TG:43")) {
+    return 13;
+  }
+  if (command == std::string("@TG:C0")) {
+    return 13;
+  }
+  return std::nullopt;
+}
+
 float decode_percent_fixed_point(uint32_t raw_value) {
   // Percentages in the maintenance payload are encoded in the upper 16 bits
   // using a Q8.8 fixed-point representation. The remaining 16 bits contain an
@@ -328,28 +341,19 @@ MachineDataFieldList parse_maintenance_counter_fields(const std::string &payload
 }
 
 std::optional<std::string> format_maintenance_percent_payload(const std::string &payload) {
-  if (payload.empty()) {
+  if (payload.size() != 13) {
     return std::nullopt;
   }
 
   const auto *data = reinterpret_cast<const uint8_t *>(payload.data());
-
-  size_t header_size = 1;
-  if (payload.size() >= 2 && (payload.size() % 4) == 2) {
-    header_size = 2;
-  }
-  if (payload.size() < header_size) {
-    return std::nullopt;
-  }
-
-  uint16_t header = header_size == 2 ? read_u16_be(data) : static_cast<uint16_t>(data[0]);
-  size_t value_offset = header_size;
+  uint8_t header = data[0];
+  size_t value_offset = 1;
   size_t values_bytes = payload.size() - value_offset;
   size_t value_count = values_bytes / 4;
 
   std::ostringstream stream;
-  stream << "header=0x" << std::uppercase << std::hex << std::setfill('0')
-         << std::setw(static_cast<int>(header_size * 2)) << header << std::dec;
+  stream << "header=0x" << std::uppercase << std::hex << std::setfill('0') << std::setw(2)
+         << static_cast<int>(header) << std::dec;
 
   for (size_t i = 0; i < value_count; ++i) {
     uint32_t raw_value = read_u32_be(&data[value_offset + i * 4]);
@@ -380,25 +384,16 @@ std::optional<std::string> format_maintenance_percent_payload(const std::string 
 
 MachineDataFieldList parse_maintenance_percent_fields(const std::string &payload) {
   MachineDataFieldList fields;
-  if (payload.empty()) {
+  if (payload.size() != 13) {
     return fields;
   }
 
   const auto *data = reinterpret_cast<const uint8_t *>(payload.data());
-  size_t header_size = 1;
-  if (payload.size() >= 2 && (payload.size() % 4) == 2) {
-    header_size = 2;
-  }
-  if (payload.size() < header_size) {
-    return fields;
-  }
-
-  uint16_t header = header_size == 2 ? read_u16_be(data) : static_cast<uint16_t>(data[0]);
-  size_t value_offset = header_size;
+  size_t value_offset = 1;
 
   std::ostringstream header_stream;
-  header_stream << "0x" << std::uppercase << std::hex << std::setfill('0')
-                << std::setw(static_cast<int>(header_size * 2)) << header;
+  header_stream << "0x" << std::uppercase << std::hex << std::setfill('0') << std::setw(2)
+                << static_cast<int>(data[0]);
   fields.push_back({"Header", header_stream.str(), std::nullopt, ""});
 
   size_t values_bytes = payload.size() - value_offset;
@@ -1420,6 +1415,22 @@ void JuraComponent::process_machine_data_query() {
       auto response = this->coffee_maker_->connection->write_xml_with_response(
           definition.command, std::chrono::milliseconds{MACHINE_DATA_REQUEST_TIMEOUT_MS});
       if (response != nullptr) {
+        auto expected = expected_machine_data_payload_size(definition.command);
+        if (expected.has_value() && response->size() != *expected) {
+          ESP_LOGW(TAG,
+                   "Discarding machine data response for command '%s' with unexpected length %zu (expected %zu).",
+                   definition.command, response->size(), *expected);
+          this->machine_data_request_pending_ = false;
+          this->machine_data_request_start_ = 0;
+          this->machine_data_command_index_ = 0;
+          this->machine_data_responses_.clear();
+          if (this->machine_data_auto_fields_ || !this->machine_data_field_sensors_.empty() ||
+              !this->machine_data_numeric_field_sensors_.empty()) {
+            this->machine_data_field_values_.clear();
+          }
+          this->machine_data_query_next_ = now + MACHINE_DATA_QUERY_INTERVAL_MS;
+          return;
+        }
         if (this->machine_data_responses_.size() != MACHINE_DATA_COMMANDS.size()) {
           this->machine_data_responses_.assign(MACHINE_DATA_COMMANDS.size(), std::string{});
         }
@@ -1465,6 +1476,21 @@ void JuraComponent::process_machine_data_query() {
         definition.command, std::chrono::milliseconds{MACHINE_DATA_REQUEST_TIMEOUT_MS});
     if (response == nullptr) {
       this->machine_data_request_pending_ = true;
+      return;
+    }
+    auto expected = expected_machine_data_payload_size(definition.command);
+    if (expected.has_value() && response->size() != *expected) {
+      ESP_LOGW(TAG, "Discarding machine data response for command '%s' with unexpected length %zu (expected %zu).",
+               definition.command, response->size(), *expected);
+      this->machine_data_responses_.clear();
+      this->machine_data_request_pending_ = false;
+      this->machine_data_request_start_ = 0;
+      this->machine_data_command_index_ = 0;
+      if (this->machine_data_auto_fields_ || !this->machine_data_field_sensors_.empty() ||
+          !this->machine_data_numeric_field_sensors_.empty()) {
+        this->machine_data_field_values_.clear();
+      }
+      this->machine_data_query_next_ = esphome::millis() + MACHINE_DATA_QUERY_INTERVAL_MS;
       return;
     }
     this->machine_data_responses_[this->machine_data_command_index_] = *response;


### PR DESCRIPTION
## Summary
- add DB frame extraction and unescaping to the XML wait path
- enforce expected machine data payload sizes and validate maintenance percent parsing
- reject malformed machine data responses to avoid publishing corrupt values

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc1267417c832889a397b96f862f64