### PR TITLE
Make ESPHome handshake non-blocking

### DIFF
--- a/docs/components/jutta_proto.md
+++ b/docs/components/jutta_proto.md
@@ -6,6 +6,20 @@ with a JURA coffee maker and exposes convenient automation actions for brewing d
 ## Configuration
 
 ```yaml
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  ap:
+    ssid: "JURA Coffee Maker Fallback"
+    password: !secret wifi_ap_password
+
+api:
+
+ota:
+
+status_led:
+  pin: GPIO2
+
 uart:
   id: jura_uart
   tx_pin: 17
@@ -20,6 +34,12 @@ jutta_proto:
 ```
 
 The component takes care of the handshake during startup. Once the handshake finishes, all brewing actions become available.
+
+!!! note
+    The example above includes the standard ESPHome `wifi`, `api`, and `ota` blocks so Home Assistant can connect to the device and you can perform wireless updates. Replace the Wi-Fi credentials with values that match your network (ideally using the `secrets.yaml` file) before flashing the firmware. Define `wifi_ap_password` in `secrets.yaml` if you keep the fallback access point enabled.
+
+!!! tip
+    Provision the device close to your wireless access point and keep the optional fallback access point (`wifi.ap`) enabled until the node shows up in Home Assistant. The fallback AP lets you connect directly to the ESP32 and update the Wi-Fi credentials if it cannot reach your network yet.
 
 ## Automation Actions
 
@@ -157,6 +177,17 @@ jutta_proto:
     status: jura_status
     processes: jura_processes
     raw: jura_machine_raw
+
+## Troubleshooting API Connectivity
+
+If Home Assistant still shows `Can't connect to ESPHome API` after flashing the firmware, try the following diagnostics:
+
+1. **Verify the node is on Wi-Fi.** Connect the ESP32 over USB and run `esphome logs <config.yaml>` to check for `WiFi connected` and `API server listening` messages. If the device repeatedly retries Wi-Fi, double-check the SSID and password or temporarily disable `fast_connect` if you are using it with a visible network.
+2. **Check the IP address.** Look for `Got IP` in the serial logs and confirm that the reported address matches what Home Assistant is trying to reach. You can also ping the IP from the Home Assistant host to confirm connectivity.
+3. **Match API credentials.** If you enable API encryption or set an API password, make sure the same key/password is configured in Home Assistant (`Configuration → Integrations → ESPHome → Configure`). A mismatch will result in connection failures even though the TCP port is reachable.
+4. **Inspect firewalls.** Ensure port 6053 is open between Home Assistant and the ESP32. Some routers or VLAN setups block device-to-device communication by default.
+
+The device should stay online as long as it maintains Wi-Fi connectivity. Use the optional `status_led` block from the sample configuration to see the connection state without opening the logs (slow blink = Wi-Fi only, fast blink = connecting, solid = API connected).
 
 To publish the built-in set of machine data field sensors, enable `auto_fields`. All known statistics, maintenance counters,
 maintenance percentages, and helper fields are pre-registered up front and reuse the same entity names on every boot. Numeric

