### PR TITLE
Fix UART buffer draining to use read_byte API

### DIFF
--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -1252,7 +1252,10 @@ void JuraComponent::loop() {
       uint32_t drain_deadline = esphome::millis() + 40;
       while (!JuraComponent::time_reached(esphome::millis(), drain_deadline)) {
         while (uart->available()) {
-          uart->read();
+          uint8_t discarded;
+          if (!uart->read_byte(&discarded)) {
+            break;
+          }
         }
         esphome::delay(1);
       }

--- a/esphome/components/jutta_proto/jutta_xml.cpp
+++ b/esphome/components/jutta_proto/jutta_xml.cpp
@@ -52,11 +52,11 @@ bool read_db_frame(esphome::uart::UARTComponent &uart, std::vector<uint8_t> &dec
   uint32_t start = esphome::millis();
   while (esphome::millis() - start < timeout_ms) {
     while (uart.available()) {
-      int value = uart.read();
-      if (value < 0) {
+      uint8_t value;
+      if (!uart.read_byte(&value)) {
         continue;
       }
-      raw.push_back(static_cast<uint8_t>(value));
+      raw.push_back(value);
       start = esphome::millis();
       if (raw.size() >= std::size(TERM) &&
           std::equal(raw.end() - std::size(TERM), raw.end(), std::begin(TERM))) {


### PR DESCRIPTION
## Summary
- replace direct UART read() calls with read_byte() handling to match the current ESPHome UART API
- ensure XML polling drain loop discards bytes safely without relying on removed API

## Testing
- Not run (platformio not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfb82167b483288b69c537e232f5e2