### PR TITLE
Add raw UART hello probe for diagnostics

### DIFF
--- a/esphome/components/jutta_proto/jutta_connection.cpp
+++ b/esphome/components/jutta_proto/jutta_connection.cpp
@@ -21,6 +21,37 @@ std::atomic<bool> uart_busy{false};
 namespace {
 static const char *const TAG = "jutta_connection";
 
+bool jutta_raw_hello_probe(esphome::uart::UARTComponent &uart) {
+  uint32_t t0 = esphome::millis();
+  while (esphome::millis() - t0 < 40) {
+    while (uart.available()) {
+      uart.read();
+    }
+    esphome::delay(1);
+  }
+
+  const char *cmd = "ty:\r\n";
+  uart.write_array(reinterpret_cast<const uint8_t *>(cmd), 4);
+
+  std::string hex;
+  hex.reserve(512);
+  uint32_t seen = 0;
+  t0 = esphome::millis();
+  while (esphome::millis() - t0 < 3000) {
+    while (uart.available()) {
+      uint8_t b = static_cast<uint8_t>(uart.read());
+      seen++;
+      static const char *H = "0123456789ABCDEF";
+      hex.push_back(H[b >> 4]);
+      hex.push_back(H[b & 0x0F]);
+      hex.push_back(' ');
+    }
+    esphome::delay(1);
+  }
+  ESP_LOGD("jutta_probe", "RAW HELLO bytes_seen=%u hex=[%s]", seen, hex.c_str());
+  return seen > 0;
+}
+
 constexpr uint32_t JUTTA_SERIAL_GAP_MS = 35;
 constexpr std::array<uint8_t, 8> DB_TRAILER = {0xDF, 0xFF, 0xDB, 0xDB, 0xFB, 0xFB, 0xDB, 0xDB};
 constexpr uint8_t DB_ESC = 0xDB;
@@ -466,6 +497,9 @@ bool JuttaConnection::read_line_until(std::string &out, uint32_t timeout_ms, uin
 }
 
 bool JuttaConnection::await_device_type(std::string &out_ty) {
+  if (auto *parent = serial_.get_parent()) {
+    jutta_raw_hello_probe(*parent);
+  }
   UartGuard lock(uart_busy);
   drain_uart_for_ms(40);
   send_line_cmd("ty:");

--- a/esphome/components/jutta_proto/serial_connection.cpp
+++ b/esphome/components/jutta_proto/serial_connection.cpp
@@ -112,6 +112,10 @@ void SerialConnection::flush() const {
     }
 }
 
+esphome::uart::UARTComponent* SerialConnection::get_parent() const {
+    return this->parent_;
+}
+
 std::vector<std::string> SerialConnection::get_available_ports() {
     return {};
 }

--- a/esphome/components/jutta_proto/serial_connection.hpp
+++ b/esphome/components/jutta_proto/serial_connection.hpp
@@ -60,6 +60,8 @@ class SerialConnection : public esphome::uart::UARTDevice {
     [[nodiscard]] bool write_serial_byte(uint8_t byte) const;
     void flush() const;
 
+    esphome::uart::UARTComponent* get_parent() const;
+
     /**
      * Returns all available serial port paths for this device.
      **/


### PR DESCRIPTION
## Summary
- add a raw UART hello probe helper that logs bytes received after issuing the ty command
- invoke the raw probe during the HELLO handshake to capture the raw serial response
- expose the UART parent from SerialConnection so the probe can access the component directly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deee357ed08328bb0ef9934b925316