--- a/esphome/components/jutta_proto/jutta_connection.cpp
+++ b/esphome/components/jutta_proto/jutta_connection.cpp
@@ -21,43 +21,6 @@ std::atomic<bool> uart_busy{false};
 namespace {
 static const char *const TAG = "jutta_connection";
 
-bool jutta_raw_hello_probe(esphome::uart::UARTComponent &uart) {
-  uint32_t t0 = esphome::millis();
-  while (esphome::millis() - t0 < 40) {
-    while (uart.available()) {
-      uint8_t discard;
-      if (!uart.read_byte(&discard)) {
-        break;
-      }
-    }
-    esphome::delay(1);
-  }
-
-  const char *cmd = "ty:\r\n";
-  uart.write_array(reinterpret_cast<const uint8_t *>(cmd), 4);
-
-  std::string hex;
-  hex.reserve(512);
-  uint32_t seen = 0;
-  t0 = esphome::millis();
-  while (esphome::millis() - t0 < 3000) {
-    while (uart.available()) {
-      uint8_t b;
-      if (!uart.read_byte(&b)) {
-        break;
-      }
-      seen++;
-      static const char *H = "0123456789ABCDEF";
-      hex.push_back(H[b >> 4]);
-      hex.push_back(H[b & 0x0F]);
-      hex.push_back(' ');
-    }
-    esphome::delay(1);
-  }
-  ESP_LOGD("jutta_probe", "RAW HELLO bytes_seen=%u hex=[%s]", seen, hex.c_str());
-  return seen > 0;
-}
-
 constexpr uint32_t JUTTA_SERIAL_GAP_MS = 35;
 constexpr std::array<uint8_t, 8> DB_TRAILER = {0xDF, 0xFF, 0xDB, 0xDB, 0xFB, 0xFB, 0xDB, 0xDB};
 constexpr uint8_t DB_ESC = 0xDB;
@@ -140,6 +103,7 @@ void JuttaConnection::init() {
   ok_wait_context_ = {};
   active_pipeline_ = ActivePipeline::Idle;
   line_read_buffer_.clear();
+  device_probe_ = {};
 }
 
 void JuttaConnection::flush_serial_input() {
@@ -150,6 +114,7 @@ void JuttaConnection::flush_serial_input() {
   ok_wait_context_ = {};
   active_pipeline_ = ActivePipeline::Idle;
   line_read_buffer_.clear();
+  device_probe_ = {};
 
   auto *self = const_cast<serial::SerialConnection *>(&serial_);
   while (self->available() > 0) {
@@ -168,6 +133,7 @@ void JuttaConnection::drain_uart_for_ms(uint32_t duration_ms) {
   line_read_buffer_.clear();
   ok_wait_context_ = {};
   active_pipeline_ = ActivePipeline::Idle;
+  device_probe_ = {};
 
   auto *self = const_cast<serial::SerialConnection *>(&serial_);
   if (duration_ms == 0) {
@@ -502,30 +468,74 @@ bool JuttaConnection::read_line_until(std::string &out, uint32_t timeout_ms, uin
   return false;
 }
 
-bool JuttaConnection::await_device_type(std::string &out_ty) {
-  if (auto *parent = serial_.get_parent()) {
-    jutta_raw_hello_probe(*parent);
-  }
-  UartGuard lock(uart_busy);
-  drain_uart_for_ms(40);
-  send_line_cmd("ty:");
+JuttaConnection::WaitResult JuttaConnection::await_device_type(std::string &out_ty) {
+  constexpr uint32_t TY_TIMEOUT_MS = 2500;
+  constexpr uint32_t OK_TIMEOUT_MS = 1200;
 
-  uint32_t bytes_seen = 0;
-  if (!read_line_until(out_ty, 2500, &bytes_seen)) {
-    ESP_LOGW(TAG, "HELLO timeout; bytes_seen=%u", bytes_seen);
-    return false;
+  if (!device_probe_.active) {
+    {
+      UartGuard guard(uart_busy);
+      flush_serial_input();
+      send_line_cmd("ty:");
+    }
+    device_probe_ = {};
+    device_probe_.active = true;
+    device_probe_.command_sent = true;
+    device_probe_.ok_received = false;
+    device_probe_.ty_line.clear();
+    device_probe_.start_time = esphome::millis();
+    set_active_pipeline(ActivePipeline::Plain);
+    ESP_LOGD(TAG, "HELLO: starting asynchronous device probe");
+    return WaitResult::Pending;
   }
 
-  std::string ok_line;
-  uint32_t ok_bytes = 0;
-  if (!read_line_until(ok_line, 1200, &ok_bytes)) {
-    ESP_LOGW(TAG, "HELLO timeout; bytes_seen=%u", ok_bytes);
-    return false;
+  poll_serial_lines(0);
+
+  std::vector<std::string> leftovers;
+  while (!pending_lines_.empty()) {
+    std::string line = std::move(pending_lines_.front());
+    pending_lines_.pop_front();
+    if (starts_with_lower(line, "ty:") && device_probe_.ty_line.empty()) {
+      device_probe_.ty_line = line;
+      ESP_LOGD(TAG, "HELLO: received %s", printable_snippet(line).c_str());
+    } else if (equals_ignore_case(line, "ok:")) {
+      device_probe_.ok_received = true;
+    } else {
+      leftovers.push_back(std::move(line));
+    }
   }
-  if (ok_line != "ok:") {
-    return false;
+
+  for (auto it = leftovers.rbegin(); it != leftovers.rend(); ++it) {
+    pending_lines_.push_front(std::move(*it));
   }
-  return starts_with_lower(out_ty, "ty:");
+
+  uint32_t now = esphome::millis();
+  uint32_t ty_deadline = device_probe_.start_time + TY_TIMEOUT_MS;
+  uint32_t ok_deadline = ty_deadline + OK_TIMEOUT_MS;
+
+  if (!device_probe_.ty_line.empty() && device_probe_.ok_received) {
+    out_ty = device_probe_.ty_line;
+    cancel_device_probe();
+    return WaitResult::Success;
+  }
+
+  if ((device_probe_.ty_line.empty() && time_reached(now, ty_deadline)) ||
+      (!device_probe_.ok_received && time_reached(now, ok_deadline))) {
+    ESP_LOGW(TAG, "HELLO timeout; ty_received=%s ok_received=%s",
+             YESNO(!device_probe_.ty_line.empty()), YESNO(device_probe_.ok_received));
+    cancel_device_probe();
+    return WaitResult::Timeout;
+  }
+
+  return WaitResult::Pending;
+}
+
+void JuttaConnection::cancel_device_probe() {
+  if (!device_probe_.active) {
+    return;
+  }
+  device_probe_ = {};
+  set_active_pipeline(ActivePipeline::Idle);
 }
 
 bool JuttaConnection::prime_initial_db() {
@@ -742,6 +752,7 @@ bool JuttaConnection::poll_response_line(std::string &line) {
 void JuttaConnection::reset_response_line_buffer() {
   plain_rx_buffer_.clear();
   pending_lines_.clear();
+  device_probe_ = {};
 }
 
 }  // namespace jutta_proto

--- a/esphome/components/jutta_proto/jutta_connection.hpp
+++ b/esphome/components/jutta_proto/jutta_connection.hpp
@@ -54,7 +54,9 @@ class JuttaConnection {
 
   bool read_line_until(std::string &out, uint32_t timeout_ms, uint32_t *bytes_seen = nullptr);
 
-  bool await_device_type(std::string &out_ty);
+  WaitResult await_device_type(std::string &out_ty);
+
+  void cancel_device_probe();
 
   bool prime_initial_db();
 
@@ -106,6 +108,14 @@ class JuttaConnection {
 
   std::string line_read_buffer_;
   std::string line_buffer_;
+
+  struct DeviceProbeContext {
+    bool active{false};
+    bool command_sent{false};
+    bool ok_received{false};
+    uint32_t start_time{0};
+    std::string ty_line;
+  } device_probe_;
 };
 
 }  // namespace jutta_proto

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -1301,7 +1301,11 @@ void JuraComponent::process_handshake() {
       break;
     case HandshakeStage::HELLO: {
       std::string device_line;
-      if (!this->connection_->await_device_type(device_line)) {
+      auto wait_result = this->connection_->await_device_type(device_line);
+      if (wait_result == JuttaConnection::WaitResult::Pending) {
+        break;
+      }
+      if (wait_result != JuttaConnection::WaitResult::Success) {
         this->restart_handshake("failed to read device type");
         break;
       }
@@ -1445,6 +1449,7 @@ void JuraComponent::restart_handshake(const char *reason) {
   ESP_LOGI(TAG, "Scheduling handshake retry in %u ms", HANDSHAKE_RETRY_DELAY_MS);
   if (this->connection_ != nullptr) {
     this->connection_->reset_response_line_buffer();
+    this->connection_->cancel_device_probe();
   }
 }
 

--- a/sample.yaml
+++ b/sample.yaml
@@ -5,9 +5,31 @@ esphome:
 esp32:
   board: esp32dev
 
+# Enable the native ESPHome API so Home Assistant can connect
+api:
+
 # Configure logging for verbose handshake diagnostics
 logger:
   level: DEBUG
+
+# Basic OTA setup to allow wireless firmware updates
+ota:
+
+# Wi-Fi configuration for the ESP32
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  # Comment or remove the next block once the device is provisioned.
+  ap:
+    ssid: "JURA Coffee Maker Fallback"
+    password: !secret wifi_ap_password
+
+# Optional status LED so you can confirm Wi-Fi/API connection state at a glance.
+status_led:
+  pin: GPIO2
+
+# If Wi-Fi credentials fail, fall back to the captive portal for provisioning
+captive_portal:
 
 # Hardware UART used to communicate with the coffee maker
 uart:


### PR DESCRIPTION
## Summary
- convert the hello handshake into an asynchronous device probe so the ESP can continue handling Wi-Fi and API tasks
- add device probe cancellation plumbing so handshake retries reset cleanly without blocking the UART buffers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df959cf5c48328871c569535fe6b69