### PR TITLE
Fix DB framing and validate machine data responses

### DIFF
--- a/esphome/components/jutta_proto/jutta_connection.cpp
+++ b/esphome/components/jutta_proto/jutta_connection.cpp
@@ -320,31 +320,23 @@ bool JuttaConnection::write_xml_unsafe(const std::vector<uint8_t>& data) const {
     std::vector<uint8_t> escaped;
     db_escape(data, escaped);
 
-    if (!escaped.empty()) {
-        ESP_LOGVV(TAG, "Escaped XML payload (%zu byte%s): %s", escaped.size(), escaped.size() == 1 ? "" : "s",
-                  format_hex(escaped).c_str());
+    std::vector<uint8_t> frame;
+    frame.reserve(escaped.size() + JUTTA_XML_TERMINATOR.size());
+    frame.insert(frame.end(), escaped.begin(), escaped.end());
+    frame.insert(frame.end(), JUTTA_XML_TERMINATOR.begin(), JUTTA_XML_TERMINATOR.end());
+
+    ESP_LOGD(TAG, "Transmitting XML frame (%zu byte%s encoded): %s", frame.size(), frame.size() == 1 ? "" : "s",
+             format_hex(frame).c_str());
+
+    bool result = serial.write_serial_buffer(frame);
+    if (!result) {
+        ESP_LOGE(TAG, "Failed to write XML frame to UART.");
+        return false;
     }
 
-    bool result = true;
-    for (uint8_t byte : escaped) {
-        if (!serial.write_serial_byte(byte)) {
-            ESP_LOGE(TAG, "Failed to write escaped XML byte 0x%02X to UART.", byte);
-            result = false;
-        }
-    }
-
-    if (!JUTTA_XML_TERMINATOR.empty()) {
-        ESP_LOGVV(TAG, "Appending XML terminator: %s", format_hex(JUTTA_XML_TERMINATOR).c_str());
-    }
-    for (uint8_t terminator_byte : JUTTA_XML_TERMINATOR) {
-        if (!serial.write_serial_byte(terminator_byte)) {
-            ESP_LOGE(TAG, "Failed to write XML terminator byte 0x%02X to UART.", terminator_byte);
-            result = false;
-        }
-    }
     serial.flush();
     wait_for_jutta_gap();
-    return result;
+    return true;
 }
 
 bool JuttaConnection::write_plain_unsafe(const std::string& data) const {

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -45,6 +45,16 @@ constexpr std::array<MachineDataCommandDefinition, 3> MACHINE_DATA_COMMANDS = {{
                                                                               {"@TG:43", "STATISTIC", "MAINTENANCECOUNTER"},
                                                                               {"@TG:C0", "STATISTIC", "MAINTENANCEPERCENT"}}};
 
+std::optional<size_t> expected_machine_data_payload_size(const std::string &command) {
+  if (command == "@TR:32") {
+    return 21;
+  }
+  if (command == "@TG:43" || command == "@TG:C0") {
+    return 13;
+  }
+  return std::nullopt;
+}
+
 std::string slugify(const std::string &value) {
   std::string result;
   result.reserve(value.size());
@@ -1358,7 +1368,20 @@ void JuraComponent::process_machine_data_query() {
     return;
   }
 
+  auto fail_current_query = [&]() {
+    this->machine_data_request_pending_ = false;
+    this->machine_data_request_start_ = 0;
+    this->machine_data_command_index_ = 0;
+    this->machine_data_responses_.clear();
+    this->machine_data_responses_valid_ = false;
+    this->machine_data_query_next_ = esphome::millis() + MACHINE_DATA_QUERY_INTERVAL_MS;
+  };
+
   uint32_t now = esphome::millis();
+
+  if (!this->machine_data_request_pending_ && this->machine_data_command_index_ == 0) {
+    this->machine_data_responses_valid_ = true;
+  }
 
   if (this->machine_data_request_pending_) {
     if (this->machine_data_command_index_ >= MACHINE_DATA_COMMANDS.size()) {
@@ -1371,23 +1394,27 @@ void JuraComponent::process_machine_data_query() {
         if (this->machine_data_responses_.size() != MACHINE_DATA_COMMANDS.size()) {
           this->machine_data_responses_.assign(MACHINE_DATA_COMMANDS.size(), std::string{});
         }
+        auto expected_length = expected_machine_data_payload_size(definition.command);
+        if (expected_length.has_value() && response->size() != expected_length.value()) {
+          ESP_LOGW(TAG,
+                   "Discarding machine data response for command '%s' due to unexpected length (expected %zu byte%s, got %zu).",
+                   definition.command, expected_length.value(), expected_length.value() == 1 ? "" : "s",
+                   response->size());
+          fail_current_query();
+          return;
+        }
         this->machine_data_responses_[this->machine_data_command_index_] = *response;
         ++this->machine_data_command_index_;
         this->machine_data_request_pending_ = false;
         this->machine_data_request_start_ = 0;
       } else {
         if (time_reached(now, this->machine_data_request_start_ + MACHINE_DATA_REQUEST_TIMEOUT_MS)) {
-          ESP_LOGW(TAG, "Timeout while waiting for machine data response to command '%s'.",
-                   definition.command);
-          this->machine_data_request_pending_ = false;
-          this->machine_data_request_start_ = 0;
-          this->machine_data_command_index_ = 0;
-          this->machine_data_responses_.clear();
+          ESP_LOGW(TAG, "Timeout while waiting for machine data response to command '%s'.", definition.command);
+          fail_current_query();
           if (this->machine_data_auto_fields_ || !this->machine_data_field_sensors_.empty() ||
               !this->machine_data_numeric_field_sensors_.empty()) {
             this->machine_data_field_values_.clear();
           }
-          this->machine_data_query_next_ = now + MACHINE_DATA_QUERY_INTERVAL_MS;
         }
         return;
       }
@@ -1415,11 +1442,33 @@ void JuraComponent::process_machine_data_query() {
       this->machine_data_request_pending_ = true;
       return;
     }
+    auto expected_length = expected_machine_data_payload_size(definition.command);
+    if (expected_length.has_value() && response->size() != expected_length.value()) {
+      ESP_LOGW(TAG,
+               "Discarding machine data response for command '%s' due to unexpected length (expected %zu byte%s, got %zu).",
+               definition.command, expected_length.value(), expected_length.value() == 1 ? "" : "s",
+               response->size());
+      fail_current_query();
+      if (this->machine_data_auto_fields_ || !this->machine_data_field_sensors_.empty() ||
+          !this->machine_data_numeric_field_sensors_.empty()) {
+        this->machine_data_field_values_.clear();
+      }
+      return;
+    }
     this->machine_data_responses_[this->machine_data_command_index_] = *response;
     ++this->machine_data_command_index_;
   }
 
   if (this->machine_data_command_index_ >= MACHINE_DATA_COMMANDS.size()) {
+    if (!this->machine_data_responses_valid_) {
+      ESP_LOGW(TAG, "Skipping machine data publish due to invalid responses.");
+      this->machine_data_responses_.clear();
+      this->machine_data_request_pending_ = false;
+      this->machine_data_request_start_ = 0;
+      this->machine_data_command_index_ = 0;
+      this->machine_data_query_next_ = esphome::millis() + MACHINE_DATA_QUERY_INTERVAL_MS;
+      return;
+    }
     bool collect_fields = this->machine_data_auto_fields_ || !this->machine_data_field_sensors_.empty() ||
                           !this->machine_data_numeric_field_sensors_.empty();
     MachineDataFieldMap field_values;

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -121,6 +121,7 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   uint32_t machine_data_request_start_{0};
   size_t machine_data_command_index_{0};
   std::vector<std::string> machine_data_responses_;
+  bool machine_data_responses_valid_{true};
 };
 
 class StartBrewAction : public esphome::Action<> {

--- a/esphome/components/jutta_proto/serial_connection.cpp
+++ b/esphome/components/jutta_proto/serial_connection.cpp
@@ -52,6 +52,19 @@ bool SerialConnection::write_serial(const std::array<uint8_t, 4>& data) const {
     return true;
 }
 
+bool SerialConnection::write_serial_buffer(const uint8_t* data, size_t length) const {
+    if (this->parent_ == nullptr) {
+        ESP_LOGE(TAG, "UART component not configured for serial connection.");
+        return false;
+    }
+    if (data == nullptr || length == 0) {
+        return true;
+    }
+    auto* self = const_cast<SerialConnection*>(this);
+    self->write_array(data, length);
+    return true;
+}
+
 bool SerialConnection::write_serial_byte(uint8_t byte) const {
     if (this->parent_ == nullptr) {
         ESP_LOGE(TAG, "UART component not configured for serial connection.");

--- a/esphome/components/jutta_proto/serial_connection.hpp
+++ b/esphome/components/jutta_proto/serial_connection.hpp
@@ -30,6 +30,14 @@ class SerialConnection : public esphome::uart::UARTDevice {
      **/
     [[nodiscard]] bool write_serial(const std::array<uint8_t, 4>& data) const;
     /**
+     * Writes the given raw buffer to the serial connection.
+     * Returns true on success.
+     **/
+    [[nodiscard]] bool write_serial_buffer(const uint8_t* data, size_t length) const;
+    [[nodiscard]] bool write_serial_buffer(const std::vector<uint8_t>& data) const {
+        return write_serial_buffer(data.data(), data.size());
+    }
+    /**
      * Writes a single byte to the serial connection.
      * Returns true on success.
      **/


### PR DESCRIPTION
## Summary
- send XML requests as fully framed DB-escaped writes and log the encoded payload
- add serial bulk write support to simplify UART framing
- validate machine data payload lengths and skip publishing invalid responses

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc1b85495483288e40643c47df7ef0