### PR TITLE
Ensure DB-encoded XML requests and validate machine data payloads

### DIFF
--- a/esphome/components/jutta_proto/jutta_connection.cpp
+++ b/esphome/components/jutta_proto/jutta_connection.cpp
@@ -150,17 +150,24 @@ bool needs_db_escape(uint8_t byte) {
     }
 }
 
-void db_escape(const std::vector<uint8_t>& input, std::vector<uint8_t>& output) {
-    output.clear();
-    output.reserve(input.size() * 2);
-    for (uint8_t byte : input) {
+std::vector<uint8_t> db_encode(const uint8_t* data, size_t length) {
+    std::vector<uint8_t> encoded;
+    encoded.reserve(length * 2 + JUTTA_XML_TERMINATOR.size());
+    for (size_t i = 0; i < length; ++i) {
+        uint8_t byte = data[i];
         if (needs_db_escape(byte)) {
-            output.push_back(0xDB);
-            output.push_back(static_cast<uint8_t>(byte ^ 0x20));
+            encoded.push_back(0xDB);
+            encoded.push_back(static_cast<uint8_t>(byte ^ 0x20));
         } else {
-            output.push_back(byte);
+            encoded.push_back(byte);
         }
     }
+    encoded.insert(encoded.end(), JUTTA_XML_TERMINATOR.begin(), JUTTA_XML_TERMINATOR.end());
+    return encoded;
+}
+
+std::vector<uint8_t> db_encode(const std::vector<uint8_t>& input) {
+    return db_encode(input.data(), input.size());
 }
 
 bool db_unescape(const std::vector<uint8_t>& input, std::vector<uint8_t>& output) {
@@ -317,34 +324,18 @@ bool JuttaConnection::write_xml_unsafe(const std::vector<uint8_t>& data) const {
         ESP_LOGVV(TAG, "Requested to write an empty XML payload.");
     }
 
-    std::vector<uint8_t> escaped;
-    db_escape(data, escaped);
+    std::vector<uint8_t> frame = db_encode(data);
+    ESP_LOGD(TAG, "Transmitting XML frame (%zu byte%s encoded incl. trailer): %s", frame.size(),
+             frame.size() == 1 ? "" : "s", format_hex(frame).c_str());
 
-    if (!escaped.empty()) {
-        ESP_LOGVV(TAG, "Escaped XML payload (%zu byte%s): %s", escaped.size(), escaped.size() == 1 ? "" : "s",
-                  format_hex(escaped).c_str());
-    }
-
-    bool result = true;
-    for (uint8_t byte : escaped) {
-        if (!serial.write_serial_byte(byte)) {
-            ESP_LOGE(TAG, "Failed to write escaped XML byte 0x%02X to UART.", byte);
-            result = false;
-        }
+    if (!serial.write_serial(frame)) {
+        ESP_LOGE(TAG, "Failed to write XML frame to UART.");
+        return false;
     }
 
-    if (!JUTTA_XML_TERMINATOR.empty()) {
-        ESP_LOGVV(TAG, "Appending XML terminator: %s", format_hex(JUTTA_XML_TERMINATOR).c_str());
-    }
-    for (uint8_t terminator_byte : JUTTA_XML_TERMINATOR) {
-        if (!serial.write_serial_byte(terminator_byte)) {
-            ESP_LOGE(TAG, "Failed to write XML terminator byte 0x%02X to UART.", terminator_byte);
-            result = false;
-        }
-    }
     serial.flush();
     wait_for_jutta_gap();
-    return result;
+    return true;
 }
 
 bool JuttaConnection::write_plain_unsafe(const std::string& data) const {
@@ -690,17 +681,36 @@ std::shared_ptr<std::string> JuttaConnection::write_xml_with_response(
     if (!data.empty() && data[0] == '&') {
         return write_plain_with_response(data, timeout);
     }
-    if (!this->xml_wait_context_.active) {
-        flush_serial_input();
-        this->xml_wait_context_.raw_buffer.clear();
-        std::vector<uint8_t> bytes(data.begin(), data.end());
-        if (!write_xml_unsafe(bytes)) {
+    std::vector<uint8_t> bytes(data.begin(), data.end());
+
+    while (true) {
+        if (!this->xml_wait_context_.active) {
+            flush_serial_input();
+            this->xml_wait_context_.raw_buffer.clear();
+            this->xml_wait_context_.retry_required = false;
+            if (!write_xml_unsafe(bytes)) {
+                return nullptr;
+            }
+        }
+
+        ESP_LOGD(TAG, "Waiting for XML response after writing payload (timeout=%lld ms).",
+                 static_cast<long long>(timeout.count()));
+
+        auto response = wait_for_xml_response_unsafe(timeout);
+        if (response != nullptr) {
+            return response;
+        }
+
+        if (!this->xml_wait_context_.retry_required) {
             return nullptr;
         }
+
+        ESP_LOGW(TAG, "Retrying XML request after receiving empty decoded frame.");
+        this->xml_wait_context_.retry_required = false;
+        this->xml_wait_context_.active = false;
+        this->xml_wait_context_.raw_buffer.clear();
+        flush_serial_input();
     }
-    ESP_LOGD(TAG, "Waiting for XML response after writing payload (timeout=%lld ms).",
-             static_cast<long long>(timeout.count()));
-    return wait_for_xml_response_unsafe(timeout);
 }
 
 std::shared_ptr<std::string> JuttaConnection::wait_for_str_unsafe(const std::chrono::milliseconds& timeout) {
@@ -874,6 +884,7 @@ std::shared_ptr<std::string> JuttaConnection::wait_for_xml_response_unsafe(
         this->xml_wait_context_.timeout = timeout;
         this->xml_wait_context_.start_time = esphome::millis();
         this->xml_wait_context_.raw_buffer.clear();
+        this->xml_wait_context_.retry_required = false;
         ESP_LOGD(TAG, "Waiting for XML response (timeout=%lld ms).", static_cast<long long>(timeout.count()));
     }
 
@@ -891,7 +902,16 @@ std::shared_ptr<std::string> JuttaConnection::wait_for_xml_response_unsafe(
             return nullptr;
         }
 
+        if (decoded.empty()) {
+            ESP_LOGW(TAG, "Discarding XML frame with zero decoded bytes.");
+            this->xml_wait_context_.raw_buffer.clear();
+            this->xml_wait_context_.active = false;
+            this->xml_wait_context_.retry_required = true;
+            return nullptr;
+        }
+
         this->xml_wait_context_.active = false;
+        this->xml_wait_context_.retry_required = false;
 
         std::string response = vec_to_string(decoded);
         auto shared_response = std::make_shared<std::string>(response);

--- a/esphome/components/jutta_proto/jutta_connection.hpp
+++ b/esphome/components/jutta_proto/jutta_connection.hpp
@@ -299,6 +299,7 @@ class JuttaConnection {
         std::chrono::milliseconds timeout{std::chrono::milliseconds{5000}};
         uint32_t start_time{0};
         std::vector<uint8_t> raw_buffer{};
+        bool retry_required{false};
     };
 
     XmlWaitContext xml_wait_context_{};

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -426,6 +426,27 @@ MachineDataFieldList parse_machine_data_fields(const std::string &command, const
   return {};
 }
 
+std::optional<size_t> expected_machine_data_payload_size(const std::string &command) {
+  if (command == std::string("@TR:32")) {
+    return 21;  // 1 header + 10 * u16 (big-endian)
+  }
+  if (command == std::string("@TG:43")) {
+    return 13;  // 1 header + 6 * u16 (big-endian)
+  }
+  if (command == std::string("@TG:C0")) {
+    return 13;  // 1 header + 3 * u32 (big-endian)
+  }
+  return std::nullopt;
+}
+
+bool is_machine_data_payload_length_valid(const std::string &command, const std::string &payload) {
+  auto expected = expected_machine_data_payload_size(command);
+  if (!expected.has_value()) {
+    return true;
+  }
+  return payload.size() == expected.value();
+}
+
 std::string to_upper_hex(const std::string &value) {
   if (value.empty()) {
     return "";
@@ -1371,7 +1392,18 @@ void JuraComponent::process_machine_data_query() {
         if (this->machine_data_responses_.size() != MACHINE_DATA_COMMANDS.size()) {
           this->machine_data_responses_.assign(MACHINE_DATA_COMMANDS.size(), std::string{});
         }
-        this->machine_data_responses_[this->machine_data_command_index_] = *response;
+        if (!is_machine_data_payload_length_valid(definition.command, *response)) {
+          auto expected = expected_machine_data_payload_size(definition.command);
+          std::string expected_text = expected.has_value() ? std::to_string(expected.value()) : std::string("unknown");
+          ESP_LOGW(TAG,
+                   "Discarding machine data response for '%s' due to unexpected length (%zu byte%s decoded, expected %s).",
+                   definition.command.c_str(), response->size(), response->size() == 1 ? "" : "s",
+                   expected_text.c_str());
+          this->machine_data_responses_[this->machine_data_command_index_].clear();
+          this->machine_data_response_invalid_ = true;
+        } else {
+          this->machine_data_responses_[this->machine_data_command_index_] = *response;
+        }
         ++this->machine_data_command_index_;
         this->machine_data_request_pending_ = false;
         this->machine_data_request_start_ = 0;
@@ -1387,6 +1419,7 @@ void JuraComponent::process_machine_data_query() {
               !this->machine_data_numeric_field_sensors_.empty()) {
             this->machine_data_field_values_.clear();
           }
+          this->machine_data_response_invalid_ = false;
           this->machine_data_query_next_ = now + MACHINE_DATA_QUERY_INTERVAL_MS;
         }
         return;
@@ -1402,6 +1435,7 @@ void JuraComponent::process_machine_data_query() {
     if (this->machine_data_responses_.size() != MACHINE_DATA_COMMANDS.size()) {
       this->machine_data_responses_.assign(MACHINE_DATA_COMMANDS.size(), std::string{});
     }
+    this->machine_data_response_invalid_ = false;
   }
 
   while (this->machine_data_command_index_ < MACHINE_DATA_COMMANDS.size()) {
@@ -1420,6 +1454,21 @@ void JuraComponent::process_machine_data_query() {
   }
 
   if (this->machine_data_command_index_ >= MACHINE_DATA_COMMANDS.size()) {
+    if (this->machine_data_response_invalid_) {
+      ESP_LOGW(TAG, "Skipping machine data publish because a response had an unexpected length.");
+      if (this->machine_data_auto_fields_ || !this->machine_data_field_sensors_.empty() ||
+          !this->machine_data_numeric_field_sensors_.empty()) {
+        this->machine_data_field_values_.clear();
+      }
+      this->machine_data_responses_.clear();
+      this->machine_data_request_pending_ = false;
+      this->machine_data_request_start_ = 0;
+      this->machine_data_command_index_ = 0;
+      this->machine_data_response_invalid_ = false;
+      this->machine_data_query_next_ = esphome::millis() + MACHINE_DATA_QUERY_INTERVAL_MS;
+      return;
+    }
+
     bool collect_fields = this->machine_data_auto_fields_ || !this->machine_data_field_sensors_.empty() ||
                           !this->machine_data_numeric_field_sensors_.empty();
     MachineDataFieldMap field_values;
@@ -1430,6 +1479,7 @@ void JuraComponent::process_machine_data_query() {
     }
     this->publish_machine_data_(payload);
     this->machine_data_responses_.clear();
+    this->machine_data_response_invalid_ = false;
     this->machine_data_request_pending_ = false;
     this->machine_data_request_start_ = 0;
     this->machine_data_command_index_ = 0;

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -121,6 +121,7 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   uint32_t machine_data_request_start_{0};
   size_t machine_data_command_index_{0};
   std::vector<std::string> machine_data_responses_;
+  bool machine_data_response_invalid_{false};
 };
 
 class StartBrewAction : public esphome::Action<> {

--- a/esphome/components/jutta_proto/serial_connection.cpp
+++ b/esphome/components/jutta_proto/serial_connection.cpp
@@ -2,6 +2,7 @@
 
 #include "esphome/core/log.h"
 #include <array>
+#include <vector>
 
 //---------------------------------------------------------------------------
 namespace serial {
@@ -43,12 +44,27 @@ size_t SerialConnection::read_serial(std::array<uint8_t, 4>& buffer) const {
 }
 
 bool SerialConnection::write_serial(const std::array<uint8_t, 4>& data) const {
+    return this->write_serial(data.data(), data.size());
+}
+
+bool SerialConnection::write_serial(const std::vector<uint8_t>& data) const {
+    if (data.empty()) {
+        return true;
+    }
+    return this->write_serial(data.data(), data.size());
+}
+
+bool SerialConnection::write_serial(const uint8_t* data, size_t length) const {
     if (this->parent_ == nullptr) {
         ESP_LOGE(TAG, "UART component not configured for serial connection.");
         return false;
     }
+    if (data == nullptr || length == 0) {
+        return true;
+    }
+
     auto* self = const_cast<SerialConnection*>(this);
-    self->write_array(data.data(), data.size());
+    self->write_array(data, length);
     return true;
 }
 

--- a/esphome/components/jutta_proto/serial_connection.hpp
+++ b/esphome/components/jutta_proto/serial_connection.hpp
@@ -29,6 +29,8 @@ class SerialConnection : public esphome::uart::UARTDevice {
      * Returns true on success.
      **/
     [[nodiscard]] bool write_serial(const std::array<uint8_t, 4>& data) const;
+    [[nodiscard]] bool write_serial(const std::vector<uint8_t>& data) const;
+    [[nodiscard]] bool write_serial(const uint8_t* data, size_t length) const;
     /**
      * Writes a single byte to the serial connection.
      * Returns true on success.


### PR DESCRIPTION
## Summary
- send XML requests after DB-encoding the payload once, append the trailer, and log the encoded frame before transmission
- add retry handling for empty decoded XML responses and extend the serial connection to write arbitrary buffers in a single call
- validate machine data response lengths, discard invalid payloads, and skip publishing machine data when a response does not match expectations

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dc1b85495483288e40643c47df7ef0