### PR TITLE
Improve DB frame handling and echo suppression

### DIFF
--- a/docs/components/jutta_proto.md
+++ b/docs/components/jutta_proto.md
@@ -48,10 +48,18 @@ with `accuracy_decimals: 0`, so no templating is required on the ESPHome side.
 
 The XML transport uses escaped DB frames. Some legacy Wi-Fi bridges reply with an ASCII echo of the `@TR:32`, `@TG:43`, or
 `@TG:C0` command before the actual data frame arrives. The component drains the UART briefly before the first command in a
-poll cycle, skips such echo frames automatically, and validates the decoded payload length (21/13/13 bytes). Frames that are
-too short or too long are treated as unrelated telemetry and dropped without touching the timeout budget. The per-command
-timeout defaults to 1.5 seconds, which proved sufficient in field tests. Keep the poll interval at or above 25 seconds so the
-telemetry stream does not collide with the XML polling.
+poll cycle, filters those echoed bytes strictly, and validates the decoded payload length (21/13/13 bytes) per block. Frames
+that are too short or too long are treated as unrelated telemetry and dropped without touching the timeout budget. The
+per-command timeout starts once the first non-echo byte was received (otherwise after the TX) and defaults to 1.5 seconds.
+Keep the poll interval at or above 25 seconds so the telemetry stream does not collide with the XML polling.
+
+**Problem.** Encodierte TX-Bytes wurden wieder in den RX-Strom eingespeist. Der Framer erhielt dadurch Mischdaten,
+die nicht zur erwarteten Nutzlastlänge passten und regelmäßig in `frame decode failed` bzw. Timeouts mündeten.
+
+**Lösung.** Ein Echo-Suppressor verwirft jetzt die encodierten TX-Bytes zeitlich begrenzt, bevor sie den Framer erreichen.
+Der Framer schneidet Frames am Terminator, de-stufft nur den einzelnen Block und prüft anschließend die Soll-Länge. Die
+Timeout-Logik startet erst bei den ersten echten RX-Bytes, wodurch robuste Antworten ohne zusätzliche Verzögerung
+ausgewertet werden können.
 
 ## Automation Actions
 

--- a/esphome/components/jutta_proto/jutta_connection.cpp
+++ b/esphome/components/jutta_proto/jutta_connection.cpp
@@ -520,7 +520,12 @@ bool JuttaConnection::write_db_command(const std::string& command) {
         encoded.push_back(static_cast<uint8_t>(c ^ DB_XOR_MASK));
     }
     encoded.insert(encoded.end(), DB_TRAILER_ENCODED.begin(), DB_TRAILER_ENCODED.end());
