### PR TITLE
Handle DB echo frames for XML polling

### DIFF
--- a/docs/components/jutta_proto.md
+++ b/docs/components/jutta_proto.md
@@ -43,6 +43,13 @@ published only after a complete, valid DB frame was received for the respective 
 If the XML mapping provides labels for a block, those replace the defaults in the same order. All sensors report integers
 with `accuracy_decimals: 0`, so no templating is required on the ESPHome side.
 
+### DB frame handling
+
+The XML transport uses escaped DB frames. Some legacy Wi-Fi bridges reply with an ASCII echo of the `@TR:32`, `@TG:43`, or
+`@TG:C0` command before the actual data frame arrives. The component drains the UART briefly before the first command in a
+poll cycle, skips such echo frames automatically, and validates the decoded payload length (21/13/13 bytes). Only complete
+and valid data frames update the sensor values; incomplete cycles simply keep the previous readings.
+
 ## Automation Actions
 
 Use the registered actions inside automations or button handlers. When only one `jutta_proto` component is configured, the

--- a/esphome/components/jutta_proto/jutta_connection.cpp
+++ b/esphome/components/jutta_proto/jutta_connection.cpp
@@ -8,6 +8,7 @@
 #include <iomanip>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include "esphome/core/log.h"
 #include "esphome/core/time.h"
 
