### PR TITLE
Ensure HELLO handshake exclusively owns the UART

### DIFF
--- a/esphome/components/jutta_proto/jutta_connection.cpp
+++ b/esphome/components/jutta_proto/jutta_connection.cpp
@@ -9,11 +9,15 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <cstring>
 
 #include "esphome/core/log.h"
 #include "esphome/core/time.h"
 
 namespace jutta_proto {
+
+std::atomic<bool> uart_busy{false};
+
 namespace {
 static const char *const TAG = "jutta_connection";
 
@@ -119,7 +123,7 @@ void JuttaConnection::flush_serial_input() {
   }
 }
 
-void JuttaConnection::drain_plain_serial(uint32_t duration_ms) {
+void JuttaConnection::drain_uart_for_ms(uint32_t duration_ms) {
   encoded_rx_buffer_.clear();
   plain_rx_buffer_.clear();
   pending_lines_.clear();
@@ -224,10 +228,12 @@ bool JuttaConnection::process_encoded_frames() {
     std::vector<uint8_t> encoded(encoded_rx_buffer_.begin(), it);
     encoded_rx_buffer_.erase(encoded_rx_buffer_.begin(), it + DB_TRAILER.size());
 
-    std::string encoded_hex = format_hex(encoded);
-    std::string trailer_hex = format_hex(std::vector<uint8_t>(DB_TRAILER.begin(), DB_TRAILER.end()), DB_TRAILER.size());
-    ESP_LOGV(TAG, "RX_ENC len=%zu hex=%s terminator=%s", encoded.size(), encoded_hex.c_str(),
-             trailer_hex.c_str());
+    if (!uart_busy.load()) {
+      std::string encoded_hex = format_hex(encoded);
+      std::string trailer_hex = format_hex(std::vector<uint8_t>(DB_TRAILER.begin(), DB_TRAILER.end()), DB_TRAILER.size());
+      ESP_LOGV(TAG, "RX_ENC len=%zu hex=%s terminator=%s", encoded.size(), encoded_hex.c_str(),
+               trailer_hex.c_str());
+    }
 
     std::vector<uint8_t> decoded;
     if (!decode_encoded_frame(encoded, decoded)) {
@@ -322,7 +328,9 @@ void JuttaConnection::route_decoded_frame(std::vector<uint8_t> decoded, size_t e
     while ((terminator_pos = plain_rx_buffer_.find("\r\n")) != std::string::npos) {
       std::string line = plain_rx_buffer_.substr(0, terminator_pos);
       plain_rx_buffer_.erase(0, terminator_pos + 2);
-      ESP_LOGD(TAG, "RX_LINE \"%s\"", printable_snippet(line).c_str());
+      if (!uart_busy.load()) {
+        ESP_LOGD(TAG, "RX_LINE \"%s\"", printable_snippet(line).c_str());
+      }
       pending_lines_.push_back(std::move(line));
     }
     return;
@@ -331,7 +339,9 @@ void JuttaConnection::route_decoded_frame(std::vector<uint8_t> decoded, size_t e
   XmlFrame frame;
   frame.payload = std::move(decoded);
   frame.encoded_size = encoded_length;
-  ESP_LOGD(TAG, "RX_XML encoded_len=%zu decoded_len=%zu", frame.encoded_size, frame.payload.size());
+  if (!uart_busy.load()) {
+    ESP_LOGD(TAG, "RX_XML encoded_len=%zu decoded_len=%zu", frame.encoded_size, frame.payload.size());
+  }
   pending_xml_frames_.push_back(std::move(frame));
 }
 
@@ -371,6 +381,20 @@ bool JuttaConnection::command_requires_ok(const std::string &command) {
          upper.rfind("FA:", 0) == 0;
 }
 
+bool JuttaConnection::starts_with_lower(const std::string &s, const char *prefix) {
+  size_t prefix_len = std::strlen(prefix);
+  if (s.size() < prefix_len) {
+    return false;
+  }
+  for (size_t i = 0; i < prefix_len; ++i) {
+    if (std::tolower(static_cast<unsigned char>(s[i])) !=
+        std::tolower(static_cast<unsigned char>(prefix[i]))) {
+      return false;
+    }
+  }
+  return true;
+}
+
 void JuttaConnection::send_line_cmd(const std::string &line) {
   ESP_LOGD(TAG, "TX_LINE \"%s\"", printable_snippet(line).c_str());
   std::vector<uint8_t> buffer(line.begin(), line.end());
@@ -379,7 +403,6 @@ void JuttaConnection::send_line_cmd(const std::string &line) {
   if (!serial_.write_serial_buffer(buffer)) {
     ESP_LOGW(TAG, "Failed to send line command over serial");
   }
-  serial_.flush();
 }
 
 void JuttaConnection::send_db_cmd(const std::string &command) {
@@ -394,19 +417,25 @@ void JuttaConnection::send_db_cmd(const std::string &command) {
     }
   }
   encoded.insert(encoded.end(), DB_TRAILER.begin(), DB_TRAILER.end());
-  ESP_LOGD(TAG, "TX_DB len=%zu", encoded.size());
+  if (!uart_busy.load()) {
+    ESP_LOGD(TAG, "TX_DB len=%zu", encoded.size());
+  }
   if (!serial_.write_serial_buffer(encoded)) {
     ESP_LOGW(TAG, "Failed to send DB command over serial (len=%zu)", encoded.size());
   }
-  serial_.flush();
 }
 
 void JuttaConnection::poll_serial_lines(uint32_t timeout_ms) {
+  if (uart_busy.load()) {
+    return;
+  }
   pump_serial(timeout_ms);
 }
 
-bool JuttaConnection::read_line_until(std::string &out, uint32_t timeout_ms) {
+bool JuttaConnection::read_line_until(std::string &out, uint32_t timeout_ms, uint32_t *bytes_seen) {
   out.clear();
+  line_buffer_.clear();
+  uint32_t seen = 0;
   uint32_t start = esphome::millis();
   auto *self = const_cast<serial::SerialConnection *>(&serial_);
   while (!time_reached(esphome::millis(), start + timeout_ms)) {
@@ -415,18 +444,63 @@ bool JuttaConnection::read_line_until(std::string &out, uint32_t timeout_ms) {
       if (!self->read_serial_byte(&byte)) {
         break;
       }
+      ++seen;
       char c = static_cast<char>(byte);
-      line_read_buffer_.push_back(c);
-      if (line_read_buffer_.size() >= 2 && line_read_buffer_[line_read_buffer_.size() - 2] == '\r' &&
-          line_read_buffer_.back() == '\n') {
-        out.assign(line_read_buffer_.begin(), line_read_buffer_.end() - 2);
-        line_read_buffer_.clear();
+      line_buffer_.push_back(c);
+      if (line_buffer_.size() >= 2 && line_buffer_[line_buffer_.size() - 2] == '\r' &&
+          line_buffer_.back() == '\n') {
+        out.assign(line_buffer_.begin(), line_buffer_.end() - 2);
+        line_buffer_.clear();
+        if (bytes_seen != nullptr) {
+          *bytes_seen = seen;
+        }
         return true;
       }
     }
     esphome::delay(1);
   }
+  if (bytes_seen != nullptr) {
+    *bytes_seen = seen;
+  }
   return false;
+}
+
+bool JuttaConnection::await_device_type(std::string &out_ty) {
+  UartGuard lock(uart_busy);
+  drain_uart_for_ms(40);
+  send_line_cmd("ty:");
+
+  uint32_t bytes_seen = 0;
+  if (!read_line_until(out_ty, 2500, &bytes_seen)) {
+    ESP_LOGW(TAG, "HELLO timeout; bytes_seen=%u", bytes_seen);
+    return false;
+  }
+
+  std::string ok_line;
+  uint32_t ok_bytes = 0;
+  if (!read_line_until(ok_line, 1200, &ok_bytes)) {
+    ESP_LOGW(TAG, "HELLO timeout; bytes_seen=%u", ok_bytes);
+    return false;
+  }
+  if (ok_line != "ok:") {
+    return false;
+  }
+  return starts_with_lower(out_ty, "ty:");
+}
+
+bool JuttaConnection::prime_initial_db() {
+  UartGuard lock(uart_busy);
+  const std::array<const char *, 3> commands = {"@TR:32", "@TG:43", "@TG:C0"};
+  for (const char *cmd : commands) {
+    pending_xml_frames_.clear();
+    drain_encoded(std::chrono::milliseconds{40});
+    send_db_cmd(cmd);
+    std::vector<uint8_t> decoded;
+    if (!read_db_frame(decoded, 1500)) {
+      return false;
+    }
+  }
+  return true;
 }
 
 bool JuttaConnection::read_db_frame(std::vector<uint8_t> &decoded, uint32_t timeout_ms) {
@@ -438,7 +512,9 @@ bool JuttaConnection::read_db_frame(std::vector<uint8_t> &decoded, uint32_t time
       XmlFrame frame = std::move(pending_xml_frames_.front());
       pending_xml_frames_.pop_front();
       decoded = std::move(frame.payload);
-      ESP_LOGD(TAG, "XML frame ready encoded_len=%zu decoded_len=%zu", frame.encoded_size, decoded.size());
+      if (!uart_busy.load()) {
+        ESP_LOGD(TAG, "XML frame ready encoded_len=%zu decoded_len=%zu", frame.encoded_size, decoded.size());
+      }
       return true;
     }
 
@@ -449,8 +525,10 @@ bool JuttaConnection::read_db_frame(std::vector<uint8_t> &decoded, uint32_t time
     uint32_t now = esphome::millis();
     if (time_reached(now, start + timeout_ms)) {
       if (!encoded_rx_buffer_.empty()) {
-        ESP_LOGW(TAG, "Timeout waiting for XML frame. buffered_hex=%s",
-                 format_hex(encoded_rx_buffer_).c_str());
+        if (!uart_busy.load()) {
+          ESP_LOGW(TAG, "Timeout waiting for XML frame. buffered_hex=%s",
+                   format_hex(encoded_rx_buffer_).c_str());
+        }
       }
       return false;
     }
@@ -480,6 +558,12 @@ bool JuttaConnection::wait_for_line(const std::string &expected, const std::chro
 
 std::shared_ptr<std::string> JuttaConnection::transact_db_internal(const std::string &command,
                                                                    const std::chrono::milliseconds &timeout, bool *ok) {
+  if (uart_busy.load()) {
+    if (ok != nullptr) {
+      *ok = false;
+    }
+    return nullptr;
+  }
   drain_encoded(std::chrono::milliseconds{40});
   pending_xml_frames_.clear();
   set_active_pipeline(ActivePipeline::Xml);
@@ -506,6 +590,9 @@ bool JuttaConnection::write_decoded(const std::string &command) {
   }
   bool had_newline = command.find('\n') != std::string::npos || command.find('\r') != std::string::npos;
   if (trimmed.front() == '@' && !had_newline) {
+    if (uart_busy.load()) {
+      return false;
+    }
     drain_encoded(std::chrono::milliseconds{40});
     pending_xml_frames_.clear();
     send_db_cmd(trimmed);
@@ -528,6 +615,9 @@ JuttaConnection::WaitResult JuttaConnection::write_decoded_wait_for(
   }
   bool had_newline = command.find('\n') != std::string::npos || command.find('\r') != std::string::npos;
   if (trimmed_command.front() == '@' && !had_newline) {
+    if (uart_busy.load()) {
+      return WaitResult::Error;
+    }
     bool ok = false;
     auto response = transact_db_internal(trimmed_command, timeout, &ok);
     if (!ok) {

--- a/esphome/components/jutta_proto/jutta_connection.hpp
+++ b/esphome/components/jutta_proto/jutta_connection.hpp
@@ -1,14 +1,28 @@
 #pragma once
 
+#include <atomic>
 #include <chrono>
 #include <deque>
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "esphome/core/hal.h"
 #include "serial_connection.hpp"
 
 namespace jutta_proto {
+
+extern std::atomic<bool> uart_busy;
+
+struct UartGuard {
+  std::atomic<bool> &flag;
+  explicit UartGuard(std::atomic<bool> &f) : flag(f) {
+    while (flag.exchange(true)) {
+      esphome::delay(1);
+    }
+  }
+  ~UartGuard() { flag.store(false); }
+};
 
 class JuttaConnection {
  public:
@@ -34,11 +48,15 @@ class JuttaConnection {
 
   void flush_serial_input();
 
-  void drain_plain_serial(uint32_t duration_ms);
+  void drain_uart_for_ms(uint32_t duration_ms);
 
   void send_plain_line(const std::string &line);
 
-  bool read_line_until(std::string &out, uint32_t timeout_ms);
+  bool read_line_until(std::string &out, uint32_t timeout_ms, uint32_t *bytes_seen = nullptr);
+
+  bool await_device_type(std::string &out_ty);
+
+  bool prime_initial_db();
 
  private:
   serial::SerialConnection serial_;
@@ -74,6 +92,7 @@ class JuttaConnection {
 
   static std::string trim_command(const std::string &command);
   static bool command_requires_ok(const std::string &command);
+  static bool starts_with_lower(const std::string &s, const char *prefix);
 
   void send_line_cmd(const std::string &line);
   void send_db_cmd(const std::string &command);
@@ -86,6 +105,7 @@ class JuttaConnection {
                                                     const std::chrono::milliseconds &timeout, bool *ok);
 
   std::string line_read_buffer_;
+  std::string line_buffer_;
 };
 
 }  // namespace jutta_proto

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -1295,56 +1295,23 @@ void JuraComponent::process_handshake() {
     case HandshakeStage::IDLE:
       break;
     case HandshakeStage::HELLO: {
-      if (!this->handshake_hello_request_sent_) {
-        ESP_LOGD(TAG, "HELLO: draining UART before requesting device type.");
-        this->connection_->drain_plain_serial(35);
-        this->handshake_buffer_.clear();
-        this->handshake_deadline_ = 0;
-        this->connection_->send_plain_line("ty:");
-        this->handshake_hello_request_sent_ = true;
-      }
-
-      std::string line;
-      if (!this->connection_->read_line_until(line, 1500)) {
-        this->restart_handshake("timeout waiting for device type line");
+      std::string device_line;
+      if (!this->connection_->await_device_type(device_line)) {
+        this->restart_handshake("failed to read device type");
         break;
       }
 
-      std::string preview = line.substr(0, std::min<size_t>(60, line.size()));
-      ESP_LOGD(TAG, "RX_LINE \"%s\"", format_printable_string(preview).c_str());
-
-      std::string lowercase_line = line;
-      std::transform(lowercase_line.begin(), lowercase_line.end(), lowercase_line.begin(),
-                     [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-      if (lowercase_line.rfind("ty:", 0) != 0) {
-        ESP_LOGW(TAG, "HELLO: unexpected response line '%s'",
-                 format_printable_string(line).c_str());
-        this->restart_handshake("unexpected device type response");
-        break;
-      }
-
-      std::string ok_line;
-      bool ok_received = this->connection_->read_line_until(ok_line, 800);
-      if (!ok_received) {
-        ESP_LOGD(TAG, "RX_OK 0");
-        this->restart_handshake("timeout waiting for ok acknowledgment");
-        break;
-      }
-
-      bool ok_match = ok_line == "ok:";
-      ESP_LOGD(TAG, "RX_OK %d", ok_match ? 1 : 0);
-      if (!ok_match) {
-        this->restart_handshake("unexpected acknowledgment line");
-        break;
-      }
-
-      if (line.size() <= 3) {
+      if (device_line.size() <= 3) {
         ESP_LOGW(TAG, "HELLO: device type response line '%s' has no payload, proceeding with unknown type.",
-                 format_printable_string(line).c_str());
+                 format_printable_string(device_line).c_str());
         this->device_type_ = "ty:unknown";
       } else {
-        this->device_type_ = line;
+        this->device_type_ = device_line;
         ESP_LOGI(TAG, "Detected coffee maker response: %s", this->device_type_.c_str());
+      }
+
+      if (!this->connection_->prime_initial_db()) {
+        ESP_LOGW(TAG, "HELLO: initial DB warm-up failed");
       }
 
       this->handshake_buffer_.clear();
@@ -1507,6 +1474,9 @@ bool JuraComponent::has_machine_data_subscribers_() const {
 
 void JuraComponent::process_machine_data_query() {
   if (!this->has_machine_data_subscribers_()) {
+    return;
+  }
+  if (::jutta_proto::uart_busy.load()) {
     return;
   }
   bool has_field_subscribers = this->machine_data_auto_fields_ || !this->machine_data_field_sensors_.empty() ||

--- a/sample.yaml
+++ b/sample.yaml
@@ -26,28 +26,11 @@ jutta_proto:
     raw: jura_machine_raw
     auto_fields: true
     field_prefix: "JURA Machine"
-    fields:
-      statistic.maintenancepercent.cleaning_percent:
-        sensor: jura_cleaning_percent
-      statistic.productcounter.espresso:
-        sensor: jura_espresso_counter
 
 text_sensor:
   - platform: template
     id: jura_machine_raw
     name: "JURA Machine Data Raw"
-
-sensor:
-  - platform: template
-    id: jura_cleaning_percent
-    name: "JURA Cleaning Percent"
-    unit_of_measurement: "%"
-    accuracy_decimals: 1
-    state_class: measurement
-  - platform: template
-    id: jura_espresso_counter
-    name: "JURA Espresso Counter"
-    state_class: total_increasing
 
 # Convenience switches to remotely power the machine on/off
 switch:


### PR DESCRIPTION
## Summary
- introduce a global UART guard that serializes HELLO and database access
- make the HELLO device-type probe exclusive and warm up initial DB frames before continuing
- suppress template sensor stubs from the sample configuration so machine data relies on component updates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dee9464b4883288f574cb7566c1b69