### PR TITLE
Handle device type replies without OK ack

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,17 @@ To connect to an JURA coffee maker we are using a 5V UART signal with the follow
 * **RX Flow Control Threshold:** 0
 
 #### Deobfuscating
-Once a connection has been established we can start sending and receiving data.  
+Once a connection has been established we can start sending and receiving data.
 **But** all data send and received is obfuscated.
-The following description shows how to **deobfuscate** data received from the coffee maker.  
+The following description shows how to **deobfuscate** data received from the coffee maker.
 To obfuscate data just follow the steps in reverse.
+The reference implementation in [`Test_Protocol/jura.cpp`](Test_Protocol/jura.cpp) does exactly that:
+each outgoing character that is written via `send_command()` is run through
+`obfuscate_byte()` before being put on the UART, and received data is passed
+through the matching `deobfuscate_4bytes()` helper before it is interpreted.
+This means the raw serial traffic that you see during the initial handshake
+(`TY:` / `ty:`) is already obfuscated on the wire and only becomes readable once
+the helper functions run.
 
 **Step 0**
 The coffee maker always sends 4 "raw" byte per one byte of data with a break of 8ms in between each "raw" byte.

--- a/esphome/components/jutta_proto/jutta_connection.cpp
+++ b/esphome/components/jutta_proto/jutta_connection.cpp
@@ -540,14 +540,25 @@ JuttaConnection::WaitResult JuttaConnection::await_device_type(std::string &out_
   uint32_t ty_deadline = device_probe_.start_time + TY_TIMEOUT_MS;
   uint32_t ok_deadline = ty_deadline + OK_TIMEOUT_MS;
 
-  if (!device_probe_.ty_line.empty() && device_probe_.ok_received) {
-    out_ty = device_probe_.ty_line;
-    cancel_device_probe();
-    return WaitResult::Success;
+  if (!device_probe_.ty_line.empty()) {
+    if (device_probe_.ok_received) {
+      out_ty = device_probe_.ty_line;
+      cancel_device_probe();
+      return WaitResult::Success;
+    }
+
+    if (time_reached(now, ok_deadline)) {
+      ESP_LOGW(TAG, "HELLO: received %s without trailing OK:, continuing handshake anyway.",
+               printable_snippet(device_probe_.ty_line).c_str());
+      out_ty = device_probe_.ty_line;
+      cancel_device_probe();
+      return WaitResult::Success;
+    }
+
+    return WaitResult::Pending;
   }
 
-  if ((device_probe_.ty_line.empty() && time_reached(now, ty_deadline)) ||
-      (!device_probe_.ok_received && time_reached(now, ok_deadline))) {
+  if (time_reached(now, ty_deadline)) {
     ESP_LOGW(TAG, "HELLO timeout; ty_received=%s ok_received=%s",
              YESNO(!device_probe_.ty_line.empty()), YESNO(device_probe_.ok_received));
     cancel_device_probe();


### PR DESCRIPTION
## Summary
- allow the Jura handshake to accept device type responses even when the coffee maker omits an `OK:` acknowledgement
- emit a warning when the `OK:` never arrives instead of aborting the handshake so that setup can continue

## Testing
- not run (logic-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dfc13e4c4c8328b3af549075d1773d