### PR TITLE
Fix Jutta HELLO probe command case

### DIFF
--- a/esphome/components/jutta_proto/jutta_connection.cpp
+++ b/esphome/components/jutta_proto/jutta_connection.cpp
@@ -476,7 +476,7 @@ JuttaConnection::WaitResult JuttaConnection::await_device_type(std::string &out_
     {
       UartGuard guard(uart_busy);
       flush_serial_input();
-      send_line_cmd("ty:");
+      send_line_cmd("TY:");
     }
     device_probe_ = {};
     device_probe_.active = true;


### PR DESCRIPTION
## Summary
- send the HELLO probe using the uppercase TY command so the machine recognizes it

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df9ba7697c8328950782f919d2425a