### PR TITLE
Expose flush_serial_input

### DIFF
--- a/esphome/components/jutta_proto/jutta_connection.hpp
+++ b/esphome/components/jutta_proto/jutta_connection.hpp
@@ -120,6 +120,11 @@ class JuttaConnection {
     void reset_response_line_buffer();
 
     /**
+     * Discards any pending UART input data and buffered decoded bytes.
+     */
+    void flush_serial_input() const;
+
+    /**
      * Encodes the given byte into 4 JUTTA bytes and writes them to the coffee maker.
      * [Thread Safe]
      **/
@@ -218,8 +223,6 @@ class JuttaConnection {
      * Not thread safe!
      **/
     [[nodiscard]] bool read_decoded_unsafe(std::vector<uint8_t>& data) const;
-
-    void flush_serial_input() const;
 
     /**
      * Encodes the given byte into 4 JUTTA bytes and writes them to the coffee maker.


### PR DESCRIPTION
## Summary
- expose `flush_serial_input` on `JuttaConnection` so callers can clear buffered UART data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc5289922c8328ac7bd370389fc29d