### PR TITLE
Enable XML polling sensors for ESPHome

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,4 +246,29 @@ esphome run your_config.yaml
 ```
 ESPHome handles dependency management, compilation, and flashing of the firmware for you.
 
+### XML-Zähler automatisch bereitstellen
+
+Die Firmware kann die JURA-internen XML-Zähler zyklisch abfragen und als numerische Sensoren in Home Assistant zur Verfügung
+stellen. Dafür ist keine zusätzliche YAML-Konfiguration nötig – alle Sensorinstanzen werden während `setup()` angelegt,
+registriert und bleiben dauerhaft sichtbar.
+
+1. **Feature aktivieren:** Die Standardwerte werden über `esphome/components/jutta_proto/jutta_config.h` gesteuert. Dort
+   können `JUTTA_XML_ENABLE`, `JUTTA_XML_POLL_MS` und `JUTTA_XML_RX_TIMEOUT_MS` bei Bedarf angepasst werden. Voreinstellung ist
+   `JUTTA_XML_ENABLE 1`, sodass der XML-Pfad ohne weitere Änderungen aktiv ist.
+2. **XML-Mapping bereitstellen:** Exportiere in der J.O.E.-App die Maschinen-XML und kopiere die Datei als
+   `/data/jura_machine.xml` auf das ESPHome-Gerät. Falls die Datei fehlt oder unvollständig ist, werden Standardbefehle und
+   generische Labels verwendet.
+3. **Zyklische Abfrage beobachten:** Nach erfolgreichem Legacy-Handshake erscheinen im Log Einträge wie `XML poll start`,
+   `TX_DB "@TR:32"`, `RX_DB decoded_len=21 expected=21` sowie `publish TR32=[…]`. Bei einem Timeout wird `RX_DB timeout`
+   ausgegeben. Nur wenn alle drei Blöcke korrekt gelesen werden, werden neue Werte veröffentlicht.
+
+#### Fehlersuche
+
+* **Sensoren tauchen nicht auf:** Prüfe, ob das Feature aktiviert ist und ob beim Start Meldungen zur Sensorregistrierung
+  erscheinen. Sensorinstanzen werden vor dem ersten Home-Assistant-Connect erstellt und mit `set_internal(false)` sichtbar
+  gemacht.
+* **Keine Werteaktualisierung:** Achte auf Logzeilen zu `RX_DB timeout` oder `decoded_len=… expected=…`. Bei laufenden
+  XML-Polls sollten andere Aufgaben den UART nicht nutzen; der Code setzt während eines Polls ein internes Busy-Flag und
+  blockiert konkurrierende Leser.
+
 `[1]`: https://uk.jura.com/en/homeproducts/accessories/SmartConnect-Main-72167

--- a/esphome/components/jutta_proto/__init__.py
+++ b/esphome/components/jutta_proto/__init__.py
@@ -94,7 +94,7 @@ CONFIG_SCHEMA = (
         {
             cv.GenerateID(): cv.declare_id(JuraComponent),
             cv.Optional(CONF_MACHINE_DATA): text_sensor.text_sensor_schema(),
-            cv.Optional(CONF_JUTTA_XML_ENABLE, default=False): cv.boolean,
+            cv.Optional(CONF_JUTTA_XML_ENABLE, default=True): cv.boolean,
             cv.Optional(CONF_JUTTA_XML_POLL_MS, default=30000): cv.positive_int,
             cv.Optional(CONF_JUTTA_XML_RX_TIMEOUT_MS, default=900): cv.positive_int,
         }

--- a/esphome/components/jutta_proto/jutta_config.h
+++ b/esphome/components/jutta_proto/jutta_config.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#ifndef JUTTA_XML_ENABLE
+#define JUTTA_XML_ENABLE 1
+#endif
+
+#ifndef JUTTA_XML_POLL_MS
+#define JUTTA_XML_POLL_MS 30000
+#endif
+
+#ifndef JUTTA_XML_RX_TIMEOUT_MS
+#define JUTTA_XML_RX_TIMEOUT_MS 900
+#endif
+

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -30,12 +30,18 @@ constexpr uint32_t XML_RX_DRAIN_MS = 40;
 
 template<typename AppT>
 auto try_register_sensor(AppT &app, sensor::Sensor *sensor, int)
+    -> decltype(app.register_component(sensor), void()) {
+  app.register_component(sensor);
+}
+
+template<typename AppT>
+auto try_register_sensor(AppT &app, sensor::Sensor *sensor, long)
     -> decltype(app.register_sensor(sensor), void()) {
   app.register_sensor(sensor);
 }
 
 template<typename AppT>
-auto try_register_sensor(AppT &app, sensor::Sensor *sensor, long)
+auto try_register_sensor(AppT &app, sensor::Sensor *sensor, double)
     -> decltype(app.register_entity(sensor), void()) {
   app.register_entity(sensor);
 }
@@ -193,6 +199,20 @@ std::string format_buffer_hex_preview(const std::string &value) {
   return formatted_suffix;
 }
 
+template<typename ArrayT>
+std::string format_numeric_array(const ArrayT &values) {
+  std::ostringstream stream;
+  stream << "[";
+  for (size_t i = 0; i < values.size(); ++i) {
+    if (i > 0) {
+      stream << ", ";
+    }
+    stream << values[i];
+  }
+  stream << "]";
+  return stream.str();
+}
+
 }  // namespace
 
 const char *JuraComponent::handshake_stage_name(JuraComponent::HandshakeStage stage) {
@@ -219,6 +239,18 @@ const char *JuraComponent::handshake_stage_name(JuraComponent::HandshakeStage st
   return "unknown";
 }
 
+JuraComponent::~JuraComponent() {
+  auto cleanup_pool = [](auto &pool) {
+    for (auto *&sensor : pool) {
+      delete sensor;
+      sensor = nullptr;
+    }
+  };
+  cleanup_pool(this->xml_tr32_sensors_);
+  cleanup_pool(this->xml_tg43_sensors_);
+  cleanup_pool(this->xml_tgc0_sensors_);
+}
+
 void JuraComponent::setup() {
   if (this->parent_ == nullptr) {
     ESP_LOGE(TAG, "UART parent not configured for JUTTA Proto component.");
@@ -233,6 +265,10 @@ void JuraComponent::setup() {
   ESP_LOGI(TAG, "Starting handshake with coffee maker...");
 
   this->reset_xml_cycle_state_();
+  if (this->xml_enabled_) {
+    this->load_xml_mapping_();
+    this->ensure_xml_sensors_created_();
+  }
 }
 
 void JuraComponent::loop() {
@@ -250,7 +286,7 @@ void JuraComponent::loop() {
     this->process_handshake();
   }
 
-  if (this->coffee_maker_ != nullptr) {
+  if (this->coffee_maker_ != nullptr && !this->xml_busy_) {
     this->coffee_maker_->loop();
     if (!this->coffee_maker_->is_locked()) {
       this->custom_cancel_flag_ = false;
@@ -547,6 +583,9 @@ void JuraComponent::process_machine_data_query() {
   if (this->is_busy()) {
     return;
   }
+  if (this->xml_busy_) {
+    return;
+  }
 
   uint32_t now = esphome::millis();
 
@@ -605,6 +644,7 @@ void JuraComponent::reset_xml_cycle_state_() {
   this->xml_has_values_ = false;
   this->xml_next_poll_ = 0;
   this->xml_mapping_logged_ = false;
+  this->xml_busy_ = false;
 }
 
 void JuraComponent::ensure_xml_sensors_created_() {
@@ -612,13 +652,14 @@ void JuraComponent::ensure_xml_sensors_created_() {
     return;
   }
   auto create_pool = [&](auto &pool) {
-    for (auto &sensor_ptr : pool) {
+    for (auto *&sensor_ptr : pool) {
       if (sensor_ptr == nullptr) {
-        auto sensor_obj = std::make_unique<sensor::Sensor>();
+        auto *sensor_obj = new sensor::Sensor();
         sensor_obj->set_accuracy_decimals(0);
-        try_set_parent(sensor_obj.get(), this, 0);
-        register_sensor_with_app(sensor_obj.get());
-        sensor_ptr = std::move(sensor_obj);
+        sensor_obj->set_internal(false);
+        try_set_parent(sensor_obj, this, 0);
+        register_sensor_with_app(sensor_obj);
+        sensor_ptr = sensor_obj;
       }
     }
   };
@@ -661,45 +702,56 @@ void JuraComponent::load_xml_mapping_() {
     return;
   }
 
+  bool commands_ok = true;
+  std::string content;
   FILE *file = fopen(XML_MAPPING_PATH, "rb");
   if (file == nullptr) {
     ESP_LOGW(TAG, "Failed to open XML mapping at %s", XML_MAPPING_PATH);
-    return;
+    commands_ok = false;
+  } else {
+    char buffer[256];
+    while (true) {
+      size_t read = fread(buffer, 1, sizeof(buffer), file);
+      if (read == 0) {
+        break;
+      }
+      content.append(buffer, read);
+    }
+    fclose(file);
+
+    auto parse_block = [&](const char *anchor_token, std::string &command, auto &labels) {
+      size_t anchor_pos = content.find(anchor_token);
+      if (anchor_pos == std::string::npos) {
+        commands_ok = false;
+        return;
+      }
+      std::string parsed_command;
+      if (extract_command(content, anchor_pos, parsed_command)) {
+        command = parsed_command;
+      } else {
+        commands_ok = false;
+      }
+      extract_labels(content, anchor_pos, labels);
+    };
+
+    parse_block("TR32", this->xml_mapping_.tr32_command, this->xml_mapping_.tr32_labels);
+    parse_block("TG43", this->xml_mapping_.tg43_command, this->xml_mapping_.tg43_labels);
+    parse_block("TGC0", this->xml_mapping_.tgc0_command, this->xml_mapping_.tgc0_labels);
   }
-
-  std::string content;
-  char buffer[256];
-  while (true) {
-    size_t read = fread(buffer, 1, sizeof(buffer), file);
-    if (read == 0) {
-      break;
-    }
-    content.append(buffer, read);
-  }
-  fclose(file);
-
-  bool commands_ok = true;
-
-  auto parse_block = [&](const char *anchor_token, std::string &command, auto &labels) {
-    size_t anchor_pos = content.find(anchor_token);
-    if (anchor_pos == std::string::npos) {
-      commands_ok = false;
-      return;
-    }
-    std::string parsed_command;
-    if (extract_command(content, anchor_pos, parsed_command)) {
-      command = parsed_command;
-    } else {
-      commands_ok = false;
-    }
-    extract_labels(content, anchor_pos, labels);
-  };
-
-  parse_block("TR32", this->xml_mapping_.tr32_command, this->xml_mapping_.tr32_labels);
-  parse_block("TG43", this->xml_mapping_.tg43_command, this->xml_mapping_.tg43_labels);
-  parse_block("TGC0", this->xml_mapping_.tgc0_command, this->xml_mapping_.tgc0_labels);
 
   this->xml_mapping_.valid = commands_ok;
+  if (!this->xml_mapping_logged_) {
+    size_t tr32_labels = count_non_empty(this->xml_mapping_.tr32_labels);
+    size_t tg43_labels = count_non_empty(this->xml_mapping_.tg43_labels);
+    size_t tgc0_labels = count_non_empty(this->xml_mapping_.tgc0_labels);
+    ESP_LOGI(TAG, "XML mapping valid=%d, cmds=<%s, %s, %s>", static_cast<int>(this->xml_mapping_.valid),
+             this->xml_mapping_.tr32_command.c_str(), this->xml_mapping_.tg43_command.c_str(),
+             this->xml_mapping_.tgc0_command.c_str());
+    ESP_LOGI(TAG, "XML labels: TR32=%u, TG43=%u, TGC0=%u", static_cast<unsigned>(tr32_labels),
+             static_cast<unsigned>(tg43_labels), static_cast<unsigned>(tgc0_labels));
+    this->xml_mapping_logged_ = true;
+  }
+  this->update_sensor_names_();
 }
 
 void JuraComponent::process_xml_polling() {
@@ -716,6 +768,10 @@ void JuraComponent::process_xml_polling() {
     return;
   }
 
+  if (this->xml_busy_) {
+    return;
+  }
+
   uint32_t now = esphome::millis();
 
   if (!this->xml_initialized_) {
@@ -723,17 +779,6 @@ void JuraComponent::process_xml_polling() {
     this->ensure_xml_sensors_created_();
     this->xml_initialized_ = true;
     this->xml_next_poll_ = now;
-    if (!this->xml_mapping_logged_) {
-      size_t tr32_labels = count_non_empty(this->xml_mapping_.tr32_labels);
-      size_t tg43_labels = count_non_empty(this->xml_mapping_.tg43_labels);
-      size_t tgc0_labels = count_non_empty(this->xml_mapping_.tgc0_labels);
-      ESP_LOGI(TAG,
-               "XML mapping valid=%d tr32=%s(%zu) tg43=%s(%zu) tgc0=%s(%zu)",
-               this->xml_mapping_.valid ? 1 : 0, this->xml_mapping_.tr32_command.c_str(),
-               tr32_labels, this->xml_mapping_.tg43_command.c_str(), tg43_labels,
-               this->xml_mapping_.tgc0_command.c_str(), tgc0_labels);
-      this->xml_mapping_logged_ = true;
-    }
     return;
   }
 
@@ -741,6 +786,7 @@ void JuraComponent::process_xml_polling() {
     return;
   }
 
+  ESP_LOGD(TAG, "XML poll start");
   if (this->perform_xml_cycle_()) {
     this->publish_xml_values_();
   }
@@ -748,11 +794,21 @@ void JuraComponent::process_xml_polling() {
 }
 
 bool JuraComponent::perform_xml_cycle_() {
-  auto *link = this->coffee_maker_->connection.get();
-  if (link == nullptr) {
+  if (this->coffee_maker_ == nullptr || this->coffee_maker_->connection == nullptr) {
+    return false;
+  }
+  if (this->xml_busy_) {
+    ESP_LOGW(TAG, "XML poll skipped because connection is busy.");
     return false;
   }
 
+  struct BusyGuard {
+    bool &flag;
+    explicit BusyGuard(bool &ref) : flag(ref) { flag = true; }
+    ~BusyGuard() { flag = false; }
+  } guard(this->xml_busy_);
+
+  auto *link = this->coffee_maker_->connection.get();
   link->drain_db_stream(std::chrono::milliseconds{XML_RX_DRAIN_MS});
 
   std::vector<uint16_t> tr32_values;
@@ -787,13 +843,18 @@ bool JuraComponent::poll_xml_block_(const std::string &command, std::vector<uint
   std::vector<uint8_t> decoded;
   ESP_LOGD(TAG, "TX_DB \"%s\"", command.c_str());
   if (!this->send_db_command_(command)) {
-    ESP_LOGD(TAG, "RX_DB decoded_len=0 ok=0");
+    ESP_LOGW(TAG, "Failed to send XML command %s", command.c_str());
     return false;
   }
   bool frame_ok = this->read_db_frame_(decoded, this->xml_rx_timeout_ms_);
-  bool length_ok = frame_ok && decoded.size() == 1 + expected_count * 2;
-  ESP_LOGD(TAG, "RX_DB decoded_len=%zu ok=%d", decoded.size(), static_cast<int>(frame_ok && length_ok));
-  if (!frame_ok || !length_ok) {
+  size_t expected_len = 1 + expected_count * 2;
+  if (!frame_ok) {
+    ESP_LOGW(TAG, "RX_DB timeout");
+    return false;
+  }
+  ESP_LOGD(TAG, "RX_DB decoded_len=%zu expected=%zu", decoded.size(), expected_len);
+  if (decoded.size() != expected_len) {
+    ESP_LOGW(TAG, "decoded_len=%zu expected=%zu", decoded.size(), expected_len);
     return false;
   }
   out_values_u16.clear();
@@ -812,13 +873,18 @@ bool JuraComponent::poll_xml_block_(const std::string &command, std::vector<uint
   std::vector<uint8_t> decoded;
   ESP_LOGD(TAG, "TX_DB \"%s\"", command.c_str());
   if (!this->send_db_command_(command)) {
-    ESP_LOGD(TAG, "RX_DB decoded_len=0 ok=0");
+    ESP_LOGW(TAG, "Failed to send XML command %s", command.c_str());
     return false;
   }
   bool frame_ok = this->read_db_frame_(decoded, this->xml_rx_timeout_ms_);
-  bool length_ok = frame_ok && decoded.size() == 1 + expected_count * 4;
-  ESP_LOGD(TAG, "RX_DB decoded_len=%zu ok=%d", decoded.size(), static_cast<int>(frame_ok && length_ok));
-  if (!frame_ok || !length_ok) {
+  size_t expected_len = 1 + expected_count * 4;
+  if (!frame_ok) {
+    ESP_LOGW(TAG, "RX_DB timeout");
+    return false;
+  }
+  ESP_LOGD(TAG, "RX_DB decoded_len=%zu expected=%zu", decoded.size(), expected_len);
+  if (decoded.size() != expected_len) {
+    ESP_LOGW(TAG, "decoded_len=%zu expected=%zu", decoded.size(), expected_len);
     return false;
   }
   out_values_u32.clear();
@@ -852,6 +918,10 @@ void JuraComponent::publish_xml_values_() {
   if (!this->xml_enabled_ || !this->xml_has_values_) {
     return;
   }
+  ESP_LOGD(TAG, "publish TR32=%s TG43=%s TGC0=%s",
+           format_numeric_array(this->xml_tr32_values_).c_str(),
+           format_numeric_array(this->xml_tg43_values_).c_str(),
+           format_numeric_array(this->xml_tgc0_values_).c_str());
   for (size_t i = 0; i < this->xml_tr32_sensors_.size(); ++i) {
     if (this->xml_tr32_sensors_[i] != nullptr) {
       this->xml_tr32_sensors_[i]->publish_state(static_cast<float>(this->xml_tr32_values_[i]));

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -30,6 +30,7 @@ class Sensor {
   virtual void publish_state(float) {}
   virtual void set_accuracy_decimals(int) {}
   virtual void set_name(const std::string &) {}
+  virtual void set_internal(bool) {}
 };
 
 }  // namespace sensor
@@ -65,6 +66,7 @@ class TextSensor {
 #include "esphome/components/uart/uart.h"
 
 #include "coffee_maker.hpp"
+#include "jutta_config.h"
 #include "jutta_connection.hpp"
 #include "jutta_commands.hpp"
 
@@ -73,6 +75,7 @@ namespace jutta_component {
 
 class JuraComponent : public esphome::Component, public esphome::uart::UARTDevice {
  public:
+  ~JuraComponent() override;
   void setup() override;
   void loop() override;
   void dump_config() override;
@@ -88,7 +91,14 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   const std::string &device_type() const { return this->device_type_; }
 
   void set_machine_data_sensor(text_sensor::TextSensor *sensor) { this->machine_data_sensor_ = sensor; }
-  void set_xml_enabled(bool enabled) { this->xml_enabled_ = enabled; }
+  void set_xml_enabled(bool enabled) {
+#if JUTTA_XML_ENABLE
+    this->xml_enabled_ = enabled;
+#else
+    (void) enabled;
+    this->xml_enabled_ = false;
+#endif
+  }
   void set_xml_poll_interval(uint32_t interval_ms) { this->xml_poll_interval_ms_ = interval_ms; }
   void set_xml_rx_timeout(uint32_t timeout_ms) { this->xml_rx_timeout_ms_ = timeout_ms; }
 
@@ -144,19 +154,20 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   };
 
   XmlMapping xml_mapping_{};
-  bool xml_enabled_{false};
-  uint32_t xml_poll_interval_ms_{30000};
-  uint32_t xml_rx_timeout_ms_{900};
+  bool xml_enabled_{JUTTA_XML_ENABLE != 0};
+  uint32_t xml_poll_interval_ms_{JUTTA_XML_POLL_MS};
+  uint32_t xml_rx_timeout_ms_{JUTTA_XML_RX_TIMEOUT_MS};
   uint32_t xml_next_poll_{0};
   bool xml_initialized_{false};
   bool xml_mapping_logged_{false};
-  std::array<std::unique_ptr<sensor::Sensor>, 10> xml_tr32_sensors_{};
-  std::array<std::unique_ptr<sensor::Sensor>, 6> xml_tg43_sensors_{};
-  std::array<std::unique_ptr<sensor::Sensor>, 3> xml_tgc0_sensors_{};
+  std::array<sensor::Sensor *, 10> xml_tr32_sensors_{};
+  std::array<sensor::Sensor *, 6> xml_tg43_sensors_{};
+  std::array<sensor::Sensor *, 3> xml_tgc0_sensors_{};
   std::array<uint16_t, 10> xml_tr32_values_{};
   std::array<uint16_t, 6> xml_tg43_values_{};
   std::array<uint32_t, 3> xml_tgc0_values_{};
   bool xml_has_values_{false};
+  bool xml_busy_{false};
 };
 
 class StartBrewAction : public esphome::Action<> {


### PR DESCRIPTION
## Summary
- add a compile-time configuration header for the XML poller and enable the feature by default in the component schema
- create and register XML sensor pools during setup so Home Assistant entities are present before the first connection
- harden the XML polling loop with busy-flag coordination, mapping logging, length/timeout checks, and structured publish logging, and document the workflow in the README

## Testing
- python -m compileall esphome/components/jutta_proto

------
https://chatgpt.com/codex/tasks/task_e_68dff1cea9bc8328b70c6e611660ae00