### PR TITLE
Handle serial write failures in Jutta connection

### DIFF
--- a/esphome/components/jutta_proto/jutta_connection.cpp
+++ b/esphome/components/jutta_proto/jutta_connection.cpp
@@ -338,7 +338,9 @@ void JuttaConnection::send_line_cmd(const std::string &line) {
   std::vector<uint8_t> buffer(line.begin(), line.end());
   buffer.push_back('\r');
   buffer.push_back('\n');
-  serial_.write_serial_buffer(buffer);
+  if (!serial_.write_serial_buffer(buffer)) {
+    ESP_LOGW(TAG, "Failed to send line command over serial");
+  }
   serial_.flush();
 }
 
@@ -355,7 +357,9 @@ void JuttaConnection::send_db_cmd(const std::string &command) {
   }
   encoded.insert(encoded.end(), DB_TRAILER.begin(), DB_TRAILER.end());
   ESP_LOGD(TAG, "TX_DB len=%zu", encoded.size());
-  serial_.write_serial_buffer(encoded);
+  if (!serial_.write_serial_buffer(encoded)) {
+    ESP_LOGW(TAG, "Failed to send DB command over serial (len=%zu)", encoded.size());
+  }
   serial_.flush();
 }
 


### PR DESCRIPTION
## Summary
- log serial transmission failures when sending line and DB commands
- keep flushing the UART while acknowledging unsuccessful writes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dee2ba82588328b3e12bae11b38224