-    return this->write_db_encoded_(encoded);
+    this->activate_tx_echo_suppressor_(encoded);
+    if (!this->write_db_encoded_(encoded)) {
+        this->deactivate_tx_echo_suppressor_();
+        return false;
+    }
+    return true;
 }
 
 bool JuttaConnection::read_db_frame(std::vector<uint8_t>& decoded, const std::chrono::milliseconds& timeout) {
@@ -545,6 +550,7 @@ void JuttaConnection::drain_db_stream(const std::chrono::milliseconds& duration)
     if (duration.count() == 0) {
         return;
     }
+    this->db_rx_queue_.clear();
     uint32_t start = esphome::millis();
     std::array<uint8_t, 4> buffer{};
     while (true) {
@@ -554,12 +560,49 @@ void JuttaConnection::drain_db_stream(const std::chrono::milliseconds& duration)
         size_t read = this->serial.read_serial(buffer);
         if (read == 0) {
             esphome::delay(5);
+            continue;
         }
+        std::vector<uint8_t> filtered;
+        filtered.reserve(read);
+        size_t dropped = this->filter_tx_echo_(buffer.data(), read, filtered);
+        if (dropped > 0) {
+            ESP_LOGD(TAG, "Echo drop: %zu of %zu bytes", dropped, read);
+        }
+        // Drop any remaining bytes by not enqueuing them.
     }
 }
 
 size_t JuttaConnection::read_db_stream_chunk(std::array<uint8_t, 4>& buffer) {
-    return this->serial.read_serial(buffer);
+    size_t produced = 0;
+    while (produced < buffer.size() && !this->db_rx_queue_.empty()) {
+        buffer[produced++] = this->db_rx_queue_.front();
+        this->db_rx_queue_.pop_front();
+    }
+    if (produced > 0) {
+        return produced;
+    }
+
+    std::array<uint8_t, 4> raw{};
+    size_t read = this->serial.read_serial(raw);
+    if (read == 0) {
+        return 0;
+    }
+
+    std::vector<uint8_t> filtered;
+    filtered.reserve(read);
+    size_t dropped = this->filter_tx_echo_(raw.data(), read, filtered);
+    if (dropped > 0) {
+        ESP_LOGD(TAG, "Echo drop: %zu of %zu bytes", dropped, read);
+    }
+    for (uint8_t byte : filtered) {
+        this->db_rx_queue_.push_back(byte);
+    }
+
+    while (produced < buffer.size() && !this->db_rx_queue_.empty()) {
+        buffer[produced++] = this->db_rx_queue_.front();
+        this->db_rx_queue_.pop_front();
+    }
+    return produced;
 }
 
 bool JuttaConnection::write_db_encoded_(const std::vector<uint8_t>& encoded) {
@@ -579,7 +622,7 @@ bool JuttaConnection::read_one_db_frame_encoded_(std::vector<uint8_t>& encoded,
     uint32_t start = esphome::millis();
     std::array<uint8_t, 4> buffer{};
     while (true) {
-        size_t read = this->serial.read_serial(buffer);
+        size_t read = this->read_db_stream_chunk(buffer);
         if (read > 0) {
             encoded.insert(encoded.end(), buffer.begin(), buffer.begin() + read);
             if (encoded.size() >= DB_TRAILER_ENCODED.size()) {
@@ -619,6 +662,66 @@ bool JuttaConnection::unescape_db_frame_(const std::vector<uint8_t>& encoded, st
         }
     }
     return true;
+}
+
+void JuttaConnection::activate_tx_echo_suppressor_(const std::vector<uint8_t>& frame) {
+    this->last_tx_frame_ = frame;
+    this->last_tx_echo_progress_ = 0;
+    this->last_tx_deadline_ = esphome::millis() + 20;
+    this->last_tx_echo_active_ = true;
+}
+
+void JuttaConnection::deactivate_tx_echo_suppressor_() {
+    this->last_tx_frame_.clear();
+    this->last_tx_echo_progress_ = 0;
+    this->last_tx_deadline_ = 0;
+    this->last_tx_echo_active_ = false;
+}
+
+void JuttaConnection::update_tx_echo_suppressor_() {
+    if (!this->last_tx_echo_active_) {
+        return;
+    }
+    if (this->last_tx_echo_progress_ >= this->last_tx_frame_.size()) {
+        this->deactivate_tx_echo_suppressor_();
+        return;
+    }
+    if (static_cast<int32_t>(esphome::millis() - this->last_tx_deadline_) >= 0) {
+        this->deactivate_tx_echo_suppressor_();
+    }
+}
+
+size_t JuttaConnection::filter_tx_echo_(const uint8_t* data, size_t length, std::vector<uint8_t>& filtered) {
+    filtered.clear();
+    if (length == 0) {
+        return 0;
+    }
+    filtered.reserve(length);
+    size_t dropped = 0;
+    size_t index = 0;
+    while (index < length) {
+        this->update_tx_echo_suppressor_();
+        bool drop_candidate = this->last_tx_echo_active_ &&
+                              this->last_tx_echo_progress_ < this->last_tx_frame_.size();
+        if (drop_candidate) {
+            uint8_t expected = this->last_tx_frame_[this->last_tx_echo_progress_];
+            if (data[index] == expected) {
+                ++dropped;
+                ++this->last_tx_echo_progress_;
+                ++index;
+                if (this->last_tx_echo_progress_ >= this->last_tx_frame_.size()) {
+                    this->deactivate_tx_echo_suppressor_();
+                }
+                continue;
+            }
+        }
+        if (this->last_tx_echo_active_) {
+            this->deactivate_tx_echo_suppressor_();
+        }
+        filtered.insert(filtered.end(), data + index, data + length);
+        break;
+    }
+    return dropped;
 }
 
 

--- a/esphome/components/jutta_proto/jutta_connection.hpp
+++ b/esphome/components/jutta_proto/jutta_connection.hpp
@@ -322,6 +322,16 @@ class JuttaConnection {
                                     const std::chrono::milliseconds& timeout);
     bool unescape_db_frame_(const std::vector<uint8_t>& encoded, std::vector<uint8_t>& decoded) const;
 
+    void activate_tx_echo_suppressor_(const std::vector<uint8_t>& frame);
+    void deactivate_tx_echo_suppressor_();
+    void update_tx_echo_suppressor_();
+    size_t filter_tx_echo_(const uint8_t* data, size_t length, std::vector<uint8_t>& filtered);
+
+    std::deque<uint8_t> db_rx_queue_{};
+    std::vector<uint8_t> last_tx_frame_{};
+    size_t last_tx_echo_progress_{0};
+    uint32_t last_tx_deadline_{0};
+    bool last_tx_echo_active_{false};
 };
 //---------------------------------------------------------------------------
 }  // namespace jutta_proto

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -1005,6 +1005,8 @@ bool JuraComponent::consume_pending_db_frame_(const std::string &command, uint8_
       continue;
     }
     if (payload[0] == command_id) {
+      ESP_LOGD(TAG, "RX_DB encoded_len=%zu decoded_len=%zu (expected=%zu)",
+               pending.encoded.size(), payload.size(), expected_len);
       if (payload.size() != expected_len) {
         ESP_LOGD(TAG, "RX_DB len=%u != %u → drop", static_cast<unsigned>(payload.size()),
                  static_cast<unsigned>(expected_len));
@@ -1029,6 +1031,8 @@ bool JuraComponent::await_db_response_(const std::string &command, uint8_t comma
   }
   uint32_t start = esphome::millis();
   const uint32_t timeout_ms = this->xml_rx_timeout_ms_;
+  bool rx_started = false;
+  uint32_t rx_start = 0;
 
   while (true) {
     if (this->consume_pending_db_frame_(command, command_id, expected_len, decoded)) {
@@ -1038,6 +1042,7 @@ bool JuraComponent::await_db_response_(const std::string &command, uint8_t comma
     std::array<uint8_t, 4> chunk{};
     size_t read = link->read_db_stream_chunk(chunk);
     if (read > 0) {
+      ESP_LOGD(TAG, "RX push: %zu bytes", read);
       this->db_framer_.push_encoded(chunk.data(), read);
       auto frames = this->db_framer_.try_extract_frames();
       for (auto &frame : frames) {
@@ -1046,11 +1051,16 @@ bool JuraComponent::await_db_response_(const std::string &command, uint8_t comma
         this->db_pending_frames_.push_back(std::move(pending));
       }
       this->discard_stale_pending_frames_();
+      if (!rx_started) {
+        rx_started = true;
+        rx_start = esphome::millis();
+      }
       continue;
     }
 
     uint32_t now = esphome::millis();
-    if (timeout_ms > 0 && now - start >= timeout_ms) {
+    uint32_t base = rx_started ? rx_start : start;
+    if (timeout_ms > 0 && static_cast<int32_t>(now - base - timeout_ms) >= 0) {
       ESP_LOGW(TAG, "RX_DB timeout %s", command.c_str());
       return false;
     }
@@ -1137,7 +1147,8 @@ bool JuraComponent::perform_xml_cycle_() {
   auto read_block = [&](const std::string &command, uint8_t command_id, size_t expected_length,
                         auto &&parser) -> bool {
     link->drain_db_stream(std::chrono::milliseconds{XML_RX_DRAIN_MS});
-    ESP_LOGD(TAG, "TX_DB \"%s\"", command.c_str());
+    size_t encoded_len = command.size() * 2 + DB_TERMINATOR.size();
+    ESP_LOGD(TAG, "TX_DB \"%s\" (len=%zu)", command.c_str(), encoded_len);
     if (!this->send_db_command_(command)) {
       ESP_LOGW(TAG, "Failed to send XML command %s", command.c_str());
       return false;


### PR DESCRIPTION
## Summary
- add a TX echo suppressor on the DB UART path and buffer filtered RX bytes
- tighten DB frame extraction, logging and timeout handling for XML polling
- document the echo issue and fix in the Jutta Proto component docs

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e03e90205883288cd6a89fa87b1c36