### PR TITLE
Fix filesystem guard in XML mapping loader

### DIFF
--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -716,9 +716,6 @@ void JuraComponent::load_xml_mapping_() {
   std::string content;
 #if defined(USE_FILESYSTEM)
   auto *fs = ::esphome::filesystem::global_filesystem;
-#else
-  auto *fs = nullptr;
-#endif
   if (fs == nullptr) {
     ESP_LOGW(TAG, "No filesystem available for XML mapping");
     commands_ok = false;
@@ -761,6 +758,10 @@ void JuraComponent::load_xml_mapping_() {
       parse_block("TGC0", this->xml_mapping_.tgc0_command, this->xml_mapping_.tgc0_labels);
     }
   }
+#else
+  ESP_LOGW(TAG, "No filesystem available for XML mapping");
+  commands_ok = false;
+#endif
 
   this->xml_mapping_.valid = commands_ok;
   if (!this->xml_mapping_logged_) {


### PR DESCRIPTION
## Summary
- avoid declaring a filesystem pointer when USE_FILESYSTEM is not defined
- keep logging a warning and invalidating the XML mapping when no filesystem is available

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e028b4c3a0832880cb34973fc91640