### PR TITLE
Add optional XML poller for machine data

### DIFF
--- a/Test_Protocol/jura-e6.yaml
+++ b/Test_Protocol/jura-e6.yaml
@@ -7,7 +7,6 @@ esphome:
     then:
       - lambda: |-
           id(jura_device)->set_text_sensor(id(jura_last_message));
-          id(jura_device)->set_total_counter_sensor(id(jura_total_counter));
 #          id(jura_device)->set_checksum_mode("repeat_key");
 #          id(jura_device)->set_heartbeat_interval_ms(40000);
 #          id(jura_device)->set_jutta_gap_ms(20);   
@@ -73,12 +72,6 @@ text_sensor:
   - platform: template
     name: "Jura Last Message"
     id: jura_last_message
-
-# Total counter sensor (heuristic)
-sensor:
-  - platform: template
-    name: "Jura Total Counter"
-    id: jura_total_counter
 
 # On boot: attach sensors to C++ object
 

--- a/esphome/components/jutta_proto/jutta_config.h
+++ b/esphome/components/jutta_proto/jutta_config.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#define JUTTA_XML_ENABLE 1
+#define JUTTA_XML_POLL_MS 30000
+#define JUTTA_XML_RX_TIMEOUT_MS 900

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -14,6 +14,8 @@
 
 #include "esphome/core/application.h"
 #include "esphome/core/time.h"
+#include "jutta_config.h"
+#include "jutta_xml.h"
 #include "machine_data_parser.h"
 
 namespace esphome {
@@ -1235,6 +1237,104 @@ void JuraComponent::loop() {
       this->custom_cancel_flag_ = false;
     }
   }
+
+#if JUTTA_XML_ENABLE
+  if (this->handshake_stage_ == HandshakeStage::DONE && this->parent_ != nullptr &&
+      this->has_machine_data_subscribers_()) {
+    static uint32_t last_xml_poll = 0;
+    uint32_t now = esphome::millis();
+    if (now - last_xml_poll >= JUTTA_XML_POLL_MS) {
+      last_xml_poll = now;
+
+      ::jutta_proto::UartGuard guard(::jutta_proto::uart_busy);
+      auto *uart = this->parent_;
+
+      uint32_t drain_deadline = esphome::millis() + 40;
+      while (!JuraComponent::time_reached(esphome::millis(), drain_deadline)) {
+        while (uart->available()) {
+          uart->read();
+        }
+        esphome::delay(1);
+      }
+
+      std::vector<uint16_t> product_counters;
+      std::vector<uint16_t> maintenance_counters;
+      uint32_t percent_a = 0;
+      uint32_t percent_b = 0;
+      uint32_t percent_c = 0;
+
+      if (jutta_xml::query_TR32(*uart, product_counters) &&
+          jutta_xml::query_TG43(*uart, maintenance_counters) &&
+          jutta_xml::query_TGC0(*uart, percent_a, percent_b, percent_c)) {
+        MachineDataFieldMap xml_fields;
+
+        if (product_counters.size() == PRODUCT_COUNTER_DEFINITIONS.size()) {
+          std::vector<std::string> base_labels = {"Statistic", "Product Counter"};
+          std::string prefix = "statistic.productcounter";
+          for (size_t i = 0; i < PRODUCT_COUNTER_DEFINITIONS.size(); ++i) {
+            MachineDataFieldValue value;
+            value.labels = base_labels;
+            value.labels.push_back(PRODUCT_COUNTER_DEFINITIONS[i].name);
+            value.text_value = std::to_string(product_counters[i]);
+            value.numeric_value = static_cast<float>(product_counters[i]);
+            value.unit = "";
+            std::string key = prefix + '.' + slugify(PRODUCT_COUNTER_DEFINITIONS[i].name);
+            xml_fields[key] = std::move(value);
+          }
+        }
+
+        if (maintenance_counters.size() == MAINTENANCE_COUNTER_NAMES.size()) {
+          std::vector<std::string> base_labels = {"Statistic", "Maintenance Counter"};
+          std::string prefix = "statistic.maintenancecounter";
+          for (size_t i = 0; i < MAINTENANCE_COUNTER_NAMES.size(); ++i) {
+            MachineDataFieldValue value;
+            value.labels = base_labels;
+            value.labels.push_back(MAINTENANCE_COUNTER_NAMES[i]);
+            value.text_value = std::to_string(maintenance_counters[i]);
+            value.numeric_value = static_cast<float>(maintenance_counters[i]);
+            value.unit = "";
+            std::string key = prefix + '.' + slugify(MAINTENANCE_COUNTER_NAMES[i]);
+            xml_fields[key] = std::move(value);
+          }
+        }
+
+        std::array<uint32_t, 3> percent_values = {percent_a, percent_b, percent_c};
+        if (percent_values.size() == MAINTENANCE_PERCENT_NAMES.size()) {
+          std::vector<std::string> base_labels = {"Statistic", "Maintenance Percent"};
+          std::string prefix = "statistic.maintenancepercent";
+          for (size_t i = 0; i < MAINTENANCE_PERCENT_NAMES.size(); ++i) {
+            uint32_t raw_value = percent_values[i];
+            float percent = decode_percent_fixed_point(raw_value);
+            uint16_t raw_aux = decode_percent_auxiliary(raw_value);
+
+            MachineDataFieldValue percent_entry;
+            percent_entry.labels = base_labels;
+            percent_entry.labels.push_back(std::string(MAINTENANCE_PERCENT_NAMES[i]) + " Percent");
+            percent_entry.text_value = format_percent_value(percent);
+            percent_entry.numeric_value = percent;
+            percent_entry.unit = "%";
+            std::string percent_key = prefix + '.' + slugify(std::string(MAINTENANCE_PERCENT_NAMES[i]) + " Percent");
+            xml_fields[percent_key] = std::move(percent_entry);
+
+            MachineDataFieldValue raw_entry;
+            raw_entry.labels = base_labels;
+            raw_entry.labels.push_back(std::string(MAINTENANCE_PERCENT_NAMES[i]) + " Raw");
+            raw_entry.text_value = std::to_string(raw_aux);
+            raw_entry.numeric_value = static_cast<float>(raw_aux);
+            raw_entry.unit = "";
+            std::string raw_key = prefix + '.' + slugify(std::string(MAINTENANCE_PERCENT_NAMES[i]) + " Raw");
+            xml_fields[raw_key] = std::move(raw_entry);
+          }
+        }
+
+        if (!xml_fields.empty()) {
+          this->machine_data_field_values_ = xml_fields;
+          this->publish_machine_data_fields_(xml_fields);
+        }
+      }
+    }
+  }
+#endif
 
   this->process_machine_data_query();
 }

