### PR TITLE
Throttle handshake retries to keep ESP responsive

### DIFF
--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -1206,6 +1206,7 @@ void JuraComponent::setup() {
   }
 
   this->handshake_stage_ = HandshakeStage::HELLO;
+  this->handshake_retry_at_ = 0;
   ESP_LOGI(TAG, "Starting handshake with coffee maker...");
 }
 
@@ -1221,6 +1222,10 @@ void JuraComponent::loop() {
 
   if (this->connection_ != nullptr && this->handshake_stage_ != HandshakeStage::DONE &&
       this->handshake_stage_ != HandshakeStage::FAILED) {
+    if (this->handshake_stage_ == HandshakeStage::HELLO && this->handshake_retry_at_ != 0 &&
+        !JuraComponent::time_reached(esphome::millis(), this->handshake_retry_at_)) {
+      return;
+    }
     this->process_handshake();
   }
 
@@ -1310,6 +1315,7 @@ void JuraComponent::process_handshake() {
         ESP_LOGI(TAG, "Detected coffee maker response: %s", this->device_type_.c_str());
       }
 
+      this->handshake_retry_at_ = 0;
       if (!this->connection_->prime_initial_db()) {
         ESP_LOGW(TAG, "HELLO: initial DB warm-up failed");
       }
@@ -1406,6 +1412,7 @@ void JuraComponent::process_handshake() {
         this->handshake_stage_ = HandshakeStage::DONE;
         this->handshake_buffer_.clear();
         this->handshake_deadline_ = 0;
+        this->handshake_retry_at_ = 0;
       } else {
         this->restart_handshake("failed to send @t3");
       }
@@ -1433,6 +1440,9 @@ void JuraComponent::restart_handshake(const char *reason) {
   this->handshake_hello_request_sent_ = false;
   this->handshake_stage_ = HandshakeStage::HELLO;
   this->last_logged_stage_ = HandshakeStage::FAILED;
+  constexpr uint32_t HANDSHAKE_RETRY_DELAY_MS = 1000;
+  this->handshake_retry_at_ = esphome::millis() + HANDSHAKE_RETRY_DELAY_MS;
+  ESP_LOGI(TAG, "Scheduling handshake retry in %u ms", HANDSHAKE_RETRY_DELAY_MS);
   if (this->connection_ != nullptr) {
     this->connection_->reset_response_line_buffer();
   }

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -102,6 +102,7 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   std::string handshake_t2_response_;
   std::string handshake_t3_response_;
   uint32_t handshake_deadline_{0};
+  uint32_t handshake_retry_at_{0};
   bool handshake_hello_request_sent_{false};
   bool custom_cancel_flag_{false};
   text_sensor::TextSensor *machine_data_sensor_{nullptr};


### PR DESCRIPTION
## Summary
- add a retry backoff timer so handshake retries are throttled instead of looping continuously
- skip handshake processing until the backoff expires and clear the retry timer when the exchange succeeds
- expose the retry timestamp in the component state so repeated failures no longer block the ESP firmware loop

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df91efb4048328ba4a7a4fe6ffd9ee