### PR TITLE
Improve DB frame parsing and XML polling robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,4 +271,19 @@ registriert und bleiben dauerhaft sichtbar.
   XML-Polls sollten andere Aufgaben den UART nicht nutzen; der Code setzt während eines Polls ein internes Busy-Flag und
   blockiert konkurrierende Leser.
 
+#### Datenrahmen-Handling
+
+**Beschreibung:** Der Jura-Dongle sendet auf DB-Kommandos wie `@TR:32` oft zuerst ein Echo-Frame mit dem ASCII des Befehls
+und danach das Daten-Frame. Der Reader erkennt den encoded Trailer `DF FF DB DB FB FB DB DB`, entfernt ihn, unescaped
+`0xDB xx → xx^0x20`, verwirft Echo-Frames und liest weiter, bis ein Daten-Frame mit der erwarteten Decoded-Länge vorliegt:
+TR32=21, TG43=13, TGC0=13. Sensoren werden beim Start registriert, Werte nur bei vollständigem Erfolg publiziert. Keine
+Textsensoren, keine HA-Templates erforderlich.
+
+**Troubleshooting:**
+
+* `decoded_len ≠ erwartet` → Reader wartet weiter innerhalb des Gesamt-Timeouts.
+* `RX_DB timeout` → `JUTTA_XML_RX_TIMEOUT_MS` erhöhen und sicherstellen, dass während des Polls kein anderer Code
+  `uart.read()` konsumiert.
+* Sensoren fehlen → Pools in `setup()` registrieren, `set_internal(false)`.
+
 `[1]`: https://uk.jura.com/en/homeproducts/accessories/SmartConnect-Main-72167

--- a/esphome/components/jutta_proto/__init__.py
+++ b/esphome/components/jutta_proto/__init__.py
@@ -96,7 +96,7 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_MACHINE_DATA): text_sensor.text_sensor_schema(),
             cv.Optional(CONF_JUTTA_XML_ENABLE, default=True): cv.boolean,
             cv.Optional(CONF_JUTTA_XML_POLL_MS, default=30000): cv.positive_int,
-            cv.Optional(CONF_JUTTA_XML_RX_TIMEOUT_MS, default=900): cv.positive_int,
+            cv.Optional(CONF_JUTTA_XML_RX_TIMEOUT_MS, default=1500): cv.positive_int,
         }
     )
     .extend(uart.UART_DEVICE_SCHEMA)

--- a/esphome/components/jutta_proto/jutta_config.h
+++ b/esphome/components/jutta_proto/jutta_config.h
@@ -9,6 +9,6 @@
 #endif
 
 #ifndef JUTTA_XML_RX_TIMEOUT_MS
-#define JUTTA_XML_RX_TIMEOUT_MS 900
+#define JUTTA_XML_RX_TIMEOUT_MS 1500
 #endif
 

--- a/esphome/components/jutta_proto/jutta_connection.cpp
+++ b/esphome/components/jutta_proto/jutta_connection.cpp
@@ -114,6 +114,22 @@ bool try_extract_line(std::string& buffer, std::string& line) {
     return true;
 }
 
