### PR TITLE
Allow configuring XML mapping path

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,19 @@ registriert und bleiben dauerhaft sichtbar.
    `TX_DB "@TR:32"`, `RX_DB decoded_len=21 expected=21` sowie `publish TR32=[…]`. Bei einem Timeout wird `RX_DB timeout`
    ausgegeben. Nur wenn alle drei Blöcke korrekt gelesen werden, werden neue Werte veröffentlicht.
 
+#### XML-Pfad konfigurieren
+
+* Standardpfad für das Mapping ist `/data/jura_machine.xml`.
+* Über die YAML-Option `xml_path` kann ein alternativer Speicherort angegeben werden:
+
+  ```yaml
+  jutta_proto:
+    id: jura1
+    xml_path: "/data/my_mapping/jura_map.xml"
+  ```
+
+* Die referenzierte Datei muss vorab mit `uploadfs` oder über das ESPHome Dashboard auf das Gerät kopiert werden.
+
 #### Fehlersuche
 
 * **Sensoren tauchen nicht auf:** Prüfe, ob das Feature aktiviert ist und ob beim Start Meldungen zur Sensorregistrierung

--- a/docs/components/jutta_proto.md
+++ b/docs/components/jutta_proto.md
@@ -20,14 +20,15 @@ jutta_proto:
   jutta_xml_enable: true           # optional, default false
   jutta_xml_poll_ms: 30000         # optional, poll interval in ms
   jutta_xml_rx_timeout_ms: 900     # optional, frame timeout in ms
