### PR TITLE
Fix XML DB codec implementation

### DIFF
--- a/esphome/components/jutta_proto/jutta_connection.cpp
+++ b/esphome/components/jutta_proto/jutta_connection.cpp
@@ -138,48 +138,58 @@ inline void wait_for_jutta_gap() {
     }
 }
 
-bool needs_db_escape(uint8_t byte) {
-    switch (byte) {
-        case 0xDB:
-        case 0xDF:
-        case 0xFB:
-        case 0xFF:
-            return true;
-        default:
-            return false;
-    }
-}
-
 void db_escape(const std::vector<uint8_t>& input, std::vector<uint8_t>& output) {
     output.clear();
-    output.reserve(input.size() * 2);
+    output.reserve(input.size() * 4);
+
     for (uint8_t byte : input) {
-        if (needs_db_escape(byte)) {
-            output.push_back(0xDB);
-            output.push_back(static_cast<uint8_t>(byte ^ 0x20));
-        } else {
-            output.push_back(byte);
+        for (int shift = 6; shift >= 0; shift -= 2) {
+            uint8_t symbol = 0xDB;
+            uint8_t two_bits = static_cast<uint8_t>((byte >> shift) & 0x03);
+
+            if (two_bits & 0x01) {
+                symbol |= 0x04;
+            }
+            if (two_bits & 0x02) {
+                symbol |= 0x20;
+            }
+
+            output.push_back(symbol);
         }
     }
 }
 
 bool db_unescape(const std::vector<uint8_t>& input, std::vector<uint8_t>& output) {
     output.clear();
-    output.reserve(input.size());
-    bool escape = false;
+    output.reserve(input.size() / 4 + (input.empty() ? 0 : 1));
+
+    uint8_t current = 0;
+    int pair_count = 0;
+
     for (uint8_t byte : input) {
-        if (escape) {
-            output.push_back(static_cast<uint8_t>(byte ^ 0x20));
-            escape = false;
+        if ((byte & 0xDB) != 0xDB) {
             continue;
         }
-        if (byte == 0xDB) {
-            escape = true;
-            continue;
+
+        uint8_t two_bits = 0;
+        if (byte & 0x04) {
+            two_bits |= 0x01;
         }
-        output.push_back(byte);
+        if (byte & 0x20) {
+            two_bits |= 0x02;
+        }
+
+        current = static_cast<uint8_t>((current << 2) | two_bits);
+        pair_count++;
+
+        if (pair_count == 4) {
+            output.push_back(current);
+            current = 0;
+            pair_count = 0;
+        }
     }
-    return !escape;
+
+    return pair_count == 0;
 }
 
 bool try_extract_db_frame(std::vector<uint8_t>& buffer, std::vector<uint8_t>& frame) {


### PR DESCRIPTION
## Summary
- replace the XML DB encoder/decoder with the 2-bit symbol codec that matches the firmware dump
- decode XML responses by regrouping four symbols per byte and reject dangling frames

## Testing
- g++ -std=c++17 /tmp/db_codec_test.cpp -o /tmp/db_codec_test
- /tmp/db_codec_test


------
https://chatgpt.com/codex/tasks/task_e_68dc385f4bcc8328896df268f90a3063