### PR TITLE
Improve DB echo suppression for XML polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,8 +296,9 @@ registriert und bleiben dauerhaft sichtbar.
 **Beschreibung:** Der Jura-Dongle sendet auf DB-Kommandos wie `@TR:32` oft zuerst ein Echo-Frame mit dem ASCII des Befehls
 und danach das Daten-Frame. Der Reader erkennt den encoded Trailer `DF FF DB DB FB FB DB DB`, entfernt ihn, unescaped
 `0xDB xx → xx^0x20`, verwirft Echo-Frames und liest weiter, bis ein Daten-Frame mit der erwarteten Decoded-Länge vorliegt:
-TR32=21, TG43=13, TGC0=13. Sensoren werden beim Start registriert, Werte nur bei vollständigem Erfolg publiziert. Keine
-Textsensoren, keine HA-Templates erforderlich.
+TR32=21, TG43=13, TGC0=13. Eine Echo-Unterdrückung bleibt bis zu 200 ms aktiv und verlängert sich bei jedem passenden Byte,
+damit auch späte Antworten der Legacy-Bridge nicht fälschlich ausgewertet werden. Sensoren werden beim Start registriert,
+Werte nur bei vollständigem Erfolg publiziert. Keine Textsensoren, keine HA-Templates erforderlich.
 
 **Troubleshooting:**
 

--- a/docs/components/jutta_proto.md
+++ b/docs/components/jutta_proto.md
@@ -59,7 +59,8 @@ die nicht zur erwarteten Nutzlastlänge passten und regelmäßig in `frame decod
 **Lösung.** Ein Echo-Suppressor verwirft jetzt die encodierten TX-Bytes zeitlich begrenzt, bevor sie den Framer erreichen.
 Der Framer schneidet Frames am Terminator, de-stufft nur den einzelnen Block und prüft anschließend die Soll-Länge. Die
 Timeout-Logik startet erst bei den ersten echten RX-Bytes, wodurch robuste Antworten ohne zusätzliche Verzögerung
-ausgewertet werden können.
+ausgewertet werden können. Die Unterdrückung der Echo-Frames bleibt bis zu 200 ms aktiv und verlängert sich mit jedem
+erkannten Byte, sodass auch träge Legacy-Bridges keine halben Kommandos mehr in den Puffer drücken können.
 
 ## Automation Actions
 

--- a/esphome/components/jutta_proto/jutta_connection.cpp
+++ b/esphome/components/jutta_proto/jutta_connection.cpp
@@ -19,6 +19,7 @@ static const char* TAG = "jutta_connection";
 
 namespace {
 constexpr uint32_t JUTTA_SERIAL_GAP_MS = 8;
+constexpr uint32_t JUTTA_TX_ECHO_WINDOW_MS = 200;
 constexpr uint8_t JUTTA_ENCODE_BASE = 0xFF;
 constexpr uint8_t JUTTA_BIT0_MASK = static_cast<uint8_t>(1u << 2);
 constexpr uint8_t JUTTA_BIT1_MASK = static_cast<uint8_t>(1u << 5);
@@ -667,7 +668,7 @@ bool JuttaConnection::unescape_db_frame_(const std::vector<uint8_t>& encoded, st
 void JuttaConnection::activate_tx_echo_suppressor_(const std::vector<uint8_t>& frame) {
     this->last_tx_frame_ = frame;
     this->last_tx_echo_progress_ = 0;
-    this->last_tx_deadline_ = esphome::millis() + 20;
+    this->last_tx_deadline_ = esphome::millis() + JUTTA_TX_ECHO_WINDOW_MS;
     this->last_tx_echo_active_ = true;
 }
 
@@ -708,6 +709,7 @@ size_t JuttaConnection::filter_tx_echo_(const uint8_t* data, size_t length, std:
             if (data[index] == expected) {
                 ++dropped;
                 ++this->last_tx_echo_progress_;
+                this->last_tx_deadline_ = esphome::millis() + JUTTA_TX_ECHO_WINDOW_MS;
                 ++index;
                 if (this->last_tx_echo_progress_ >= this->last_tx_frame_.size()) {
                     this->deactivate_tx_echo_suppressor_();

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -976,7 +976,10 @@ void JuraComponent::discard_stale_pending_frames_() {
 }
 
 bool JuraComponent::consume_pending_db_frame_(const std::string &command, uint8_t command_id, size_t expected_len,
-                                              std::vector<uint8_t> &decoded) {
+                                              std::vector<uint8_t> &decoded, bool *dropped_echo) {
+  if (dropped_echo != nullptr) {
+    *dropped_echo = false;
+  }
   for (auto it = this->db_pending_frames_.begin(); it != this->db_pending_frames_.end();) {
     PendingDbFrame &pending = *it;
     if (!pending.decode_attempted) {
@@ -996,6 +999,9 @@ bool JuraComponent::consume_pending_db_frame_(const std::string &command, uint8_
     auto &payload = pending.decoded;
     if (is_ascii_echo(payload, command)) {
       ESP_LOGD(TAG, "RX_DB echo ignored: \"%s\"", command.c_str());
+      if (dropped_echo != nullptr) {
+        *dropped_echo = true;
+      }
       it = this->db_pending_frames_.erase(it);
       continue;
     }
@@ -1035,8 +1041,13 @@ bool JuraComponent::await_db_response_(const std::string &command, uint8_t comma
   uint32_t rx_start = 0;
 
   while (true) {
-    if (this->consume_pending_db_frame_(command, command_id, expected_len, decoded)) {
+    bool dropped_echo = false;
+    if (this->consume_pending_db_frame_(command, command_id, expected_len, decoded, &dropped_echo)) {
       return true;
+    }
+    if (dropped_echo) {
+      rx_started = false;
+      rx_start = 0;
     }
 
     std::array<uint8_t, 4> chunk{};

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -134,7 +134,7 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   bool await_db_response_(const std::string &command, uint8_t command_id, size_t expected_len,
                           std::vector<uint8_t> &decoded);
   bool consume_pending_db_frame_(const std::string &command, uint8_t command_id, size_t expected_len,
-                                 std::vector<uint8_t> &decoded);
+                                 std::vector<uint8_t> &decoded, bool *dropped_echo = nullptr);
   void discard_stale_pending_frames_();
 
   std::unique_ptr<::jutta_proto::JuttaConnection> connection_;


### PR DESCRIPTION
## Summary
- extend the DB echo suppressor window and refresh it while dropping bytes so delayed echoes stay filtered
- reset the XML response timeout whenever a pending echo frame is removed to avoid premature RX timeouts
- document the wider echo window in the README and component docs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e04237ca708328a6fd4de67c100797