+  xml_path: "/data/jura_machine.xml"   # optional, override XML mapping path
 ```
 
 The component takes care of the handshake during startup. Once the handshake finishes, all brewing actions become available.
 
 When `jutta_xml_enable` is set to `true`, the component periodically polls the JURA statistics interface using DB framing.
-During initialization it scans `/data/jura_machine.xml` (J.O.E. export) to discover the exact command strings and optional
-labels for the exposed statistics blocks. If the file is missing or malformed the defaults `@TR:32`, `@TG:43`, and
-`@TG:C0` are used and the sensors keep their generic names.
+During initialization it scans the mapping file (default `/data/jura_machine.xml`, configurable via `xml_path`, typically a
+J.O.E. export) to discover the exact command strings and optional labels for the exposed statistics blocks. If the file is
+missing or malformed the defaults `@TR:32`, `@TG:43`, and `@TG:C0` are used and the sensors keep their generic names.
 
 ### XML statistics sensors
 

--- a/esphome/components/jutta_proto/__init__.py
+++ b/esphome/components/jutta_proto/__init__.py
@@ -22,6 +22,7 @@ CONF_MACHINE_DATA = "machine_data"
 CONF_JUTTA_XML_ENABLE = "jutta_xml_enable"
 CONF_JUTTA_XML_POLL_MS = "jutta_xml_poll_ms"
 CONF_JUTTA_XML_RX_TIMEOUT_MS = "jutta_xml_rx_timeout_ms"
+CONF_XML_PATH = "xml_path"
 
 jutta_component_ns = cg.esphome_ns.namespace("jutta_component")
 jutta_proto_ns = cg.global_ns.namespace("jutta_proto")
@@ -97,6 +98,7 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_JUTTA_XML_ENABLE, default=True): cv.boolean,
             cv.Optional(CONF_JUTTA_XML_POLL_MS, default=30000): cv.positive_int,
             cv.Optional(CONF_JUTTA_XML_RX_TIMEOUT_MS, default=1500): cv.positive_int,
+            cv.Optional(CONF_XML_PATH): cv.string,
         }
     )
     .extend(uart.UART_DEVICE_SCHEMA)
@@ -242,6 +244,8 @@ async def to_code(config):
     cg.add(var.set_xml_enabled(config[CONF_JUTTA_XML_ENABLE]))
     cg.add(var.set_xml_poll_interval(config[CONF_JUTTA_XML_POLL_MS]))
     cg.add(var.set_xml_rx_timeout(config[CONF_JUTTA_XML_RX_TIMEOUT_MS]))
+    if CONF_XML_PATH in config:
+        cg.add(var.set_xml_path(config[CONF_XML_PATH]))
 
     if CONF_MACHINE_DATA in config:
         sensor = await text_sensor.new_text_sensor(config[CONF_MACHINE_DATA])

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -22,7 +22,6 @@ constexpr size_t HANDSHAKE_LOG_PREVIEW_LIMIT = 64;
 constexpr uint32_t MACHINE_DATA_QUERY_INTERVAL_MS = 30000;
 constexpr uint32_t MACHINE_DATA_REQUEST_TIMEOUT_MS = 2000;
 const char *const MACHINE_DATA_COMMAND = "&STAT?\r\n";
-constexpr const char *XML_MAPPING_PATH = "/data/jura_machine.xml";
 constexpr size_t XML_TR32_COUNT = 10;
 constexpr size_t XML_TG43_COUNT = 6;
 constexpr size_t XML_TGC0_COUNT = 3;
@@ -358,6 +357,7 @@ void JuraComponent::dump_config() {
   }
 
   ESP_LOGCONFIG(TAG, "  XML polling: %s", this->xml_enabled_ ? "enabled" : "disabled");
+  ESP_LOGCONFIG(TAG, "  XML mapping path: %s", this->xml_path_.c_str());
   if (this->xml_enabled_) {
     ESP_LOGCONFIG(TAG, "  XML poll interval: %u ms", static_cast<unsigned>(this->xml_poll_interval_ms_));
     ESP_LOGCONFIG(TAG, "  XML RX timeout: %u ms", static_cast<unsigned>(this->xml_rx_timeout_ms_));
@@ -711,43 +711,53 @@ void JuraComponent::load_xml_mapping_() {
 
   bool commands_ok = true;
   std::string content;
-  FILE *file = fopen(XML_MAPPING_PATH, "rb");
-  if (file == nullptr) {
-    ESP_LOGW(TAG, "Failed to open XML mapping at %s", XML_MAPPING_PATH);
+  auto *fs = App.get_filesystem();
+  if (fs == nullptr) {
+    ESP_LOGW(TAG, "No filesystem available for XML mapping");
     commands_ok = false;
   } else {
-    char buffer[256];
-    while (true) {
-      size_t read = fread(buffer, 1, sizeof(buffer), file);
-      if (read == 0) {
-        break;
+    auto file = fs->open(this->xml_path_.c_str(), "r");
+    if (!file) {
+      ESP_LOGW(TAG, "Failed to open XML mapping at %s", this->xml_path_.c_str());
+      commands_ok = false;
+    } else {
+      char buffer[256];
+      while (true) {
+        size_t read = file.readBytes(buffer, sizeof(buffer));
+        if (read == 0) {
+          break;
+        }
+        content.append(buffer, read);
+        if (read < sizeof(buffer) && !file.available()) {
+          break;
+        }
       }
-      content.append(buffer, read);
+      file.close();
+
+      auto parse_block = [&](const char *anchor_token, std::string &command, auto &labels) {
+        size_t anchor_pos = content.find(anchor_token);
+        if (anchor_pos == std::string::npos) {
+          commands_ok = false;
+          return;
+        }
+        std::string parsed_command;
+        if (extract_command(content, anchor_pos, parsed_command)) {
+          command = parsed_command;
+        } else {
+          commands_ok = false;
+        }
+        extract_labels(content, anchor_pos, labels);
+      };
+
+      parse_block("TR32", this->xml_mapping_.tr32_command, this->xml_mapping_.tr32_labels);
+      parse_block("TG43", this->xml_mapping_.tg43_command, this->xml_mapping_.tg43_labels);
+      parse_block("TGC0", this->xml_mapping_.tgc0_command, this->xml_mapping_.tgc0_labels);
     }
-    fclose(file);
-
-    auto parse_block = [&](const char *anchor_token, std::string &command, auto &labels) {
-      size_t anchor_pos = content.find(anchor_token);
-      if (anchor_pos == std::string::npos) {
-        commands_ok = false;
-        return;
-      }
-      std::string parsed_command;
-      if (extract_command(content, anchor_pos, parsed_command)) {
-        command = parsed_command;
-      } else {
-        commands_ok = false;
-      }
-      extract_labels(content, anchor_pos, labels);
-    };
-
-    parse_block("TR32", this->xml_mapping_.tr32_command, this->xml_mapping_.tr32_labels);
-    parse_block("TG43", this->xml_mapping_.tg43_command, this->xml_mapping_.tg43_labels);
-    parse_block("TGC0", this->xml_mapping_.tgc0_command, this->xml_mapping_.tgc0_labels);
   }
 
   this->xml_mapping_.valid = commands_ok;
   if (!this->xml_mapping_logged_) {
+    ESP_LOGI(TAG, "XML mapping path = %s", this->xml_path_.c_str());
     size_t tr32_labels = count_non_empty(this->xml_mapping_.tr32_labels);
     size_t tg43_labels = count_non_empty(this->xml_mapping_.tg43_labels);
     size_t tgc0_labels = count_non_empty(this->xml_mapping_.tgc0_labels);

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -102,6 +102,7 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   }
   void set_xml_poll_interval(uint32_t interval_ms) { this->xml_poll_interval_ms_ = interval_ms; }
   void set_xml_rx_timeout(uint32_t timeout_ms) { this->xml_rx_timeout_ms_ = timeout_ms; }
+  void set_xml_path(const std::string &path) { this->xml_path_ = path; }
 
  protected:
   enum class HandshakeStage { IDLE, HELLO, SEND_T1, WAIT_T2, SEND_T2, WAIT_T3, SEND_T3, DONE, FAILED };
@@ -168,6 +169,7 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   std::array<uint32_t, 3> xml_tgc0_values_{};
   bool xml_has_values_{false};
   bool xml_busy_{false};
+  std::string xml_path_{"/data/jura_machine.xml"};
 };
 
 class StartBrewAction : public esphome::Action<> {


### PR DESCRIPTION
## Summary
- add an xml_path option to jutta_proto and expose it via the YAML schema
- read the mapping file from the configured filesystem path and log the configured path
- document how to override the XML mapping location

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e025243e5483288ef8b461fdd6fb51