@@ -509,28 +510,58 @@ bool JuttaConnection::write_db_command(const std::string& command) {
 bool JuttaConnection::read_db_frame(std::vector<uint8_t>& decoded, const std::chrono::milliseconds& timeout) {
     decoded.clear();
     std::vector<uint8_t> encoded;
-    if (!this->read_db_frame_encoded_(encoded, timeout)) {
+    if (!this->read_one_db_frame_with_trailer_(encoded, timeout)) {
         return false;
     }
-    if (encoded.size() < DB_TRAILER_ENCODED.size()) {
-        return false;
-    }
-    encoded.resize(encoded.size() - DB_TRAILER_ENCODED.size());
+    return this->unescape_db_frame_(encoded, decoded);
+}
+
+bool JuttaConnection::read_db_data_frame(std::vector<uint8_t>& decoded, const std::chrono::milliseconds& timeout,
+                                         std::string_view last_cmd_ascii) {
     decoded.clear();
-    decoded.reserve(encoded.size());
-    for (size_t i = 0; i < encoded.size();) {
-        uint8_t byte = encoded[i++];
-        if (byte == DB_ESCAPE) {
-            if (i >= encoded.size()) {
+    const uint32_t start = esphome::millis();
+    while (true) {
+        std::chrono::milliseconds remaining = timeout;
+        if (timeout.count() > 0) {
+            uint32_t elapsed = esphome::millis() - start;
+            if (static_cast<int32_t>(elapsed - static_cast<uint32_t>(timeout.count())) >= 0) {
                 return false;
             }
-            uint8_t escaped = encoded[i++];
-            decoded.push_back(static_cast<uint8_t>(escaped ^ DB_XOR_MASK));
-        } else {
-            decoded.push_back(byte);
+            uint32_t timeout_ms = static_cast<uint32_t>(timeout.count());
+            if (elapsed < timeout_ms) {
+                remaining = std::chrono::milliseconds{timeout_ms - elapsed};
+            } else {
+                remaining = std::chrono::milliseconds{0};
+            }
         }
+
+        std::vector<uint8_t> candidate;
+        if (!this->read_db_frame(candidate, remaining)) {
+            return false;
+        }
+
+        bool is_echo = false;
+        if (!last_cmd_ascii.empty() && !candidate.empty()) {
+            is_echo = std::all_of(candidate.begin(), candidate.end(), [](uint8_t b) {
+                return b >= 0x20 && b <= 0x7E;
+            });
+            if (is_echo) {
+                std::string_view view(reinterpret_cast<const char*>(candidate.data()), candidate.size());
+                if (view != last_cmd_ascii) {
+                    is_echo = false;
+                }
+            }
+        }
+
+        if (is_echo) {
+            ESP_LOGD("jutta_proto", "RX_DB echo ignored: \"%.*s\"", static_cast<int>(candidate.size()),
+                     reinterpret_cast<const char*>(candidate.data()));
+            continue;
+        }
+
+        decoded.swap(candidate);
+        return true;
     }
-    return true;
 }
 
 void JuttaConnection::drain_db_stream(const std::chrono::milliseconds& duration) {
@@ -561,8 +592,8 @@ bool JuttaConnection::write_db_encoded_(const std::vector<uint8_t>& encoded) {
     return true;
 }
 
-bool JuttaConnection::read_db_frame_encoded_(std::vector<uint8_t>& encoded,
-                                             const std::chrono::milliseconds& timeout) {
+bool JuttaConnection::read_one_db_frame_with_trailer_(std::vector<uint8_t>& encoded,
+                                                      const std::chrono::milliseconds& timeout) {
     encoded.clear();
     uint32_t start = esphome::millis();
     std::array<uint8_t, 4> buffer{};
@@ -573,6 +604,7 @@ bool JuttaConnection::read_db_frame_encoded_(std::vector<uint8_t>& encoded,
             if (encoded.size() >= DB_TRAILER_ENCODED.size()) {
                 if (std::equal(DB_TRAILER_ENCODED.begin(), DB_TRAILER_ENCODED.end(),
                                encoded.end() - DB_TRAILER_ENCODED.size())) {
+                    encoded.resize(encoded.size() - DB_TRAILER_ENCODED.size());
                     return true;
                 }
             }
@@ -588,6 +620,25 @@ bool JuttaConnection::read_db_frame_encoded_(std::vector<uint8_t>& encoded,
         esphome::delay(5);
     }
     return false;
+}
+
+bool JuttaConnection::unescape_db_frame_(const std::vector<uint8_t>& encoded, std::vector<uint8_t>& decoded) const {
+    decoded.clear();
+    decoded.reserve(encoded.size());
+    for (size_t i = 0; i < encoded.size(); ++i) {
+        uint8_t byte = encoded[i];
+        if (byte == DB_ESCAPE) {
+            ++i;
+            if (i >= encoded.size()) {
+                return false;
+            }
+            uint8_t escaped = encoded[i];
+            decoded.push_back(static_cast<uint8_t>(escaped ^ DB_XOR_MASK));
+        } else {
+            decoded.push_back(byte);
+        }
+    }
+    return true;
 }
 
 

--- a/esphome/components/jutta_proto/jutta_connection.hpp
+++ b/esphome/components/jutta_proto/jutta_connection.hpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 #include <deque>
 
@@ -122,6 +123,13 @@ class JuttaConnection {
      * Returns true on success.
      */
     bool read_db_frame(std::vector<uint8_t>& decoded, const std::chrono::milliseconds& timeout);
+
+    /**
+     * Reads DB framed responses while skipping optional ASCII echo frames that exactly match the
+     * provided command. The decoded payload of the first non-echo frame is stored in "decoded".
+     */
+    bool read_db_data_frame(std::vector<uint8_t>& decoded, const std::chrono::milliseconds& timeout,
+                            std::string_view last_cmd_ascii);
 
     /**
      * Drains incoming DB stream bytes for the specified duration.
@@ -305,7 +313,9 @@ class JuttaConnection {
     void reinject_decoded_front(const std::string& data) const;
 
     bool write_db_encoded_(const std::vector<uint8_t>& encoded);
-    bool read_db_frame_encoded_(std::vector<uint8_t>& encoded, const std::chrono::milliseconds& timeout);
+    bool read_one_db_frame_with_trailer_(std::vector<uint8_t>& encoded,
+                                         const std::chrono::milliseconds& timeout);
+    bool unescape_db_frame_(const std::vector<uint8_t>& encoded, std::vector<uint8_t>& decoded) const;
 
 };
 //---------------------------------------------------------------------------

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -818,92 +818,67 @@ bool JuraComponent::perform_xml_cycle_() {
   auto *link = this->coffee_maker_->connection.get();
   link->drain_db_stream(std::chrono::milliseconds{XML_RX_DRAIN_MS});
 
-  std::vector<uint16_t> tr32_values;
-  std::vector<uint16_t> tg43_values;
-  std::vector<uint32_t> tgc0_values;
+  std::vector<uint8_t> buffer;
+  std::array<uint16_t, XML_TR32_COUNT> tr32_values{};
+  std::array<uint16_t, XML_TG43_COUNT> tg43_values{};
+  std::array<uint32_t, XML_TGC0_COUNT> tgc0_values{};
 
-  if (!this->poll_xml_block_(this->xml_mapping_.tr32_command, tr32_values, XML_TR32_COUNT)) {
+  auto parse_u16 = [](const std::vector<uint8_t> &src, auto &dest) {
+    for (size_t i = 0; i < dest.size(); ++i) {
+      size_t offset = 1 + i * 2;
+      dest[i] = static_cast<uint16_t>((static_cast<uint16_t>(src[offset]) << 8) |
+                                      static_cast<uint16_t>(src[offset + 1]));
+    }
+  };
+  auto parse_u32 = [](const std::vector<uint8_t> &src, auto &dest) {
+    for (size_t i = 0; i < dest.size(); ++i) {
+      size_t offset = 1 + i * 4;
+      dest[i] = (static_cast<uint32_t>(src[offset]) << 24) |
+                (static_cast<uint32_t>(src[offset + 1]) << 16) |
+                (static_cast<uint32_t>(src[offset + 2]) << 8) |
+                static_cast<uint32_t>(src[offset + 3]);
+    }
+  };
+
+  auto read_block = [&](const std::string &command, size_t expected_length, auto &&parser) -> bool {
+    ESP_LOGD(TAG, "TX_DB \"%s\"", command.c_str());
+    if (!this->send_db_command_(command)) {
+      ESP_LOGW(TAG, "Failed to send XML command %s", command.c_str());
+      return false;
+    }
+    if (!this->read_db_data_frame_(buffer, this->xml_rx_timeout_ms_, command)) {
+      ESP_LOGW(TAG, "RX_DB timeout");
+      return false;
+    }
+    ESP_LOGD(TAG, "RX_DB decoded_len=%zu", buffer.size());
+    if (buffer.size() != expected_length) {
+      ESP_LOGW(TAG, "decoded_len=%zu expected=%zu", buffer.size(), expected_length);
+      return false;
+    }
+    parser(buffer);
+    return true;
+  };
+
+  if (!read_block(this->xml_mapping_.tr32_command, 1 + XML_TR32_COUNT * 2, [&](const std::vector<uint8_t> &src) {
+        parse_u16(src, tr32_values);
+      })) {
     return false;
   }
-  if (!this->poll_xml_block_(this->xml_mapping_.tg43_command, tg43_values, XML_TG43_COUNT)) {
+  if (!read_block(this->xml_mapping_.tg43_command, 1 + XML_TG43_COUNT * 2, [&](const std::vector<uint8_t> &src) {
+        parse_u16(src, tg43_values);
+      })) {
     return false;
   }
-  if (!this->poll_xml_block_(this->xml_mapping_.tgc0_command, tgc0_values, XML_TGC0_COUNT)) {
+  if (!read_block(this->xml_mapping_.tgc0_command, 1 + XML_TGC0_COUNT * 4, [&](const std::vector<uint8_t> &src) {
+        parse_u32(src, tgc0_values);
+      })) {
     return false;
   }
 
-  for (size_t i = 0; i < XML_TR32_COUNT; ++i) {
-    this->xml_tr32_values_[i] = tr32_values[i];
-  }
-  for (size_t i = 0; i < XML_TG43_COUNT; ++i) {
-    this->xml_tg43_values_[i] = tg43_values[i];
-  }
-  for (size_t i = 0; i < XML_TGC0_COUNT; ++i) {
-    this->xml_tgc0_values_[i] = tgc0_values[i];
-  }
+  this->xml_tr32_values_ = tr32_values;
+  this->xml_tg43_values_ = tg43_values;
+  this->xml_tgc0_values_ = tgc0_values;
   this->xml_has_values_ = true;
-  return true;
-}
-
-bool JuraComponent::poll_xml_block_(const std::string &command, std::vector<uint16_t> &out_values_u16,
-                                    size_t expected_count) {
-  std::vector<uint8_t> decoded;
-  ESP_LOGD(TAG, "TX_DB \"%s\"", command.c_str());
-  if (!this->send_db_command_(command)) {
-    ESP_LOGW(TAG, "Failed to send XML command %s", command.c_str());
-    return false;
-  }
-  bool frame_ok = this->read_db_frame_(decoded, this->xml_rx_timeout_ms_);
-  size_t expected_len = 1 + expected_count * 2;
-  if (!frame_ok) {
-    ESP_LOGW(TAG, "RX_DB timeout");
-    return false;
-  }
-  ESP_LOGD(TAG, "RX_DB decoded_len=%zu expected=%zu", decoded.size(), expected_len);
-  if (decoded.size() != expected_len) {
-    ESP_LOGW(TAG, "decoded_len=%zu expected=%zu", decoded.size(), expected_len);
-    return false;
-  }
-  out_values_u16.clear();
-  out_values_u16.reserve(expected_count);
-  for (size_t i = 0; i < expected_count; ++i) {
-    size_t offset = 1 + i * 2;
-    uint16_t value = static_cast<uint16_t>((static_cast<uint16_t>(decoded[offset]) << 8) |
-                                           static_cast<uint16_t>(decoded[offset + 1]));
-    out_values_u16.push_back(value);
-  }
-  return true;
-}
-
-bool JuraComponent::poll_xml_block_(const std::string &command, std::vector<uint32_t> &out_values_u32,
-                                    size_t expected_count) {
-  std::vector<uint8_t> decoded;
-  ESP_LOGD(TAG, "TX_DB \"%s\"", command.c_str());
-  if (!this->send_db_command_(command)) {
-    ESP_LOGW(TAG, "Failed to send XML command %s", command.c_str());
-    return false;
-  }
-  bool frame_ok = this->read_db_frame_(decoded, this->xml_rx_timeout_ms_);
-  size_t expected_len = 1 + expected_count * 4;
-  if (!frame_ok) {
-    ESP_LOGW(TAG, "RX_DB timeout");
-    return false;
-  }
-  ESP_LOGD(TAG, "RX_DB decoded_len=%zu expected=%zu", decoded.size(), expected_len);
-  if (decoded.size() != expected_len) {
-    ESP_LOGW(TAG, "decoded_len=%zu expected=%zu", decoded.size(), expected_len);
-    return false;
-  }
-  out_values_u32.clear();
-  out_values_u32.reserve(expected_count);
-  for (size_t i = 0; i < expected_count; ++i) {
-    size_t offset = 1 + i * 4;
-    uint32_t value = (static_cast<uint32_t>(decoded[offset]) << 24) |
-                     (static_cast<uint32_t>(decoded[offset + 1]) << 16) |
-                     (static_cast<uint32_t>(decoded[offset + 2]) << 8) |
-                     static_cast<uint32_t>(decoded[offset + 3]);
-    out_values_u32.push_back(value);
-  }
   return true;
 }
 
@@ -914,11 +889,13 @@ bool JuraComponent::send_db_command_(const std::string &command) {
   return this->coffee_maker_->connection->write_db_command(command);
 }
 
-bool JuraComponent::read_db_frame_(std::vector<uint8_t> &decoded, uint32_t timeout_ms) {
+bool JuraComponent::read_db_data_frame_(std::vector<uint8_t> &decoded, uint32_t timeout_ms,
+                                        std::string_view last_cmd_ascii) {
   if (this->coffee_maker_ == nullptr || this->coffee_maker_->connection == nullptr) {
     return false;
   }
-  return this->coffee_maker_->connection->read_db_frame(decoded, std::chrono::milliseconds{timeout_ms});
+  return this->coffee_maker_->connection->read_db_data_frame(decoded, std::chrono::milliseconds{timeout_ms},
+                                                             last_cmd_ascii);
 }
 
 void JuraComponent::publish_xml_values_() {

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "esphome/core/automation.h"
@@ -118,11 +119,8 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   void ensure_xml_sensors_created_();
   void reset_xml_cycle_state_();
   bool perform_xml_cycle_();
-  bool poll_xml_block_(const std::string &command, std::vector<uint16_t> &out_values_u16,
-                       size_t expected_count);
-  bool poll_xml_block_(const std::string &command, std::vector<uint32_t> &out_values_u32,
-                       size_t expected_count);
-  bool read_db_frame_(std::vector<uint8_t> &decoded, uint32_t timeout_ms);
+  bool read_db_data_frame_(std::vector<uint8_t> &decoded, uint32_t timeout_ms,
+                           std::string_view last_cmd_ascii);
   bool send_db_command_(const std::string &command);
   void publish_xml_values_();
   void update_sensor_names_();


### PR DESCRIPTION
## Summary
- add a DB data frame reader that skips ASCII echo replies and reuses the existing decoder
- enforce the expected XML block lengths, aborting the cycle without publishing on mismatches
- document the new DB handling behaviour for XML polling sensors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e01b31f5a483288b8cfd16c8d334b3