--- a/esphome/components/jutta_proto/jutta_xml.cpp
+++ b/esphome/components/jutta_proto/jutta_xml.cpp
@@ -1,0 +1,136 @@
+#include "jutta_xml.h"
+
+#include <algorithm>
+
+#include "esphome/components/uart/uart.h"
+#include "esphome/core/hal.h"
+
+#include "jutta_config.h"
+
+namespace {
+
+constexpr uint8_t TERM[8] = {0xDF, 0xFF, 0xDB, 0xDB, 0xFB, 0xFB, 0xDB, 0xDB};
+
+inline void db_encode(const char *s, std::vector<uint8_t> &out) {
+  out.clear();
+  for (const uint8_t *p = reinterpret_cast<const uint8_t *>(s); *p != 0; ++p) {
+    uint8_t b = *p;
+    if (b == 0xDB || b == 0xDF || b == 0xFB || b == 0xFF) {
+      out.push_back(0xDB);
+      out.push_back(static_cast<uint8_t>(b ^ 0x20));
+    } else {
+      out.push_back(b);
+    }
+  }
+  out.insert(out.end(), std::begin(TERM), std::end(TERM));
+}
+
+inline uint16_t u16be(const std::vector<uint8_t> &v, size_t offset) {
+  return static_cast<uint16_t>((static_cast<uint16_t>(v[offset]) << 8) |
+                               static_cast<uint16_t>(v[offset + 1]));
+}
+
+inline uint32_t u32be(const std::vector<uint8_t> &v, size_t offset) {
+  return (static_cast<uint32_t>(v[offset]) << 24) | (static_cast<uint32_t>(v[offset + 1]) << 16) |
+         (static_cast<uint32_t>(v[offset + 2]) << 8) | static_cast<uint32_t>(v[offset + 3]);
+}
+
+}  // namespace
+
+namespace jutta_xml {
+
+bool send_db_cmd(esphome::uart::UARTComponent &uart, const char *ascii_at) {
+  std::vector<uint8_t> encoded;
+  db_encode(ascii_at, encoded);
+  uart.write_array(encoded.data(), encoded.size());
+  return true;
+}
+
+bool read_db_frame(esphome::uart::UARTComponent &uart, std::vector<uint8_t> &decoded, uint32_t timeout_ms) {
+  std::vector<uint8_t> raw;
+  raw.reserve(256);
+  uint32_t start = esphome::millis();
+  while (esphome::millis() - start < timeout_ms) {
+    while (uart.available()) {
+      int value = uart.read();
+      if (value < 0) {
+        continue;
+      }
+      raw.push_back(static_cast<uint8_t>(value));
+      start = esphome::millis();
+      if (raw.size() >= std::size(TERM) &&
+          std::equal(raw.end() - std::size(TERM), raw.end(), std::begin(TERM))) {
+        raw.resize(raw.size() - std::size(TERM));
+        decoded.clear();
+        decoded.reserve(raw.size());
+        for (size_t i = 0; i < raw.size();) {
+          uint8_t b = raw[i++];
+          if (b == 0xDB && i < raw.size()) {
+            decoded.push_back(static_cast<uint8_t>(raw[i++] ^ 0x20));
+          } else {
+            decoded.push_back(b);
+          }
+        }
+        return true;
+      }
+    }
+    esphome::delay(1);
+  }
+  return false;
+}
+
+bool query_TR32(esphome::uart::UARTComponent &uart, std::vector<uint16_t> &out10) {
+  out10.clear();
+  if (!send_db_cmd(uart, "@TR:32")) {
+    return false;
+  }
+  std::vector<uint8_t> decoded;
+  if (!read_db_frame(uart, decoded, JUTTA_XML_RX_TIMEOUT_MS)) {
+    return false;
+  }
+  if (decoded.size() != 21) {
+    return false;
+  }
+  for (size_t i = 0; i < 10; ++i) {
+    out10.push_back(u16be(decoded, 1 + i * 2));
+  }
+  return true;
+}
+
+bool query_TG43(esphome::uart::UARTComponent &uart, std::vector<uint16_t> &out6) {
+  out6.clear();
+  if (!send_db_cmd(uart, "@TG:43")) {
+    return false;
+  }
+  std::vector<uint8_t> decoded;
+  if (!read_db_frame(uart, decoded, JUTTA_XML_RX_TIMEOUT_MS)) {
+    return false;
+  }
+  if (decoded.size() != 13) {
+    return false;
+  }
+  for (size_t i = 0; i < 6; ++i) {
+    out6.push_back(u16be(decoded, 1 + i * 2));
+  }
+  return true;
+}
+
+bool query_TGC0(esphome::uart::UARTComponent &uart, uint32_t &a, uint32_t &b, uint32_t &c) {
+  if (!send_db_cmd(uart, "@TG:C0")) {
+    return false;
+  }
+  std::vector<uint8_t> decoded;
+  if (!read_db_frame(uart, decoded, JUTTA_XML_RX_TIMEOUT_MS)) {
+    return false;
+  }
+  if (decoded.size() != 13) {
+    return false;
+  }
+  a = u32be(decoded, 1);
+  b = u32be(decoded, 5);
+  c = u32be(decoded, 9);
+  return true;
+}
+
+}  // namespace jutta_xml
+

--- a/esphome/components/jutta_proto/jutta_xml.h
+++ b/esphome/components/jutta_proto/jutta_xml.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace esphome {
+namespace uart {
+class UARTComponent;
+}
+}  // namespace esphome
+
+namespace jutta_xml {
+
+bool send_db_cmd(esphome::uart::UARTComponent &uart, const char *ascii_at);
+bool read_db_frame(esphome::uart::UARTComponent &uart, std::vector<uint8_t> &decoded, uint32_t timeout_ms);
+bool query_TR32(esphome::uart::UARTComponent &uart, std::vector<uint16_t> &out10);
+bool query_TG43(esphome::uart::UARTComponent &uart, std::vector<uint16_t> &out6);
+bool query_TGC0(esphome::uart::UARTComponent &uart, uint32_t &a, uint32_t &b, uint32_t &c);
+
+}  // namespace jutta_xml
+


### PR DESCRIPTION
## Summary
- add a central XML configuration header and standalone XML DB transport helpers
- integrate an optional post-handshake XML polling path that publishes decoded counters
- clean up the legacy test YAML by removing an empty template sensor entry

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfaf4f9b7083288b3f7f7255f92d0a