### PR TITLE
Fix UART hello probe to use read_byte

### DIFF
--- a/esphome/components/jutta_proto/jutta_connection.cpp
+++ b/esphome/components/jutta_proto/jutta_connection.cpp
@@ -25,7 +25,10 @@ bool jutta_raw_hello_probe(esphome::uart::UARTComponent &uart) {
   uint32_t t0 = esphome::millis();
   while (esphome::millis() - t0 < 40) {
     while (uart.available()) {
-      uart.read();
+      uint8_t discard;
+      if (!uart.read_byte(&discard)) {
+        break;
+      }
     }
     esphome::delay(1);
   }
@@ -39,7 +42,10 @@ bool jutta_raw_hello_probe(esphome::uart::UARTComponent &uart) {
   t0 = esphome::millis();
   while (esphome::millis() - t0 < 3000) {
     while (uart.available()) {
-      uint8_t b = static_cast<uint8_t>(uart.read());
+      uint8_t b;
+      if (!uart.read_byte(&b)) {
+        break;
+      }
       seen++;
       static const char *H = "0123456789ABCDEF";
       hex.push_back(H[b >> 4]);


### PR DESCRIPTION
## Summary
- replace deprecated direct UARTComponent reads in the raw hello probe with read_byte
- ensure the probe breaks out if reading from UART fails

## Testing
- `pio run -e jura-e6` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68df8d9257708328953838cfff0629c2