+inline bool is_printable_ascii(uint8_t byte) {
+    return byte >= 0x20 && byte <= 0x7E;
+}
+
+bool is_ascii_equal(const std::vector<uint8_t>& dec, std::string_view cmd) {
+    if (dec.size() != cmd.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < cmd.size(); ++i) {
+        if (dec[i] != static_cast<uint8_t>(cmd[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
 inline bool is_possible_encoded_byte(uint8_t byte) {
     switch (byte) {
         case JUTTA_ENCODE_BASE:
@@ -510,7 +526,7 @@ bool JuttaConnection::write_db_command(const std::string& command) {
 bool JuttaConnection::read_db_frame(std::vector<uint8_t>& decoded, const std::chrono::milliseconds& timeout) {
     decoded.clear();
     std::vector<uint8_t> encoded;
-    if (!this->read_one_db_frame_with_trailer_(encoded, timeout)) {
+    if (!this->read_one_db_frame_encoded_(encoded, timeout)) {
         return false;
     }
     return this->unescape_db_frame_(encoded, decoded);
@@ -520,40 +536,31 @@ bool JuttaConnection::read_db_data_frame(std::vector<uint8_t>& decoded, const st
                                          std::string_view last_cmd_ascii) {
     decoded.clear();
     const uint32_t start = esphome::millis();
+    std::vector<uint8_t> encoded;
+    std::vector<uint8_t> candidate;
     while (true) {
-        std::chrono::milliseconds remaining = timeout;
+        uint32_t remaining_ms = 0;
         if (timeout.count() > 0) {
-            uint32_t elapsed = esphome::millis() - start;
-            if (static_cast<int32_t>(elapsed - static_cast<uint32_t>(timeout.count())) >= 0) {
+            uint32_t now = esphome::millis();
+            uint32_t elapsed = now - start;
+            uint32_t timeout_ms = static_cast<uint32_t>(timeout.count());
+            if (elapsed >= timeout_ms) {
                 return false;
             }
-            uint32_t timeout_ms = static_cast<uint32_t>(timeout.count());
-            if (elapsed < timeout_ms) {
-                remaining = std::chrono::milliseconds{timeout_ms - elapsed};
-            } else {
-                remaining = std::chrono::milliseconds{0};
-            }
+            remaining_ms = timeout_ms - elapsed;
         }
 
-        std::vector<uint8_t> candidate;
-        if (!this->read_db_frame(candidate, remaining)) {
+        if (!this->read_one_db_frame_encoded_(encoded, std::chrono::milliseconds{remaining_ms})) {
             return false;
         }
 
-        bool is_echo = false;
-        if (!last_cmd_ascii.empty() && !candidate.empty()) {
-            is_echo = std::all_of(candidate.begin(), candidate.end(), [](uint8_t b) {
-                return b >= 0x20 && b <= 0x7E;
-            });
-            if (is_echo) {
-                std::string_view view(reinterpret_cast<const char*>(candidate.data()), candidate.size());
-                if (view != last_cmd_ascii) {
-                    is_echo = false;
-                }
-            }
+        candidate.clear();
+        if (!this->unescape_db_frame_(encoded, candidate)) {
+            return false;
         }
 
-        if (is_echo) {
+        bool ascii = std::all_of(candidate.begin(), candidate.end(), is_printable_ascii);
+        if (ascii && !last_cmd_ascii.empty() && is_ascii_equal(candidate, last_cmd_ascii)) {
             ESP_LOGD("jutta_proto", "RX_DB echo ignored: \"%.*s\"", static_cast<int>(candidate.size()),
                      reinterpret_cast<const char*>(candidate.data()));
             continue;
@@ -592,8 +599,8 @@ bool JuttaConnection::write_db_encoded_(const std::vector<uint8_t>& encoded) {
     return true;
 }
 
-bool JuttaConnection::read_one_db_frame_with_trailer_(std::vector<uint8_t>& encoded,
-                                                      const std::chrono::milliseconds& timeout) {
+bool JuttaConnection::read_one_db_frame_encoded_(std::vector<uint8_t>& encoded,
+                                                 const std::chrono::milliseconds& timeout) {
     encoded.clear();
     uint32_t start = esphome::millis();
     std::array<uint8_t, 4> buffer{};
@@ -611,13 +618,13 @@ bool JuttaConnection::read_one_db_frame_with_trailer_(std::vector<uint8_t>& enco
             continue;
         }
         if (timeout.count() == 0) {
-            esphome::delay(5);
+            esphome::delay(1);
             continue;
         }
         if (static_cast<int32_t>(esphome::millis() - start - timeout.count()) >= 0) {
             break;
         }
-        esphome::delay(5);
+        esphome::delay(1);
     }
     return false;
 }
@@ -625,14 +632,13 @@ bool JuttaConnection::read_one_db_frame_with_trailer_(std::vector<uint8_t>& enco
 bool JuttaConnection::unescape_db_frame_(const std::vector<uint8_t>& encoded, std::vector<uint8_t>& decoded) const {
     decoded.clear();
     decoded.reserve(encoded.size());
-    for (size_t i = 0; i < encoded.size(); ++i) {
-        uint8_t byte = encoded[i];
+    for (size_t i = 0; i < encoded.size();) {
+        uint8_t byte = encoded[i++];
         if (byte == DB_ESCAPE) {
-            ++i;
             if (i >= encoded.size()) {
                 return false;
             }
-            uint8_t escaped = encoded[i];
+            uint8_t escaped = encoded[i++];
             decoded.push_back(static_cast<uint8_t>(escaped ^ DB_XOR_MASK));
         } else {
             decoded.push_back(byte);

--- a/esphome/components/jutta_proto/jutta_connection.hpp
+++ b/esphome/components/jutta_proto/jutta_connection.hpp
@@ -313,8 +313,8 @@ class JuttaConnection {
     void reinject_decoded_front(const std::string& data) const;
 
     bool write_db_encoded_(const std::vector<uint8_t>& encoded);
-    bool read_one_db_frame_with_trailer_(std::vector<uint8_t>& encoded,
-                                         const std::chrono::milliseconds& timeout);
+    bool read_one_db_frame_encoded_(std::vector<uint8_t>& encoded,
+                                    const std::chrono::milliseconds& timeout);
     bool unescape_db_frame_(const std::vector<uint8_t>& encoded, std::vector<uint8_t>& decoded) const;
 
 };

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -846,13 +846,7 @@ bool JuraComponent::perform_xml_cycle_() {
       ESP_LOGW(TAG, "Failed to send XML command %s", command.c_str());
       return false;
     }
-    if (!this->read_db_data_frame_(buffer, this->xml_rx_timeout_ms_, command)) {
-      ESP_LOGW(TAG, "RX_DB timeout");
-      return false;
-    }
-    ESP_LOGD(TAG, "RX_DB decoded_len=%zu", buffer.size());
-    if (buffer.size() != expected_length) {
-      ESP_LOGW(TAG, "decoded_len=%zu expected=%zu", buffer.size(), expected_length);
+    if (!this->read_db_with_expected_len_(buffer, this->xml_rx_timeout_ms_, command, expected_length)) {
       return false;
     }
     parser(buffer);
@@ -896,6 +890,35 @@ bool JuraComponent::read_db_data_frame_(std::vector<uint8_t> &decoded, uint32_t 
   }
   return this->coffee_maker_->connection->read_db_data_frame(decoded, std::chrono::milliseconds{timeout_ms},
                                                              last_cmd_ascii);
+}
+
+bool JuraComponent::read_db_with_expected_len_(std::vector<uint8_t> &decoded, uint32_t total_timeout_ms,
+                                               std::string_view cmd, size_t expected_len) {
+  const uint32_t start = esphome::millis();
+  while (true) {
+    uint32_t remaining = 0;
+    if (total_timeout_ms > 0) {
+      uint32_t now = esphome::millis();
+      uint32_t elapsed = now - start;
+      if (elapsed >= total_timeout_ms) {
+        ESP_LOGW(TAG, "RX_DB timeout");
+        return false;
+      }
+      remaining = total_timeout_ms - elapsed;
+    }
+
+    if (!this->read_db_data_frame_(decoded, remaining, cmd)) {
+      ESP_LOGW(TAG, "RX_DB timeout");
+      return false;
+    }
+
+    ESP_LOGD(TAG, "RX_DB decoded_len=%zu", decoded.size());
+    if (decoded.size() == expected_len) {
+      return true;
+    }
+
+    ESP_LOGW(TAG, "RX_DB decoded_len=%zu expected=%zu, continue waiting", decoded.size(), expected_len);
+  }
 }
 
 void JuraComponent::publish_xml_values_() {

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -121,6 +121,8 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   bool perform_xml_cycle_();
   bool read_db_data_frame_(std::vector<uint8_t> &decoded, uint32_t timeout_ms,
                            std::string_view last_cmd_ascii);
+  bool read_db_with_expected_len_(std::vector<uint8_t> &decoded, uint32_t total_timeout_ms,
+                                  std::string_view cmd, size_t expected_len);
   bool send_db_command_(const std::string &command);
   void publish_xml_values_();
   void update_sensor_names_();


### PR DESCRIPTION
## Summary
- tighten the encoded DB frame reader to strip the trailer, unescape pairs only and ignore ASCII echo frames
- wait for XML responses with the expected decoded length, logging anomalies and raising the default timeout to 1500 ms
- document the DB polling behaviour and troubleshooting steps in the README

## Testing
- python -m compileall esphome/components/jutta_proto/__init__.py

------
https://chatgpt.com/codex/tasks/task_e_68e0217c8a508328be1637acf474e484