### PR TITLE
Add XML polling via DB frames for Jutta component

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,45 @@ Since newer models **do not use** this old V1-Protocol any more I started this p
 
 ## ESPHome-Integration (Kurzüberblick)
 
-* **XML-Quelle:** Die Komponente lädt das Mapping entweder aus `xml_inline` im YAML (mehrzeilige Zeichenkette) oder aus `xml_path` (Standard `/config/esphome/e6.xml`). Fehlt ein Dateisystem, wird automatisch auf Inline-Daten zurückgegriffen.
-* **Entitäten:** Für `TR32` (10 Zähler), `TG43` (6 Zähler) und `TGC0` (3 Werte) werden beim Boot Sensoren erstellt und dauerhaft registriert. Labels aus dem XML werden beim Start angewendet.
-* **Polling:** Alle 25–30 s werden nacheinander `@TR:32`, `@TG:43` und `@TG:C0` angefragt. Ein robuster Framer erkennt den Terminator `DF FF DB DB FB FB DB DB`, entfernt Escapes und verwirft fehlerhafte Frames.
-* **Fehlersuche:** Log-Ausgaben zeigen Quelle und Status des XML-Mappings, jede `TX_DB`-/`RX_DB`-Phase sowie Zeitüberschreitungen an. Bei „No filesystem available“ sollte `xml_inline` genutzt oder das Dateisystem aktiviert werden.
+### Aktivierung des XML-Pollings
+
+- `enable_xml_poll`: Schaltet den zusätzlichen XML-Pfad frei (Standard `false`).
+- `xml_mapping_path`: Dateipfad zum J.O.E.-Mapping (Standard `"/config/esphome/e6.xml"`).
+- `xml_poll_interval_ms`: Abstand zwischen zwei Abfragen in Millisekunden (Standard `30000`).
+
+Beispiel-Konfiguration in ESPHome:
+
+```yaml
+uart:
+  id: uart_bus
+  baud_rate: 9600
+
+jutta_proto:
+  id: jura_e6
+  uart_id: uart_bus
+  enable_xml_poll: true
+  xml_mapping_path: "/config/esphome/e6.xml"
+  xml_poll_interval_ms: 30000
+```
+
+### Mapping-Datei
+
+- Das Mapping folgt der Struktur der veröffentlichten `jura_joe_xml_bundle_final`-Dateien.
+- Bei erfolgreichem Laden erscheint im Log eine Zeile wie `XML mapping loaded from /config/esphome/e6.xml (valid=1, fields=...)`.
+- Ist die Datei nicht vorhanden oder fehlerhaft, läuft die Komponente weiter – lediglich das XML-Polling bleibt inaktiv.
+
+### Automatisch erzeugte Sensoren
+
+- Für jedes Feld der Frames `@TR:32`, `@TG:43` und `@TG:C0` wird ein numerischer `sensor::Sensor` erstellt.
+- Typische Werte (abhängig vom Mapping): `coffee_total`, `espresso_total`, `cappuccino_total`, `cleaning_counter`, `decalc_counter`, `filter_change_counter`, `cleaning_percent`, `decalc_percent`, `filter_change_percent`.
+- Die sichtbaren Home-Assistant-Entitäten tragen den im Mapping hinterlegten Label-Text.
+
+### Ablauf & Logging
+
+- Nach erfolgreichem Handshake sendet die Firmware alle `xml_poll_interval_ms` nacheinander `@TR:32`, `@TG:43` und `@TG:C0`.
+- Jeder Befehl wird als `TX_DB` geloggt, Antworten erscheinen als `RX_DB <Frame> decoded_len=<N> reason=<gap|CRLF>`.
+- Zeitüberschreitungen führen lediglich zu einer Warnung; beim nächsten Intervall wird automatisch weiter versucht.
+- Erfolgreich geparste Felder werden mit `XML publish: <Name>=<Wert>` protokolliert.
 
 ## Example
 The following example shows the interaction with a JURA coffee maker over [XMPP](https://xmpp.org/).

--- a/esphome/components/jutta_proto/__init__.py
+++ b/esphome/components/jutta_proto/__init__.py
@@ -19,11 +19,9 @@ CONF_DELAY = "delay"
 CONF_TIMEOUT = "timeout"
 CONF_DESCRIPTION = "description"
 CONF_MACHINE_DATA = "machine_data"
-CONF_JUTTA_XML_ENABLE = "jutta_xml_enable"
-CONF_JUTTA_XML_POLL_MS = "jutta_xml_poll_ms"
-CONF_JUTTA_XML_RX_TIMEOUT_MS = "jutta_xml_rx_timeout_ms"
-CONF_XML_PATH = "xml_path"
-CONF_XML_INLINE = "xml_inline"
+CONF_ENABLE_XML_POLL = "enable_xml_poll"
+CONF_XML_MAPPING_PATH = "xml_mapping_path"
+CONF_XML_POLL_INTERVAL_MS = "xml_poll_interval_ms"
 
 jutta_component_ns = cg.esphome_ns.namespace("jutta_component")
 jutta_proto_ns = cg.global_ns.namespace("jutta_proto")
@@ -96,13 +94,11 @@ CONFIG_SCHEMA = (
         {
             cv.GenerateID(): cv.declare_id(JuraComponent),
             cv.Optional(CONF_MACHINE_DATA): text_sensor.text_sensor_schema(),
-            cv.Optional(CONF_JUTTA_XML_ENABLE, default=True): cv.boolean,
-            cv.Optional(CONF_JUTTA_XML_POLL_MS, default=30000): cv.All(
+            cv.Optional(CONF_ENABLE_XML_POLL, default=False): cv.boolean,
+            cv.Optional(CONF_XML_MAPPING_PATH, default="/config/esphome/e6.xml"): cv.string,
+            cv.Optional(CONF_XML_POLL_INTERVAL_MS, default=30000): cv.All(
                 cv.positive_int, cv.Range(min=25000)
             ),
-            cv.Optional(CONF_JUTTA_XML_RX_TIMEOUT_MS, default=1500): cv.positive_int,
-            cv.Optional(CONF_XML_PATH, default="/config/esphome/e6.xml"): cv.string,
-            cv.Optional(CONF_XML_INLINE, default=""): cv.string,
         }
     )
     .extend(uart.UART_DEVICE_SCHEMA)
@@ -245,12 +241,9 @@ async def to_code(config):
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
 
-    cg.add(var.set_xml_enabled(config[CONF_JUTTA_XML_ENABLE]))
-    cg.add(var.set_xml_poll_interval(config[CONF_JUTTA_XML_POLL_MS]))
-    cg.add(var.set_xml_rx_timeout(config[CONF_JUTTA_XML_RX_TIMEOUT_MS]))
-    cg.add(var.set_xml_path(cg.std_string(config[CONF_XML_PATH])))
-    if CONF_XML_INLINE in config and config[CONF_XML_INLINE]:
-        cg.add(var.set_xml_inline(cg.std_string(config[CONF_XML_INLINE])))
+    cg.add(var.set_enable_xml_poll(config[CONF_ENABLE_XML_POLL]))
+    cg.add(var.set_xml_mapping_path(cg.std_string(config[CONF_XML_MAPPING_PATH])))
+    cg.add(var.set_xml_poll_interval(config[CONF_XML_POLL_INTERVAL_MS]))
 
     if CONF_MACHINE_DATA in config:
         sensor = await text_sensor.new_text_sensor(config[CONF_MACHINE_DATA])

--- a/esphome/components/jutta_proto/jutta_connection.cpp
+++ b/esphome/components/jutta_proto/jutta_connection.cpp
@@ -23,9 +23,6 @@ constexpr uint32_t JUTTA_TX_ECHO_WINDOW_MS = 200;
 constexpr uint8_t JUTTA_ENCODE_BASE = 0xFF;
 constexpr uint8_t JUTTA_BIT0_MASK = static_cast<uint8_t>(1u << 2);
 constexpr uint8_t JUTTA_BIT1_MASK = static_cast<uint8_t>(1u << 5);
-constexpr uint8_t DB_ESCAPE = 0xDB;
-constexpr uint8_t DB_XOR_MASK = 0x20;
-constexpr std::array<uint8_t, 8> DB_TRAILER_ENCODED{{0xDF, 0xFF, 0xDB, 0xDB, 0xFB, 0xFB, 0xDB, 0xDB}};
 std::string format_hex(const uint8_t* data, size_t length) {
     if (length == 0) {
         return "[]";
@@ -513,155 +510,165 @@ void JuttaConnection::reset_response_line_buffer() {
     }
 }
 
-bool JuttaConnection::write_db_command(const std::string& command) {
+void JuttaConnection::tx_db_command(const std::string& ascii) {
+    static const std::array<uint8_t, 8> TERMINATOR{{0xDF, 0xFF, 0xDB, 0xDB, 0xFB, 0xFB, 0xDB, 0xDB}};
     std::vector<uint8_t> encoded;
-    encoded.reserve(command.size() * 2 + DB_TRAILER_ENCODED.size());
-    for (unsigned char c : command) {
-        encoded.push_back(DB_ESCAPE);
-        encoded.push_back(static_cast<uint8_t>(c ^ DB_XOR_MASK));
+    encoded.reserve(ascii.size() * 4 + TERMINATOR.size());
+
+    for (unsigned char ch : ascii) {
+        uint8_t value = static_cast<uint8_t>(ch);
+        for (int pair = 0; pair < 4; ++pair) {
+            uint8_t symbol = 0xDB;
+            int shift = 6 - 2 * pair;
+            uint8_t two_bits = static_cast<uint8_t>((value >> shift) & 0x03);
+            if ((two_bits & 0x01u) != 0u) {
+                symbol |= 0x04u;
+            }
+            if ((two_bits & 0x02u) != 0u) {
+                symbol |= 0x20u;
+            }
+            encoded.push_back(symbol);
+        }
     }
-    encoded.insert(encoded.end(), DB_TRAILER_ENCODED.begin(), DB_TRAILER_ENCODED.end());
+
+    encoded.insert(encoded.end(), TERMINATOR.begin(), TERMINATOR.end());
+
     this->activate_tx_echo_suppressor_(encoded);
-    if (!this->write_db_encoded_(encoded)) {
-        this->deactivate_tx_echo_suppressor_();
-        return false;
-    }
-    return true;
-}
+    ESP_LOGD(TAG, "TX_DB \"%s\"", ascii.c_str());
 
-bool JuttaConnection::read_db_frame(std::vector<uint8_t>& decoded, const std::chrono::milliseconds& timeout) {
-    decoded.clear();
-    std::vector<uint8_t> encoded;
-    if (!this->read_one_db_frame_encoded_(encoded, timeout)) {
-        return false;
-    }
-    return this->unescape_db_frame_(encoded, decoded);
-}
-
-bool JuttaConnection::read_db_data_frame(std::vector<uint8_t>& decoded, const std::chrono::milliseconds& timeout) {
-    decoded.clear();
-    std::vector<uint8_t> encoded;
-    if (!this->read_one_db_frame_encoded_(encoded, timeout)) {
-        return false;
-    }
-    return this->unescape_db_frame_(encoded, decoded);
-}
-
-void JuttaConnection::drain_db_stream(const std::chrono::milliseconds& duration) {
-    if (duration.count() == 0) {
-        return;
-    }
-    this->db_rx_queue_.clear();
-    uint32_t start = esphome::millis();
-    std::array<uint8_t, 4> buffer{};
-    while (true) {
-        if (static_cast<int32_t>(esphome::millis() - start - duration.count()) >= 0) {
-            break;
-        }
-        size_t read = this->serial.read_serial(buffer);
-        if (read == 0) {
-            esphome::delay(5);
-            continue;
-        }
-        std::vector<uint8_t> filtered;
-        filtered.reserve(read);
-        size_t dropped = this->filter_tx_echo_(buffer.data(), read, filtered);
-        if (dropped > 0) {
-            ESP_LOGD(TAG, "Echo drop: %zu of %zu bytes", dropped, read);
-        }
-        // Drop any remaining bytes by not enqueuing them.
-    }
-}
-
-size_t JuttaConnection::read_db_stream_chunk(std::array<uint8_t, 4>& buffer) {
-    size_t produced = 0;
-    while (produced < buffer.size() && !this->db_rx_queue_.empty()) {
-        buffer[produced++] = this->db_rx_queue_.front();
-        this->db_rx_queue_.pop_front();
-    }
-    if (produced > 0) {
-        return produced;
-    }
-
-    std::array<uint8_t, 4> raw{};
-    size_t read = this->serial.read_serial(raw);
-    if (read == 0) {
-        return 0;
-    }
-
-    std::vector<uint8_t> filtered;
-    filtered.reserve(read);
-    size_t dropped = this->filter_tx_echo_(raw.data(), read, filtered);
-    if (dropped > 0) {
-        ESP_LOGD(TAG, "Echo drop: %zu of %zu bytes", dropped, read);
-    }
-    for (uint8_t byte : filtered) {
-        this->db_rx_queue_.push_back(byte);
-    }
-
-    while (produced < buffer.size() && !this->db_rx_queue_.empty()) {
-        buffer[produced++] = this->db_rx_queue_.front();
-        this->db_rx_queue_.pop_front();
-    }
-    return produced;
-}
-
-bool JuttaConnection::write_db_encoded_(const std::vector<uint8_t>& encoded) {
     for (uint8_t byte : encoded) {
         if (!this->serial.write_serial_byte(byte)) {
             ESP_LOGW(TAG, "Failed to write DB byte 0x%02X", static_cast<unsigned>(byte));
-            return false;
+            this->deactivate_tx_echo_suppressor_();
+            return;
         }
     }
     this->serial.flush();
-    return true;
 }
 
-bool JuttaConnection::read_one_db_frame_encoded_(std::vector<uint8_t>& encoded,
-                                                 const std::chrono::milliseconds& timeout) {
-    encoded.clear();
+bool JuttaConnection::read_db_frame(std::vector<uint8_t>& decoded, uint32_t timeout_ms) {
+    decoded.clear();
+
+    constexpr uint32_t GAP_MS = 20;
+    enum class FrameEnd { None, Gap, Terminator, Timeout };
+
+    FrameEnd end_reason = FrameEnd::None;
     uint32_t start = esphome::millis();
-    std::array<uint8_t, 4> buffer{};
-    while (true) {
-        size_t read = this->read_db_stream_chunk(buffer);
-        if (read > 0) {
-            encoded.insert(encoded.end(), buffer.begin(), buffer.begin() + read);
-            if (encoded.size() >= DB_TRAILER_ENCODED.size()) {
-                if (std::equal(DB_TRAILER_ENCODED.begin(), DB_TRAILER_ENCODED.end(),
-                               encoded.end() - DB_TRAILER_ENCODED.size())) {
-                    encoded.resize(encoded.size() - DB_TRAILER_ENCODED.size());
-                    return true;
+    uint32_t last_activity = 0;
+    bool frame_started = false;
+    bool frame_complete = false;
+    uint8_t accumulator = 0;
+    int pair_count = 0;
+
+    auto decode_symbol = [&](uint8_t symbol) {
+        if ((symbol & 0xDBu) != 0xDBu) {
+            return;
+        }
+        accumulator >>= 2;
+        if ((symbol & 0x04u) != 0u) {
+            accumulator |= 0x40u;
+        }
+        if ((symbol & 0x20u) != 0u) {
+            accumulator |= 0x80u;
+        }
+        if (++pair_count == 4) {
+            decoded.push_back(accumulator);
+            pair_count = 0;
+            accumulator = 0;
+            if (decoded.size() >= 2) {
+                size_t n = decoded.size();
+                if (decoded[n - 2] == '\r' && decoded[n - 1] == '\n') {
+                    decoded.resize(n - 2);
+                    frame_complete = true;
+                    end_reason = FrameEnd::Terminator;
                 }
             }
+        }
+    };
+
+    auto process_queue = [&]() {
+        while (!this->db_rx_queue_.empty() && !frame_complete) {
+            uint8_t symbol = this->db_rx_queue_.front();
+            this->db_rx_queue_.pop_front();
+            decode_symbol(symbol);
+            frame_started = true;
+            last_activity = esphome::millis();
+        }
+    };
+
+    process_queue();
+    if (frame_complete) {
+        ESP_LOGD(TAG, "RX_DB decoded_len=%u reason=CRLF", static_cast<unsigned>(decoded.size()));
+        return true;
+    }
+    if (timeout_ms == 0 && !frame_started) {
+        return false;
+    }
+
+    while (!frame_complete) {
+        std::array<uint8_t, 4> raw{};
+        size_t read = this->serial.read_serial(raw);
+        if (read > 0) {
+            last_activity = esphome::millis();
+            std::vector<uint8_t> filtered;
+            filtered.reserve(read);
+            size_t dropped = this->filter_tx_echo_(raw.data(), read, filtered);
+            if (dropped > 0) {
+                ESP_LOGV(TAG, "Dropped %zu echo byte%s while reading DB frame.", dropped,
+                         dropped == 1 ? "" : "s");
+            }
+            for (uint8_t byte : filtered) {
+                this->db_rx_queue_.push_back(byte);
+            }
+            process_queue();
+            if (frame_complete) {
+                break;
+            }
+            frame_started = frame_started || !filtered.empty();
             continue;
         }
-        if (timeout.count() == 0) {
-            esphome::delay(1);
-            continue;
+
+        uint32_t now = esphome::millis();
+        if (frame_started && last_activity != 0 &&
+            static_cast<int32_t>(now - last_activity - GAP_MS) >= 0) {
+            end_reason = FrameEnd::Gap;
+            break;
         }
-        if (static_cast<int32_t>(esphome::millis() - start - timeout.count()) >= 0) {
+        if (timeout_ms != 0 && static_cast<int32_t>(now - start - timeout_ms) >= 0) {
+            end_reason = frame_started ? FrameEnd::Gap : FrameEnd::Timeout;
             break;
         }
         esphome::delay(1);
     }
-    return false;
-}
 
-bool JuttaConnection::unescape_db_frame_(const std::vector<uint8_t>& encoded, std::vector<uint8_t>& decoded) const {
-    decoded.clear();
-    decoded.reserve(encoded.size());
-    for (size_t i = 0; i < encoded.size();) {
-        uint8_t byte = encoded[i++];
-        if (byte == DB_ESCAPE) {
-            if (i >= encoded.size()) {
-                return false;
-            }
-            uint8_t escaped = encoded[i++];
-            decoded.push_back(static_cast<uint8_t>(escaped ^ DB_XOR_MASK));
-        } else {
-            decoded.push_back(byte);
+    if (decoded.empty()) {
+        if (end_reason == FrameEnd::Timeout) {
+            ESP_LOGW(TAG, "RX_DB timeout (no data)");
         }
+        return false;
     }
+
+    if (end_reason == FrameEnd::None) {
+        end_reason = FrameEnd::Gap;
+    }
+
+    const char* reason = nullptr;
+    switch (end_reason) {
+        case FrameEnd::Gap:
+            reason = "gap";
+            break;
+        case FrameEnd::Terminator:
+            reason = "CRLF";
+            break;
+        case FrameEnd::Timeout:
+            reason = "timeout";
+            break;
+        case FrameEnd::None:
+            reason = "unknown";
+            break;
+    }
+
+    ESP_LOGD(TAG, "RX_DB decoded_len=%u reason=%s", static_cast<unsigned>(decoded.size()), reason);
     return true;
 }
 

--- a/esphome/components/jutta_proto/jutta_connection.hpp
+++ b/esphome/components/jutta_proto/jutta_connection.hpp
@@ -116,30 +116,8 @@ class JuttaConnection {
     /**
      * Sends an escaped DB command ("@..." without trailing CRLF) with the fixed trailer required for XML frames.
      */
-    bool write_db_command(const std::string& command);
-
-    /**
-     * Reads a DB framed response, decoding the payload into "decoded".
-     * Returns true on success.
-     */
-    bool read_db_frame(std::vector<uint8_t>& decoded, const std::chrono::milliseconds& timeout);
-
-    /**
-     * Reads a single DB framed response and decodes the payload into "decoded".
-     * Returns true on success.
-     */
-    bool read_db_data_frame(std::vector<uint8_t>& decoded, const std::chrono::milliseconds& timeout);
-
-    /**
-     * Drains incoming DB stream bytes for the specified duration.
-     */
-    void drain_db_stream(const std::chrono::milliseconds& duration);
-
-    /**
-     * Reads raw encoded DB bytes from the UART stream into the provided buffer.
-     * Returns the number of bytes that were read.
-     */
-    size_t read_db_stream_chunk(std::array<uint8_t, 4>& buffer);
+    void tx_db_command(const std::string& ascii);
+    bool read_db_frame(std::vector<uint8_t>& decoded, uint32_t timeout_ms);
 
     /**
      * Encodes the given byte into 4 JUTTA bytes and writes them to the coffee maker.
@@ -316,11 +294,6 @@ class JuttaConnection {
     mutable std::string response_line_buffer_{};
 
     void reinject_decoded_front(const std::string& data) const;
-
-    bool write_db_encoded_(const std::vector<uint8_t>& encoded);
-    bool read_one_db_frame_encoded_(std::vector<uint8_t>& encoded,
-                                    const std::chrono::milliseconds& timeout);
-    bool unescape_db_frame_(const std::vector<uint8_t>& encoded, std::vector<uint8_t>& decoded) const;
 
     void activate_tx_echo_suppressor_(const std::vector<uint8_t>& frame);
     void deactivate_tx_echo_suppressor_();

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -10,14 +10,6 @@
 
 #include "esphome/core/application.h"
 #include "esphome/core/time.h"
-#ifdef USE_FILESYSTEM
-#include "esphome/components/filesystem/filesystem.h"
-#endif
-#if defined(USE_LITTLEFS)
-#include <LittleFS.h>
-#elif defined(USE_SPIFFS)
-#include <SPIFFS.h>
-#endif
 
 namespace esphome {
 namespace jutta_component {
@@ -30,42 +22,8 @@ constexpr size_t HANDSHAKE_LOG_PREVIEW_LIMIT = 64;
 constexpr uint32_t MACHINE_DATA_QUERY_INTERVAL_MS = 30000;
 constexpr uint32_t MACHINE_DATA_REQUEST_TIMEOUT_MS = 2000;
 const char *const MACHINE_DATA_COMMAND = "&STAT?\r\n";
-constexpr size_t XML_TR32_COUNT = 10;
-constexpr size_t XML_TG43_COUNT = 6;
-constexpr size_t XML_TGC0_COUNT = 3;
-constexpr uint32_t XML_RX_DRAIN_MS = 40;
-constexpr uint8_t DB_ESCAPE = 0xDB;
-constexpr uint8_t DB_XOR_MASK = 0x20;
-constexpr std::array<uint8_t, 8> DB_TERMINATOR{{0xDF, 0xFF, 0xDB, 0xDB, 0xFB, 0xFB, 0xDB, 0xDB}};
-
-bool decode_db_frame(const std::vector<uint8_t> &encoded, std::vector<uint8_t> &decoded) {
-  if (encoded.size() < DB_TERMINATOR.size()) {
-    return false;
-  }
-  size_t payload_len = encoded.size() - DB_TERMINATOR.size();
-  decoded.clear();
-  decoded.reserve(payload_len);
-  for (size_t i = 0; i < payload_len;) {
-    uint8_t byte = encoded[i++];
-    if (byte == DB_ESCAPE) {
-      if (i >= payload_len) {
-        return false;
-      }
-      uint8_t escaped = encoded[i++];
-      decoded.push_back(static_cast<uint8_t>(escaped ^ DB_XOR_MASK));
-    } else {
-      decoded.push_back(byte);
-    }
-  }
-  return true;
-}
-
-bool is_ascii_echo(const std::vector<uint8_t> &decoded, const std::string &command) {
-  if (decoded.size() != command.size()) {
-    return false;
-  }
-  return std::equal(decoded.begin(), decoded.end(), command.begin());
-}
+constexpr uint32_t XML_RESPONSE_TIMEOUT_MS = 1000;
+constexpr uint32_t XML_INTER_COMMAND_DELAY_MS = 180;
 
 template<typename AppT>
 auto try_register_sensor(AppT &app, sensor::Sensor *sensor, long)
@@ -109,77 +67,6 @@ template<typename SensorT>
 void try_set_parent(SensorT *, Component *, ...) {}
 
 template <size_t N>
-void fill_default_labels(const char *prefix, std::array<std::string, N> &labels) {
-  for (size_t i = 0; i < N; ++i) {
-    char buffer[32];
-    snprintf(buffer, sizeof(buffer), "%s %u", prefix, static_cast<unsigned>(i + 1));
-    labels[i] = buffer;
-  }
-}
-
-template <size_t N>
-size_t count_non_empty(const std::array<std::string, N> &labels) {
-  size_t count = 0;
-  for (const auto &label : labels) {
-    if (!label.empty()) {
-      ++count;
-    }
-  }
-  return count;
-}
-
-bool extract_command(const std::string &content, size_t anchor, std::string &command) {
-  size_t search_start = content.find('@', anchor);
-  if (search_start == std::string::npos) {
-    return false;
-  }
-  size_t end = search_start;
-  while (end < content.size()) {
-    unsigned char ch = static_cast<unsigned char>(content[end]);
-    if (std::isalnum(ch) != 0 || ch == '@' || ch == ':' || ch == '_' || ch == '-') {
-      ++end;
-    } else {
-      break;
-    }
-  }
-  if (end <= search_start + 1) {
-    return false;
-  }
-  command = content.substr(search_start, end - search_start);
-  return true;
-}
-
-template <size_t N>
-void extract_labels(const std::string &content, size_t anchor, std::array<std::string, N> &labels) {
-  size_t block_end = content.find("</", anchor);
-  if (block_end == std::string::npos) {
-    block_end = content.size();
-  }
-  size_t cursor = anchor;
-  size_t count = 0;
-  while (count < N) {
-    size_t label_pos = content.find("label", cursor);
-    if (label_pos == std::string::npos || label_pos >= block_end) {
-      break;
-    }
-    size_t quote_pos = content.find_first_of("\"'", label_pos);
-    if (quote_pos == std::string::npos) {
-      break;
-    }
-    char quote_char = content[quote_pos];
-    size_t value_start = quote_pos + 1;
-    size_t value_end = content.find(quote_char, value_start);
-    if (value_end == std::string::npos) {
-      break;
-    }
-    if (value_end > value_start) {
-      labels[count] = content.substr(value_start, value_end - value_start);
-    }
-    ++count;
-    cursor = value_end + 1;
-  }
-}
-
 std::string format_printable_char(uint8_t byte) {
   switch (byte) {
     case '\r':
@@ -286,18 +173,11 @@ const char *JuraComponent::handshake_stage_name(JuraComponent::HandshakeStage st
 }
 
 JuraComponent::~JuraComponent() {
-  auto cleanup_pool = [](auto &pool) {
-    for (auto *&sensor : pool) {
-      delete sensor;
-      sensor = nullptr;
-    }
-  };
-  cleanup_pool(this->xml_tr32_sensors_);
-  cleanup_pool(this->xml_tg43_sensors_);
-  cleanup_pool(this->xml_tgc0_sensors_);
+  for (auto &entry : this->xml_sensors_) {
+    delete entry.second;
+  }
+  this->xml_sensors_.clear();
 }
-
-void JuraComponent::set_xml_inline(const std::string &xml) { this->xml_inline_ = xml; }
 
 void JuraComponent::setup() {
   if (this->parent_ == nullptr) {
@@ -313,11 +193,11 @@ void JuraComponent::setup() {
   ESP_LOGI(TAG, "Starting handshake with coffee maker...");
 
   this->reset_xml_cycle_state_();
-  this->load_xml_mapping_();
-  this->ensure_xml_sensors_created_();
-  this->apply_xml_labels_();
-  this->xml_initialized_ = true;
   this->xml_next_poll_ = esphome::millis();
+  if (this->enable_xml_poll_) {
+    this->ensure_xml_mapping_loaded_();
+    this->ensure_xml_sensors_created_();
+  }
 }
 
 void JuraComponent::loop() {
@@ -335,7 +215,7 @@ void JuraComponent::loop() {
     this->process_handshake();
   }
 
-  if (this->coffee_maker_ != nullptr && !this->xml_busy_) {
+  if (this->coffee_maker_ != nullptr) {
     this->coffee_maker_->loop();
     if (!this->coffee_maker_->is_locked()) {
       this->custom_cancel_flag_ = false;
@@ -399,13 +279,12 @@ void JuraComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "  Coffee maker ready: %s", YESNO(false));
   }
 
-  ESP_LOGCONFIG(TAG, "  XML polling: %s", this->xml_enabled_ ? "enabled" : "disabled");
-  ESP_LOGCONFIG(TAG, "  XML mapping path: %s", this->xml_path_.c_str());
-  ESP_LOGCONFIG(TAG, "  XML inline mapping: %s", this->xml_inline_.empty() ? "no" : "yes");
-  if (this->xml_enabled_) {
-    ESP_LOGCONFIG(TAG, "  XML poll interval: %u ms", static_cast<unsigned>(this->xml_poll_interval_ms_));
-    ESP_LOGCONFIG(TAG, "  XML RX timeout: %u ms", static_cast<unsigned>(this->xml_rx_timeout_ms_));
-  }
+  ESP_LOGCONFIG(TAG, "  XML polling: %s", this->enable_xml_poll_ ? "enabled" : "disabled");
+  ESP_LOGCONFIG(TAG, "  XML mapping path: %s", this->xml_mapping_path_.c_str());
+  ESP_LOGCONFIG(TAG, "  XML poll interval: %u ms", static_cast<unsigned>(this->xml_poll_interval_ms_));
+  ESP_LOGCONFIG(TAG, "  XML mapping loaded: %s",
+                YESNO(this->xml_mapping_loaded_ && this->xml_mapping_.valid));
+  ESP_LOGCONFIG(TAG, "  XML sensors: %u", static_cast<unsigned>(this->xml_sensors_.size()));
 }
 
 void JuraComponent::process_handshake() {
@@ -634,9 +513,6 @@ void JuraComponent::process_machine_data_query() {
   if (this->is_busy()) {
     return;
   }
-  if (this->xml_busy_) {
-    return;
-  }
 
   uint32_t now = esphome::millis();
 
@@ -690,544 +566,260 @@ void JuraComponent::publish_machine_data_(const std::string &response) {
   }
 }
 
-void JuraComponent::reset_xml_cycle_state_() {
-  this->xml_initialized_ = false;
-  this->xml_has_values_ = false;
-  this->xml_next_poll_ = 0;
-  this->xml_mapping_logged_ = false;
-  this->xml_busy_ = false;
-  this->db_framer_.clear();
-  this->db_pending_frames_.clear();
-}
-
 void JuraComponent::ensure_xml_sensors_created_() {
-  auto create_pool = [&](auto &pool) {
-    for (auto *&sensor_ptr : pool) {
-      if (sensor_ptr == nullptr) {
-        auto *sensor_obj = new sensor::Sensor();
-        sensor_obj->set_accuracy_decimals(0);
-        sensor_obj->set_internal(false);
-        try_set_parent(sensor_obj, this, 0);
-        register_sensor_with_app(sensor_obj);
-        sensor_ptr = sensor_obj;
-      }
-    }
-  };
-  create_pool(this->xml_tr32_sensors_);
-  create_pool(this->xml_tg43_sensors_);
-  create_pool(this->xml_tgc0_sensors_);
-}
-
-void JuraComponent::update_sensor_names_() {
-  auto assign = [](auto &pool, const auto &labels, const char *default_prefix) {
-    for (size_t i = 0; i < pool.size(); ++i) {
-      if (pool[i] == nullptr) {
-        continue;
-      }
-      std::string label = labels[i];
-      if (label.empty()) {
-        char buffer[32];
-        snprintf(buffer, sizeof(buffer), "%s %u", default_prefix, static_cast<unsigned>(i + 1));
-        label = buffer;
-      }
-      pool[i]->set_name(label);
-    }
-  };
-  assign(this->xml_tr32_sensors_, this->xml_mapping_.tr32_labels, "TR32");
-  assign(this->xml_tg43_sensors_, this->xml_mapping_.tg43_labels, "TG43");
-  assign(this->xml_tgc0_sensors_, this->xml_mapping_.tgc0_labels, "TGC0");
-}
-
-void JuraComponent::apply_xml_labels_() {
-  this->update_sensor_names_();
-}
-
-void JuraComponent::load_xml_mapping_() {
-  fill_default_labels("TR32", this->xml_mapping_.tr32_labels);
-  fill_default_labels("TG43", this->xml_mapping_.tg43_labels);
-  fill_default_labels("TGC0", this->xml_mapping_.tgc0_labels);
-  this->xml_mapping_.tr32_command = "@TR:32";
-  this->xml_mapping_.tg43_command = "@TG:43";
-  this->xml_mapping_.tgc0_command = "@TG:C0";
-  this->xml_mapping_.tr32_id = 0x32;
-  this->xml_mapping_.tg43_id = 0x43;
-  this->xml_mapping_.tgc0_id = 0xC0;
-  this->xml_mapping_.valid = false;
-
-  if (!this->xml_enabled_) {
-    this->log_xml_mapping_info_();
+  if (!this->enable_xml_poll_ || !this->xml_mapping_.valid) {
     return;
   }
-
-  std::string content;
-  if (!this->xml_inline_.empty()) {
-    content = this->xml_inline_;
-  } else if (!this->xml_path_.empty()) {
-    if (!this->load_xml_from_path_(content)) {
-      ESP_LOGW(TAG, "Failed to load XML mapping at %s", this->xml_path_.c_str());
-    }
-  }
-
-  if (!content.empty()) {
-    if (!this->parse_xml_content_(content)) {
-      ESP_LOGW(TAG, "XML mapping parse failed, keeping defaults");
-    }
-  }
-
-  this->log_xml_mapping_info_();
-  this->apply_xml_labels_();
-}
-
-void JuraComponent::log_xml_mapping_info_() {
-  if (this->xml_mapping_logged_) {
-    return;
-  }
-  ESP_LOGI(TAG, "XML mapping path = %s", this->xml_path_.c_str());
-  ESP_LOGI(TAG, "inline XML = %s", this->xml_inline_.empty() ? "no" : "yes");
-  size_t tr32_labels = count_non_empty(this->xml_mapping_.tr32_labels);
-  size_t tg43_labels = count_non_empty(this->xml_mapping_.tg43_labels);
-  size_t tgc0_labels = count_non_empty(this->xml_mapping_.tgc0_labels);
-  ESP_LOGI(TAG, "XML mapping valid=%d, cmds=<%s, %s, %s>", static_cast<int>(this->xml_mapping_.valid),
-           this->xml_mapping_.tr32_command.c_str(), this->xml_mapping_.tg43_command.c_str(),
-           this->xml_mapping_.tgc0_command.c_str());
-  ESP_LOGI(TAG, "XML labels: TR32=%u, TG43=%u, TGC0=%u", static_cast<unsigned>(tr32_labels),
-           static_cast<unsigned>(tg43_labels), static_cast<unsigned>(tgc0_labels));
-  this->xml_mapping_logged_ = true;
-}
-
-bool JuraComponent::ensure_filesystem_ready_() {
-#if defined(USE_FILESYSTEM)
-  if (this->filesystem_attempted_) {
-    return this->filesystem_available_;
-  }
-  this->filesystem_attempted_ = true;
-  bool ok = true;
-#if defined(USE_LITTLEFS)
-  ok = LittleFS.begin();
-  ESP_LOGI(TAG, "LittleFS.begin() %s", ok ? "succeeded" : "failed");
-#elif defined(USE_SPIFFS)
-  ok = SPIFFS.begin();
-  ESP_LOGI(TAG, "SPIFFS.begin() %s", ok ? "succeeded" : "failed");
-#else
-  ESP_LOGV(TAG, "Using ESPHome filesystem backend without explicit mount call");
-#endif
-  this->filesystem_available_ = ok;
-  if (!ok) {
-    ESP_LOGW(TAG, "Failed to initialise filesystem backend for XML mapping");
-  }
-  return ok;
-#else
-  return false;
-#endif
-}
-
-bool JuraComponent::load_xml_from_path_(std::string &content) {
-  content.clear();
-#if defined(USE_FILESYSTEM)
-  if (!this->ensure_filesystem_ready_()) {
-    ESP_LOGW(TAG, "No filesystem available for XML mapping");
-    return false;
-  }
-  auto *fs = ::esphome::filesystem::global_filesystem;
-  if (fs == nullptr) {
-    ESP_LOGW(TAG, "No filesystem instance accessible");
-    return false;
-  }
-  auto file = fs->open(this->xml_path_.c_str(), "r");
-  if (!file) {
-    return false;
-  }
-  char buffer[256];
-  while (true) {
-    size_t read = file.readBytes(buffer, sizeof(buffer));
-    if (read == 0) {
-      break;
-    }
-    content.append(buffer, read);
-    if (read < sizeof(buffer) && !file.available()) {
-      break;
-    }
-  }
-  file.close();
-  return true;
-#else
-  (void) content;
-  return false;
-#endif
-}
-
-bool JuraComponent::parse_xml_content_(const std::string &content) {
-  bool commands_ok = true;
-  auto parse_block = [&](const char *anchor_token, std::string &command, auto &labels) {
-    size_t anchor_pos = content.find(anchor_token);
-    if (anchor_pos == std::string::npos) {
-      commands_ok = false;
-      return;
-    }
-    std::string parsed_command;
-    if (extract_command(content, anchor_pos, parsed_command)) {
-      command = parsed_command;
-    } else {
-      commands_ok = false;
-    }
-    extract_labels(content, anchor_pos, labels);
+  auto ensure_field = [&](const XmlField &field) {
+    this->get_or_create_sensor_(field.name, field.label);
   };
+  for (const auto &field : this->xml_mapping_.tr32_fields.fields) {
+    ensure_field(field);
+  }
+  for (const auto &field : this->xml_mapping_.tg43_fields.fields) {
+    ensure_field(field);
+  }
+  for (const auto &field : this->xml_mapping_.tgc0_fields.fields) {
+    ensure_field(field);
+  }
+}
 
-  parse_block("TR32", this->xml_mapping_.tr32_command, this->xml_mapping_.tr32_labels);
-  parse_block("TG43", this->xml_mapping_.tg43_command, this->xml_mapping_.tg43_labels);
-  parse_block("TGC0", this->xml_mapping_.tgc0_command, this->xml_mapping_.tgc0_labels);
-
-  bool ids_ok = true;
-  ids_ok &= this->parse_command_id_(this->xml_mapping_.tr32_command, this->xml_mapping_.tr32_id);
-  ids_ok &= this->parse_command_id_(this->xml_mapping_.tg43_command, this->xml_mapping_.tg43_id);
-  ids_ok &= this->parse_command_id_(this->xml_mapping_.tgc0_command, this->xml_mapping_.tgc0_id);
-
-  this->xml_mapping_.valid = commands_ok && ids_ok;
+bool JuraComponent::ensure_xml_mapping_loaded_() {
+  if (!this->enable_xml_poll_) {
+    return false;
+  }
+  if (this->xml_mapping_loaded_) {
+    return this->xml_mapping_.valid;
+  }
+  XmlMapping mapping;
+  if (!load_xml_mapping(this->xml_mapping_path_, mapping)) {
+    ESP_LOGW(TAG, "Failed to load XML mapping at %s", this->xml_mapping_path_.c_str());
+    this->xml_mapping_loaded_ = false;
+    this->xml_mapping_.valid = false;
+    this->xml_mapping_logged_ = false;
+    this->xml_stats_.clear();
+    this->log_xml_mapping_status_();
+    return false;
+  }
+  this->xml_mapping_ = std::move(mapping);
+  this->xml_mapping_loaded_ = this->xml_mapping_.valid;
+  this->xml_mapping_logged_ = false;
+  this->xml_stats_.clear();
+  this->log_xml_mapping_status_();
   return this->xml_mapping_.valid;
 }
 
-bool JuraComponent::parse_command_id_(const std::string &command, uint8_t &command_id) const {
-  size_t colon = command.find(':');
-  if (colon == std::string::npos || colon + 1 >= command.size()) {
-    ESP_LOGW(TAG, "Cannot derive command id from '%s'", command.c_str());
-    return false;
-  }
-  unsigned value = 0;
-  for (size_t i = colon + 1; i < command.size(); ++i) {
-    unsigned char ch = static_cast<unsigned char>(command[i]);
-    if (std::isxdigit(ch) == 0) {
-      ESP_LOGW(TAG, "Invalid hex digit '%c' in command '%s'", command[i], command.c_str());
-      return false;
-    }
-    value <<= 4;
-    if (ch >= '0' && ch <= '9') {
-      value |= static_cast<unsigned>(ch - '0');
-    } else {
-      ch = static_cast<unsigned char>(std::tolower(ch));
-      value |= static_cast<unsigned>(ch - 'a' + 10);
-    }
-    if (value > 0xFF) {
-      ESP_LOGW(TAG, "Command id overflow in '%s'", command.c_str());
-      return false;
-    }
-  }
-  command_id = static_cast<uint8_t>(value);
-  return true;
-}
-
-void JuraComponent::DbFramer::clear() {
-  this->head_ = 0;
-  this->size_ = 0;
-}
-
-void JuraComponent::DbFramer::consume(size_t length) {
-  if (length >= this->size_) {
-    this->clear();
+void JuraComponent::log_xml_mapping_status_() {
+  if (this->xml_mapping_logged_) {
     return;
   }
-  this->head_ = (this->head_ + length) % BUFFER_CAPACITY;
-  this->size_ -= length;
+  ESP_LOGI(TAG, "XML mapping loaded from %s (valid=%d, fields=%u/%u/%u)",
+           this->xml_mapping_path_.c_str(), static_cast<int>(this->xml_mapping_.valid),
+           static_cast<unsigned>(this->xml_mapping_.tr32_fields.fields.size()),
+           static_cast<unsigned>(this->xml_mapping_.tg43_fields.fields.size()),
+           static_cast<unsigned>(this->xml_mapping_.tgc0_fields.fields.size()));
+  this->xml_mapping_logged_ = true;
 }
 
-void JuraComponent::DbFramer::push_encoded(const uint8_t *data, size_t length) {
-  if (length == 0) {
-    return;
-  }
-  if (length >= BUFFER_CAPACITY) {
-    data += length - BUFFER_CAPACITY;
-    length = BUFFER_CAPACITY;
-    this->clear();
-  }
-  while (this->size_ + length > BUFFER_CAPACITY) {
-    this->consume(1);
-  }
-  for (size_t i = 0; i < length; ++i) {
-    size_t index = (this->head_ + this->size_) % BUFFER_CAPACITY;
-    this->buffer_[index] = data[i];
-    ++this->size_;
-  }
-}
-
-std::vector<std::vector<uint8_t>> JuraComponent::DbFramer::try_extract_frames() {
-  std::vector<std::vector<uint8_t>> frames;
-  while (this->size_ >= DB_TERMINATOR.size()) {
-    std::vector<uint8_t> linear(this->size_);
-    for (size_t i = 0; i < this->size_; ++i) {
-      linear[i] = this->buffer_[(this->head_ + i) % BUFFER_CAPACITY];
-    }
-    auto it = std::search(linear.begin(), linear.end(), DB_TERMINATOR.begin(), DB_TERMINATOR.end());
-    if (it == linear.end()) {
-      break;
-    }
-    size_t frame_len = static_cast<size_t>(std::distance(linear.begin(), it)) + DB_TERMINATOR.size();
-    std::vector<uint8_t> frame(frame_len);
-    std::copy_n(linear.begin(), frame_len, frame.begin());
-    frames.push_back(std::move(frame));
-    this->consume(frame_len);
-  }
-  return frames;
-}
-
-void JuraComponent::discard_stale_pending_frames_() {
-  constexpr size_t MAX_PENDING_FRAMES = 16;
-  while (this->db_pending_frames_.size() > MAX_PENDING_FRAMES) {
-    this->db_pending_frames_.pop_front();
-  }
-}
-
-bool JuraComponent::consume_pending_db_frame_(const std::string &command, uint8_t command_id, size_t expected_len,
-                                              std::vector<uint8_t> &decoded, bool *dropped_echo) {
-  if (dropped_echo != nullptr) {
-    *dropped_echo = false;
-  }
-  for (auto it = this->db_pending_frames_.begin(); it != this->db_pending_frames_.end();) {
-    PendingDbFrame &pending = *it;
-    if (!pending.decode_attempted) {
-      pending.decode_attempted = true;
-      pending.decoded_valid = decode_db_frame(pending.encoded, pending.decoded);
-      if (!pending.decoded_valid) {
-        ESP_LOGD(TAG, "RX_DB frame decode failed (%zu bytes) -> drop", pending.encoded.size());
-        it = this->db_pending_frames_.erase(it);
-        continue;
-      }
-    }
-    if (!pending.decoded_valid) {
-      it = this->db_pending_frames_.erase(it);
-      continue;
-    }
-
-    auto &payload = pending.decoded;
-    if (is_ascii_echo(payload, command)) {
-      ESP_LOGD(TAG, "RX_DB echo ignored: \"%s\"", command.c_str());
-      if (dropped_echo != nullptr) {
-        *dropped_echo = true;
-      }
-      it = this->db_pending_frames_.erase(it);
-      continue;
-    }
-    if (payload.empty()) {
-      ESP_LOGD(TAG, "RX_DB empty payload -> drop");
-      it = this->db_pending_frames_.erase(it);
-      continue;
-    }
-    if (payload[0] == command_id) {
-      ESP_LOGD(TAG, "RX_DB encoded_len=%zu decoded_len=%zu (expected=%zu)",
-               pending.encoded.size(), payload.size(), expected_len);
-      if (payload.size() != expected_len) {
-        ESP_LOGD(TAG, "RX_DB len=%u != %u → drop", static_cast<unsigned>(payload.size()),
-                 static_cast<unsigned>(expected_len));
-        it = this->db_pending_frames_.erase(it);
-        continue;
-      }
-      decoded = payload;
-      this->db_pending_frames_.erase(it);
-      ESP_LOGD(TAG, "RX_DB decoded_len=%zu expected=%zu", decoded.size(), expected_len);
-      return true;
-    }
-    ++it;
-  }
-  return false;
-}
-
-bool JuraComponent::await_db_response_(const std::string &command, uint8_t command_id, size_t expected_len,
-                                       std::vector<uint8_t> &decoded) {
-  auto *link = this->coffee_maker_->connection.get();
-  if (link == nullptr) {
-    return false;
-  }
-  uint32_t start = esphome::millis();
-  const uint32_t timeout_ms = this->xml_rx_timeout_ms_;
-  bool rx_started = false;
-  uint32_t rx_start = 0;
-
-  while (true) {
-    bool dropped_echo = false;
-    if (this->consume_pending_db_frame_(command, command_id, expected_len, decoded, &dropped_echo)) {
-      return true;
-    }
-    if (dropped_echo) {
-      rx_started = false;
-      rx_start = 0;
-    }
-
-    std::array<uint8_t, 4> chunk{};
-    size_t read = link->read_db_stream_chunk(chunk);
-    if (read > 0) {
-      ESP_LOGD(TAG, "RX push: %zu bytes", read);
-      this->db_framer_.push_encoded(chunk.data(), read);
-      auto frames = this->db_framer_.try_extract_frames();
-      for (auto &frame : frames) {
-        PendingDbFrame pending;
-        pending.encoded = std::move(frame);
-        this->db_pending_frames_.push_back(std::move(pending));
-      }
-      this->discard_stale_pending_frames_();
-      if (!rx_started) {
-        rx_started = true;
-        rx_start = esphome::millis();
-      }
-      continue;
-    }
-
-    uint32_t now = esphome::millis();
-    uint32_t base = rx_started ? rx_start : start;
-    if (timeout_ms > 0 && static_cast<int32_t>(now - base - timeout_ms) >= 0) {
-      ESP_LOGW(TAG, "RX_DB timeout %s", command.c_str());
-      return false;
-    }
-    esphome::delay(5);
-  }
+void JuraComponent::reset_xml_cycle_state_() {
+  this->xml_cycle_.reset();
+  this->xml_stats_.clear();
 }
 
 void JuraComponent::process_xml_polling() {
-  if (!this->xml_enabled_) {
+  if (!this->enable_xml_poll_) {
     return;
   }
   if (!this->is_ready()) {
     return;
   }
-  if (this->coffee_maker_ == nullptr || this->coffee_maker_->connection == nullptr) {
+  if (!this->ensure_xml_mapping_loaded_()) {
     return;
   }
-  if (this->is_busy()) {
-    return;
-  }
-
-  if (this->xml_busy_) {
-    return;
-  }
+  this->ensure_xml_sensors_created_();
 
   uint32_t now = esphome::millis();
-
-  if (!this->xml_initialized_) {
-    this->load_xml_mapping_();
-    this->ensure_xml_sensors_created_();
-    this->xml_initialized_ = true;
-    this->xml_next_poll_ = now;
+  if (this->xml_cycle_.phase == XmlCycleState::Phase::Idle) {
+    if (this->xml_next_poll_ != 0 && !time_reached(now, this->xml_next_poll_)) {
+      return;
+    }
+    this->start_xml_cycle_(now);
     return;
   }
-
-  if (this->xml_next_poll_ != 0 && !time_reached(now, this->xml_next_poll_)) {
-    return;
-  }
-
-  ESP_LOGD(TAG, "XML poll start");
-  if (this->perform_xml_cycle_()) {
-    this->publish_xml_values_();
-  }
-  this->xml_next_poll_ = now + this->xml_poll_interval_ms_;
+  this->handle_xml_cycle_(now);
 }
 
-bool JuraComponent::perform_xml_cycle_() {
+void JuraComponent::start_xml_cycle_(uint32_t now) {
+  if (this->coffee_maker_ == nullptr || this->coffee_maker_->connection == nullptr) {
+    return;
+  }
+  this->xml_cycle_.reset();
+  this->xml_cycle_.phase = XmlCycleState::Phase::WaitingForFrame;
+  this->xml_cycle_.command_index = 0;
+  const char *command = xml_command_for_index_(0);
+  ESP_LOGD(TAG, "TX_DB \"%s\"", command);
+  this->coffee_maker_->connection->tx_db_command(command);
+  this->xml_cycle_.deadline_ms = now + XML_RESPONSE_TIMEOUT_MS;
+  this->xml_cycle_.next_action_ms = 0;
+}
+
+void JuraComponent::handle_xml_cycle_(uint32_t now) {
+  if (this->coffee_maker_ == nullptr || this->coffee_maker_->connection == nullptr) {
+    this->finish_xml_cycle_(now, false);
+    return;
+  }
+
+  switch (this->xml_cycle_.phase) {
+    case XmlCycleState::Phase::Idle:
+      break;
+    case XmlCycleState::Phase::WaitingForFrame: {
+      if (this->try_receive_xml_frame_(now)) {
+        this->xml_cycle_.phase = XmlCycleState::Phase::DelayBeforeNext;
+        this->xml_cycle_.next_action_ms = now + XML_INTER_COMMAND_DELAY_MS;
+        return;
+      }
+      if (this->xml_cycle_.deadline_ms != 0 &&
+          static_cast<int32_t>(now - this->xml_cycle_.deadline_ms) >= 0) {
+        ESP_LOGW(TAG, "RX_DB timeout %s", xml_log_label_for_index_(this->xml_cycle_.command_index));
+        this->xml_cycle_.phase = XmlCycleState::Phase::DelayBeforeNext;
+        this->xml_cycle_.next_action_ms = now + XML_INTER_COMMAND_DELAY_MS;
+      }
+      break;
+    }
+    case XmlCycleState::Phase::DelayBeforeNext: {
+      if (this->xml_cycle_.next_action_ms != 0 &&
+          static_cast<int32_t>(now - this->xml_cycle_.next_action_ms) < 0) {
+        return;
+      }
+      size_t next_index = this->xml_cycle_.command_index + 1;
+      if (next_index >= 3) {
+        this->finish_xml_cycle_(now, true);
+        return;
+      }
+      const char *command = xml_command_for_index_(next_index);
+      ESP_LOGD(TAG, "TX_DB \"%s\"", command);
+      this->coffee_maker_->connection->tx_db_command(command);
+      this->xml_cycle_.command_index = next_index;
+      this->xml_cycle_.phase = XmlCycleState::Phase::WaitingForFrame;
+      this->xml_cycle_.deadline_ms = now + XML_RESPONSE_TIMEOUT_MS;
+      break;
+    }
+  }
+}
+
+bool JuraComponent::try_receive_xml_frame_(uint32_t now) {
+  (void) now;
   if (this->coffee_maker_ == nullptr || this->coffee_maker_->connection == nullptr) {
     return false;
   }
-  if (this->xml_busy_) {
-    ESP_LOGW(TAG, "XML poll skipped because connection is busy.");
+  std::vector<uint8_t> decoded;
+  if (!this->coffee_maker_->connection->read_db_frame(decoded, 0)) {
     return false;
   }
-
-  struct BusyGuard {
-    bool &flag;
-    explicit BusyGuard(bool &ref) : flag(ref) { flag = true; }
-    ~BusyGuard() { flag = false; }
-  } guard(this->xml_busy_);
-
-  auto *link = this->coffee_maker_->connection.get();
-  std::array<uint16_t, XML_TR32_COUNT> tr32_values{};
-  std::array<uint16_t, XML_TG43_COUNT> tg43_values{};
-  std::array<uint32_t, XML_TGC0_COUNT> tgc0_values{};
-
-  auto parse_u16 = [](const std::vector<uint8_t> &src, auto &dest) {
-    for (size_t i = 0; i < dest.size(); ++i) {
-      size_t offset = 1 + i * 2;
-      dest[i] = static_cast<uint16_t>((static_cast<uint16_t>(src[offset]) << 8) |
-                                      static_cast<uint16_t>(src[offset + 1]));
-    }
-  };
-  auto parse_u32 = [](const std::vector<uint8_t> &src, auto &dest) {
-    for (size_t i = 0; i < dest.size(); ++i) {
-      size_t offset = 1 + i * 4;
-      dest[i] = (static_cast<uint32_t>(src[offset]) << 24) |
-                (static_cast<uint32_t>(src[offset + 1]) << 16) |
-                (static_cast<uint32_t>(src[offset + 2]) << 8) |
-                static_cast<uint32_t>(src[offset + 3]);
-    }
-  };
-
-  auto read_block = [&](const std::string &command, uint8_t command_id, size_t expected_length,
-                        auto &&parser) -> bool {
-    link->drain_db_stream(std::chrono::milliseconds{XML_RX_DRAIN_MS});
-    size_t encoded_len = command.size() * 2 + DB_TERMINATOR.size();
-    ESP_LOGD(TAG, "TX_DB \"%s\" (len=%zu)", command.c_str(), encoded_len);
-    if (!this->send_db_command_(command)) {
-      ESP_LOGW(TAG, "Failed to send XML command %s", command.c_str());
-      return false;
-    }
-    std::vector<uint8_t> buffer;
-    uint32_t start = esphome::millis();
-    if (!this->await_db_response_(command, command_id, expected_length, buffer)) {
-      return false;
-    }
-    uint32_t elapsed = esphome::millis() - start;
-    ESP_LOGD(TAG, "OK %s in %u ms", command.c_str(), static_cast<unsigned>(elapsed));
-    parser(buffer);
-    return true;
-  };
-
-  bool tr32_ok = read_block(this->xml_mapping_.tr32_command, this->xml_mapping_.tr32_id,
-                            1 + XML_TR32_COUNT * 2, [&](const std::vector<uint8_t> &src) {
-                              parse_u16(src, tr32_values);
-                            });
-  bool tg43_ok = read_block(this->xml_mapping_.tg43_command, this->xml_mapping_.tg43_id,
-                            1 + XML_TG43_COUNT * 2, [&](const std::vector<uint8_t> &src) {
-                              parse_u16(src, tg43_values);
-                            });
-  bool tgc0_ok = read_block(this->xml_mapping_.tgc0_command, this->xml_mapping_.tgc0_id,
-                            1 + XML_TGC0_COUNT * 4, [&](const std::vector<uint8_t> &src) {
-                              parse_u32(src, tgc0_values);
-                            });
-
-  if (!(tr32_ok && tg43_ok && tgc0_ok)) {
-    return false;
-  }
-
-  this->xml_tr32_values_ = tr32_values;
-  this->xml_tg43_values_ = tg43_values;
-  this->xml_tgc0_values_ = tgc0_values;
-  this->xml_has_values_ = true;
+  size_t index = this->xml_cycle_.command_index;
+  this->xml_cycle_.responses[index] = std::move(decoded);
+  ESP_LOGD(TAG, "RX_DB %s decoded_len=%u", xml_log_label_for_index_(index),
+           static_cast<unsigned>(this->xml_cycle_.responses[index].size()));
   return true;
 }
 
-bool JuraComponent::send_db_command_(const std::string &command) {
-  if (this->coffee_maker_ == nullptr || this->coffee_maker_->connection == nullptr) {
-    return false;
+void JuraComponent::finish_xml_cycle_(uint32_t now, bool success) {
+  bool any_value = false;
+
+  auto handle_response = [&](size_t index, auto mapper) {
+    const auto &response = this->xml_cycle_.responses[index];
+    const char *label = xml_log_label_for_index_(index);
+    if (response.empty()) {
+      ESP_LOGW(TAG, "XML %s: keine Daten empfangen", label);
+      return;
+    }
+    if (mapper(response, this->xml_mapping_, this->xml_stats_)) {
+      any_value = true;
+    }
+  };
+
+  handle_response(0, map_tr32);
+  handle_response(1, map_tg43);
+  handle_response(2, map_tgc0);
+
+  if (any_value) {
+    this->publish_xml_stats_();
   }
-  return this->coffee_maker_->connection->write_db_command(command);
+
+  if (!success) {
+    ESP_LOGW(TAG, "XML poll aborted");
+  }
+  this->xml_cycle_.reset();
+  this->xml_next_poll_ = now + this->xml_poll_interval_ms_;
 }
 
-void JuraComponent::publish_xml_values_() {
-  if (!this->xml_enabled_ || !this->xml_has_values_) {
+void JuraComponent::publish_xml_stats_() {
+  if (!this->enable_xml_poll_) {
     return;
   }
-  ESP_LOGD(TAG, "publish TR32=%s TG43=%s TGC0=%s",
-           format_numeric_array(this->xml_tr32_values_).c_str(),
-           format_numeric_array(this->xml_tg43_values_).c_str(),
-           format_numeric_array(this->xml_tgc0_values_).c_str());
-  for (size_t i = 0; i < this->xml_tr32_sensors_.size(); ++i) {
-    if (this->xml_tr32_sensors_[i] != nullptr) {
-      this->xml_tr32_sensors_[i]->publish_state(static_cast<float>(this->xml_tr32_values_[i]));
-    }
+  if (this->xml_stats_.empty()) {
+    return;
   }
-  for (size_t i = 0; i < this->xml_tg43_sensors_.size(); ++i) {
-    if (this->xml_tg43_sensors_[i] != nullptr) {
-      this->xml_tg43_sensors_[i]->publish_state(static_cast<float>(this->xml_tg43_values_[i]));
-    }
+  const auto &stats = this->xml_stats_.values();
+  for (const auto &entry : stats) {
+    this->publish_single_stat_(entry.first, entry.second.value, entry.second.label);
   }
-  for (size_t i = 0; i < this->xml_tgc0_sensors_.size(); ++i) {
-    if (this->xml_tgc0_sensors_[i] != nullptr) {
-      this->xml_tgc0_sensors_[i]->publish_state(static_cast<float>(this->xml_tgc0_values_[i]));
+}
+
+void JuraComponent::publish_single_stat_(const std::string &name, double value, const std::string &label) {
+  auto *sensor = this->get_or_create_sensor_(name, label);
+  if (sensor == nullptr) {
+    ESP_LOGW(TAG, "XML field %s konnte nicht veröffentlicht werden", name.c_str());
+    return;
+  }
+  sensor->publish_state(static_cast<float>(value));
+  ESP_LOGD(TAG, "XML publish: %s=%.3f", name.c_str(), value);
+}
+
+sensor::Sensor *JuraComponent::get_or_create_sensor_(const std::string &name, const std::string &label) {
+  auto it = this->xml_sensors_.find(name);
+  if (it != this->xml_sensors_.end()) {
+    if (!label.empty() && this->xml_sensor_labels_[name] != label) {
+      it->second->set_name(label);
+      this->xml_sensor_labels_[name] = label;
     }
+    return it->second;
+  }
+  auto *sensor_obj = new sensor::Sensor();
+  sensor_obj->set_accuracy_decimals(0);
+  sensor_obj->set_internal(false);
+  try_set_parent(sensor_obj, this, 0);
+  register_sensor_with_app(sensor_obj);
+  std::string effective_label = label.empty() ? name : label;
+  sensor_obj->set_name(effective_label);
+  this->xml_sensor_labels_[name] = effective_label;
+  this->xml_sensors_[name] = sensor_obj;
+  return sensor_obj;
+}
+
+const char *JuraComponent::xml_command_for_index_(size_t index) {
+  static const char *const COMMANDS[] = {"@TR:32", "@TG:43", "@TG:C0"};
+  if (index >= sizeof(COMMANDS) / sizeof(COMMANDS[0])) {
+    return "";
+  }
+  return COMMANDS[index];
+}
+
+const char *JuraComponent::xml_log_label_for_index_(size_t index) {
+  static const char *const LABELS[] = {"TR32", "TG43", "TGC0"};
+  if (index >= sizeof(LABELS) / sizeof(LABELS[0])) {
+    return "?";
+  }
+  return LABELS[index];
+}
+
+void JuraComponent::XmlCycleState::reset() {
+  this->phase = Phase::Idle;
+  this->command_index = 0;
+  this->deadline_ms = 0;
+  this->next_action_ms = 0;
+  for (auto &response : this->responses) {
+    response.clear();
   }
 }
 

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -6,8 +6,8 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
-#include <deque>
 
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
@@ -71,6 +71,7 @@ class TextSensor {
 #include "jutta_config.h"
 #include "jutta_connection.hpp"
 #include "jutta_commands.hpp"
+#include "jutta_proto_xml.h"
 
 namespace esphome {
 namespace jutta_component {
@@ -93,18 +94,9 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   const std::string &device_type() const { return this->device_type_; }
 
   void set_machine_data_sensor(text_sensor::TextSensor *sensor) { this->machine_data_sensor_ = sensor; }
-  void set_xml_enabled(bool enabled) {
-#if JUTTA_XML_ENABLE
-    this->xml_enabled_ = enabled;
-#else
-    (void) enabled;
-    this->xml_enabled_ = false;
-#endif
-  }
+  void set_enable_xml_poll(bool enabled) { this->enable_xml_poll_ = enabled; }
+  void set_xml_mapping_path(const std::string &path) { this->xml_mapping_path_ = path; }
   void set_xml_poll_interval(uint32_t interval_ms) { this->xml_poll_interval_ms_ = interval_ms; }
-  void set_xml_rx_timeout(uint32_t timeout_ms) { this->xml_rx_timeout_ms_ = timeout_ms; }
-  void set_xml_path(const std::string &path) { this->xml_path_ = path; }
-  void set_xml_inline(const std::string &xml);
 
  protected:
   enum class HandshakeStage { IDLE, HELLO, SEND_T1, WAIT_T2, SEND_T2, WAIT_T3, SEND_T3, DONE, FAILED };
@@ -118,24 +110,19 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   void process_machine_data_query();
   void publish_machine_data_(const std::string &response);
   void process_xml_polling();
-  void load_xml_mapping_();
+  bool ensure_xml_mapping_loaded_();
+  void log_xml_mapping_status_();
   void ensure_xml_sensors_created_();
-  void apply_xml_labels_();
   void reset_xml_cycle_state_();
-  bool perform_xml_cycle_();
-  bool send_db_command_(const std::string &command);
-  void publish_xml_values_();
-  void update_sensor_names_();
-  bool ensure_filesystem_ready_();
-  bool load_xml_from_path_(std::string &content);
-  bool parse_xml_content_(const std::string &content);
-  bool parse_command_id_(const std::string &command, uint8_t &command_id) const;
-  void log_xml_mapping_info_();
-  bool await_db_response_(const std::string &command, uint8_t command_id, size_t expected_len,
-                          std::vector<uint8_t> &decoded);
-  bool consume_pending_db_frame_(const std::string &command, uint8_t command_id, size_t expected_len,
-                                 std::vector<uint8_t> &decoded, bool *dropped_echo = nullptr);
-  void discard_stale_pending_frames_();
+  void start_xml_cycle_(uint32_t now);
+  void handle_xml_cycle_(uint32_t now);
+  bool try_receive_xml_frame_(uint32_t now);
+  void finish_xml_cycle_(uint32_t now, bool success);
+  void publish_xml_stats_();
+  void publish_single_stat_(const std::string &name, double value, const std::string &label);
+  sensor::Sensor *get_or_create_sensor_(const std::string &name, const std::string &label);
+  static const char *xml_command_for_index_(size_t index);
+  static const char *xml_log_label_for_index_(size_t index);
 
   std::unique_ptr<::jutta_proto::JuttaConnection> connection_;
   std::unique_ptr<::jutta_proto::CoffeeMaker> coffee_maker_;
@@ -153,63 +140,28 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   bool machine_data_request_pending_{false};
   uint32_t machine_data_request_start_{0};
 
-  struct XmlMapping {
-    bool valid{false};
-    std::string tr32_command{"@TR:32"};
-    std::string tg43_command{"@TG:43"};
-    std::string tgc0_command{"@TG:C0"};
-    std::array<std::string, 10> tr32_labels{};
-    std::array<std::string, 6> tg43_labels{};
-    std::array<std::string, 3> tgc0_labels{};
-    uint8_t tr32_id{0x32};
-    uint8_t tg43_id{0x43};
-    uint8_t tgc0_id{0xC0};
-  };
-
-  XmlMapping xml_mapping_{};
-  bool xml_enabled_{JUTTA_XML_ENABLE != 0};
-  uint32_t xml_poll_interval_ms_{JUTTA_XML_POLL_MS};
-  uint32_t xml_rx_timeout_ms_{JUTTA_XML_RX_TIMEOUT_MS};
+  bool enable_xml_poll_{false};
+  uint32_t xml_poll_interval_ms_{30000};
+  std::string xml_mapping_path_{"/config/esphome/e6.xml"};
   uint32_t xml_next_poll_{0};
-  bool xml_initialized_{false};
   bool xml_mapping_logged_{false};
-  std::array<sensor::Sensor *, 10> xml_tr32_sensors_{};
-  std::array<sensor::Sensor *, 6> xml_tg43_sensors_{};
-  std::array<sensor::Sensor *, 3> xml_tgc0_sensors_{};
-  std::array<uint16_t, 10> xml_tr32_values_{};
-  std::array<uint16_t, 6> xml_tg43_values_{};
-  std::array<uint32_t, 3> xml_tgc0_values_{};
-  bool xml_has_values_{false};
-  bool xml_busy_{false};
-  std::string xml_path_{"/config/esphome/e6.xml"};
-  std::string xml_inline_{};
-  bool filesystem_attempted_{false};
-  bool filesystem_available_{false};
+  bool xml_mapping_loaded_{false};
+  XmlMapping xml_mapping_{};
+  MachineStats xml_stats_{};
+  std::unordered_map<std::string, sensor::Sensor *> xml_sensors_{};
+  std::unordered_map<std::string, std::string> xml_sensor_labels_{};
 
-  struct DbFramer {
-    void clear();
-    void push_encoded(const uint8_t *data, size_t length);
-    std::vector<std::vector<uint8_t>> try_extract_frames();
+  struct XmlCycleState {
+    enum class Phase { Idle, WaitingForFrame, DelayBeforeNext };
 
-    static constexpr size_t BUFFER_CAPACITY = 2048;
+    void reset();
 
-   private:
-    void consume(size_t length);
-
-    std::array<uint8_t, BUFFER_CAPACITY> buffer_{};
-    size_t head_{0};
-    size_t size_{0};
-  };
-
-  struct PendingDbFrame {
-    std::vector<uint8_t> encoded;
-    std::vector<uint8_t> decoded;
-    bool decoded_valid{false};
-    bool decode_attempted{false};
-  };
-
-  DbFramer db_framer_{};
-  std::deque<PendingDbFrame> db_pending_frames_{};
+    Phase phase{Phase::Idle};
+    size_t command_index{0};
+    uint32_t deadline_ms{0};
+    uint32_t next_action_ms{0};
+    std::array<std::vector<uint8_t>, 3> responses{};
+  } xml_cycle_{};
 };
 
 class StartBrewAction : public esphome::Action<> {

--- a/esphome/components/jutta_proto/jutta_proto_xml.cpp
+++ b/esphome/components/jutta_proto/jutta_proto_xml.cpp
@@ -1,0 +1,402 @@
+#include "esphome/components/jutta_proto/jutta_proto_xml.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <sstream>
+
+#include "esphome/core/log.h"
+#ifdef USE_FILESYSTEM
+#include "esphome/components/filesystem/filesystem.h"
+#endif
+
+namespace esphome {
+namespace jutta_component {
+
+namespace {
+static const char *const TAG = "jutta_proto.xml";
+
+struct AttributeMap {
+  std::unordered_map<std::string, std::string> values;
+
+  std::string get(const std::string &key) const {
+    auto it = this->values.find(key);
+    if (it != this->values.end()) {
+      return it->second;
+    }
+    return {};
+  }
+};
+
+inline std::string to_lower(const std::string &input) {
+  std::string result = input;
+  std::transform(result.begin(), result.end(), result.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return result;
+}
+
+AttributeMap parse_attributes(const std::string &tag) {
+  AttributeMap map;
+  std::size_t pos = 0;
+  while (pos < tag.size()) {
+    std::size_t name_start = tag.find_first_not_of(" \t\r\n<", pos);
+    if (name_start == std::string::npos) {
+      break;
+    }
+    std::size_t name_end = tag.find_first_of("= \t\r\n>", name_start);
+    if (name_end == std::string::npos) {
+      break;
+    }
+    std::string key = to_lower(tag.substr(name_start, name_end - name_start));
+    pos = tag.find('=', name_end);
+    if (pos == std::string::npos) {
+      break;
+    }
+    ++pos;
+    pos = tag.find_first_not_of(" \t\r\n", pos);
+    if (pos == std::string::npos) {
+      break;
+    }
+    char quote = tag[pos];
+    if (quote == '\"' || quote == '\'') {
+      ++pos;
+    } else {
+      quote = ' ';
+    }
+    std::size_t value_end;
+    if (quote == ' ') {
+      value_end = tag.find_first_of(" \t\r\n>", pos);
+    } else {
+      value_end = tag.find(quote, pos);
+    }
+    if (value_end == std::string::npos) {
+      break;
+    }
+    std::string value = tag.substr(pos, value_end - pos);
+    map.values[key] = value;
+    pos = value_end + 1;
+  }
+  return map;
+}
+
+bool parse_size_t(const AttributeMap &attrs, std::initializer_list<const char *> keys, std::size_t &out) {
+  for (const char *key : keys) {
+    std::string value = attrs.get(to_lower(key));
+    if (!value.empty()) {
+      char *end = nullptr;
+      auto parsed = std::strtoul(value.c_str(), &end, 0);
+      if (end != value.c_str()) {
+        out = static_cast<std::size_t>(parsed);
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+bool parse_double(const AttributeMap &attrs, std::initializer_list<const char *> keys, double &out) {
+  for (const char *key : keys) {
+    std::string value = attrs.get(to_lower(key));
+    if (!value.empty()) {
+      char *end = nullptr;
+      auto parsed = std::strtod(value.c_str(), &end);
+      if (end != value.c_str()) {
+        out = parsed;
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+bool load_file_content(const std::string &path, std::string &content) {
+#ifdef USE_FILESYSTEM
+  if (auto *fs = esphome::filesystem::global_filesystem; fs != nullptr) {
+    auto file = fs->open(path.c_str(), "r");
+    if (file) {
+      std::ostringstream stream;
+      while (file.available()) {
+        stream << static_cast<char>(file.read());
+      }
+      content = stream.str();
+      return true;
+    }
+  }
+#endif
+  std::ifstream file(path, std::ios::binary);
+  if (!file.is_open()) {
+    return false;
+  }
+  std::ostringstream stream;
+  stream << file.rdbuf();
+  content = stream.str();
+  return true;
+}
+
+void trim(std::string &value) {
+  auto begin = value.find_first_not_of(" \t\r\n");
+  auto end = value.find_last_not_of(" \t\r\n");
+  if (begin == std::string::npos || end == std::string::npos) {
+    value.clear();
+  } else {
+    value = value.substr(begin, end - begin + 1);
+  }
+}
+
+bool decode_field_value(const XmlField &field, const std::vector<uint8_t> &decoded, double &value) {
+  if (field.byte_length == 0) {
+    return false;
+  }
+  std::size_t required = field.byte_offset + field.byte_length;
+  if (decoded.size() < required) {
+    return false;
+  }
+  std::uint64_t raw = 0;
+  for (std::size_t i = 0; i < field.byte_length; ++i) {
+    std::size_t index = field.little_endian ? (field.byte_offset + field.byte_length - 1 - i)
+                                           : (field.byte_offset + i);
+    raw = (raw << 8) | static_cast<std::uint64_t>(decoded[index]);
+  }
+  if (field.bit_length > 0) {
+    std::size_t shift = field.bit_offset;
+    raw >>= shift;
+    if (field.bit_length < 64U) {
+      std::uint64_t mask = (static_cast<std::uint64_t>(1) << field.bit_length) - 1ULL;
+      raw &= mask;
+    }
+  }
+  value = static_cast<double>(raw) * field.scale;
+  return true;
+}
+
+bool map_fields(const std::vector<uint8_t> &decoded, const XmlCommandMapping &mapping,
+                MachineStats &out, const char *label) {
+  bool any = false;
+  for (const auto &field : mapping.fields) {
+    double numeric = 0.0;
+    if (!decode_field_value(field, decoded, numeric)) {
+      ESP_LOGW(TAG, "XML %s Feld %s konnte nicht gelesen werden (Offset=%u, Bytes=%u, Daten=%u)", label,
+               field.name.c_str(), static_cast<unsigned>(field.byte_offset),
+               static_cast<unsigned>(field.byte_length), static_cast<unsigned>(decoded.size()));
+      continue;
+    }
+    out.set_value(field.name, numeric, field.label);
+    any = true;
+  }
+  return any;
+}
+
+XmlCommandMapping *mapping_for_id(XmlMapping &mapping, const std::string &id) {
+  std::string lowered = to_lower(id);
+  if (lowered == "tr32") {
+    return &mapping.tr32_fields;
+  }
+  if (lowered == "tg43") {
+    return &mapping.tg43_fields;
+  }
+  if (lowered == "tgc0") {
+    return &mapping.tgc0_fields;
+  }
+  return nullptr;
+}
+
+}  // namespace
+
+void MachineStats::clear() { this->values_.clear(); }
+
+bool MachineStats::empty() const { return this->values_.empty(); }
+
+void MachineStats::set_value(const std::string &name, double value, const std::string &label) {
+  this->values_[name] = StatValue{value, label};
+}
+
+bool MachineStats::has_value(const std::string &name) const {
+  return this->values_.find(name) != this->values_.end();
+}
+
+const std::unordered_map<std::string, StatValue> &MachineStats::values() const { return this->values_; }
+
+namespace {
+
+bool parse_fields(const std::string &content, XmlCommandMapping &mapping) {
+  std::string lower = to_lower(content);
+  std::size_t search_pos = 0;
+  while (true) {
+    std::size_t field_pos = lower.find("<field", search_pos);
+    if (field_pos == std::string::npos) {
+      break;
+    }
+    std::size_t tag_end = lower.find('>', field_pos);
+    if (tag_end == std::string::npos) {
+      break;
+    }
+    std::string tag_text = content.substr(field_pos, tag_end - field_pos + 1);
+    auto attrs = parse_attributes(tag_text);
+    XmlField field;
+    field.name = attrs.get("name");
+    trim(field.name);
+    if (field.name.empty()) {
+      ESP_LOGW(TAG, "XML Feld ohne Namen ignoriert");
+      search_pos = tag_end + 1;
+      continue;
+    }
+    field.label = attrs.get("label");
+    trim(field.label);
+    if (field.label.empty()) {
+      field.label = field.name;
+    }
+    parse_size_t(attrs, {"byte", "offset", "start", "index"}, field.byte_offset);
+    parse_size_t(attrs, {"bits", "bit_length"}, field.bit_length);
+    parse_size_t(attrs, {"bit", "bit_offset"}, field.bit_offset);
+    if (!parse_size_t(attrs, {"bytes", "length", "size"}, field.byte_length)) {
+      if (field.bit_length > 0) {
+        field.byte_length = (field.bit_offset + field.bit_length + 7) / 8;
+      } else {
+        std::string type = to_lower(attrs.get("type"));
+        if (type.find("32") != std::string::npos) {
+          field.byte_length = 4;
+        } else if (type.find("16") != std::string::npos) {
+          field.byte_length = 2;
+        } else if (type.find("8") != std::string::npos || type == "u8") {
+          field.byte_length = 1;
+        }
+      }
+    }
+    if (field.byte_length == 0) {
+      field.byte_length = 2;
+    }
+    std::string endian = to_lower(attrs.get("endian"));
+    if (endian == "little" || attrs.get("little_endian") == "1") {
+      field.little_endian = true;
+    }
+    double scale = field.scale;
+    if (parse_double(attrs, {"scale", "factor", "multiplier"}, scale)) {
+      field.scale = scale;
+    }
+    double divisor = 0.0;
+    if (parse_double(attrs, {"divisor"}, divisor) && divisor != 0.0) {
+      field.scale /= divisor;
+    }
+    mapping.fields.push_back(field);
+    search_pos = tag_end + 1;
+  }
+  return !mapping.fields.empty();
+}
+
+bool parse_xml_mapping_content(const std::string &content, XmlMapping &mapping) {
+  std::string lower = to_lower(content);
+  std::size_t search_pos = 0;
+  bool any_fields = false;
+  while (true) {
+    std::size_t frame_pos = lower.find("<frame", search_pos);
+    if (frame_pos == std::string::npos) {
+      break;
+    }
+    std::size_t tag_end = lower.find('>', frame_pos);
+    if (tag_end == std::string::npos) {
+      break;
+    }
+    std::size_t close_pos = lower.find("</frame", tag_end);
+    if (close_pos == std::string::npos) {
+      break;
+    }
+    std::string tag_text = content.substr(frame_pos, tag_end - frame_pos + 1);
+    auto attrs = parse_attributes(tag_text);
+    std::string id = attrs.get("id");
+    trim(id);
+    auto *command = mapping_for_id(mapping, id);
+    if (command == nullptr) {
+      ESP_LOGW(TAG, "Unbekannter Frame-Typ '%s'", id.c_str());
+      search_pos = close_pos + 7;
+      continue;
+    }
+    std::string inner = content.substr(tag_end + 1, close_pos - tag_end - 1);
+    if (parse_fields(inner, *command)) {
+      any_fields = true;
+    }
+    search_pos = close_pos + 7;
+  }
+  mapping.valid = any_fields;
+  return mapping.valid;
+}
+
+}  // namespace
+
+bool load_xml_mapping(const std::string &path, XmlMapping &mapping) {
+  std::string content;
+  if (!load_file_content(path, content)) {
+    ESP_LOGW(TAG, "XML Mapping %s konnte nicht geladen werden", path.c_str());
+    mapping.valid = false;
+    return false;
+  }
+  mapping = XmlMapping{};
+  mapping.source_path = path;
+  if (!parse_xml_mapping_content(content, mapping)) {
+    ESP_LOGW(TAG, "XML Mapping %s enthält keine bekannten Felder", path.c_str());
+    mapping.valid = false;
+    return false;
+  }
+  return true;
+}
+
+namespace {
+XmlMapping g_current_mapping{};
+bool g_has_mapping = false;
+}
+
+bool load_xml_mapping(const std::string &path) {
+  XmlMapping mapping;
+  if (!load_xml_mapping(path, mapping)) {
+    g_has_mapping = false;
+    g_current_mapping = XmlMapping{};
+    return false;
+  }
+  g_current_mapping = mapping;
+  g_has_mapping = mapping.valid;
+  return g_has_mapping;
+}
+
+const XmlMapping &get_loaded_xml_mapping() { return g_current_mapping; }
+
+bool map_tr32(const std::vector<uint8_t> &decoded, const XmlMapping &mapping, MachineStats &out) {
+  return map_fields(decoded, mapping.tr32_fields, out, "TR32");
+}
+
+bool map_tg43(const std::vector<uint8_t> &decoded, const XmlMapping &mapping, MachineStats &out) {
+  return map_fields(decoded, mapping.tg43_fields, out, "TG43");
+}
+
+bool map_tgc0(const std::vector<uint8_t> &decoded, const XmlMapping &mapping, MachineStats &out) {
+  return map_fields(decoded, mapping.tgc0_fields, out, "TGC0");
+}
+
+bool map_tr32(const std::vector<uint8_t> &decoded, MachineStats &out) {
+  if (!g_has_mapping) {
+    ESP_LOGW(TAG, "Kein XML-Mapping geladen");
+    return false;
+  }
+  return map_tr32(decoded, g_current_mapping, out);
+}
+
+bool map_tg43(const std::vector<uint8_t> &decoded, MachineStats &out) {
+  if (!g_has_mapping) {
+    ESP_LOGW(TAG, "Kein XML-Mapping geladen");
+    return false;
+  }
+  return map_tg43(decoded, g_current_mapping, out);
+}
+
+bool map_tgc0(const std::vector<uint8_t> &decoded, MachineStats &out) {
+  if (!g_has_mapping) {
+    ESP_LOGW(TAG, "Kein XML-Mapping geladen");
+    return false;
+  }
+  return map_tgc0(decoded, g_current_mapping, out);
+}
+
+}  // namespace jutta_component
+}  // namespace esphome
+

--- a/esphome/components/jutta_proto/jutta_proto_xml.h
+++ b/esphome/components/jutta_proto/jutta_proto_xml.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace esphome {
+namespace jutta_component {
+
+struct XmlField {
+  std::string name;
+  std::string label;
+  std::size_t byte_offset{0};
+  std::size_t byte_length{0};
+  std::size_t bit_offset{0};
+  std::size_t bit_length{0};
+  bool little_endian{false};
+  double scale{1.0};
+};
+
+struct XmlCommandMapping {
+  std::vector<XmlField> fields;
+};
+
+struct XmlMapping {
+  bool valid{false};
+  std::string source_path;
+  XmlCommandMapping tr32_fields;
+  XmlCommandMapping tg43_fields;
+  XmlCommandMapping tgc0_fields;
+};
+
+struct StatValue {
+  double value{0.0};
+  std::string label;
+};
+
+class MachineStats {
+ public:
+  void clear();
+  bool empty() const;
+  void set_value(const std::string &name, double value, const std::string &label);
+  bool has_value(const std::string &name) const;
+  const std::unordered_map<std::string, StatValue> &values() const;
+
+ private:
+  std::unordered_map<std::string, StatValue> values_{};
+};
+
+bool load_xml_mapping(const std::string &path, XmlMapping &mapping);
+bool load_xml_mapping(const std::string &path);
+const XmlMapping &get_loaded_xml_mapping();
+
+bool map_tr32(const std::vector<uint8_t> &decoded, const XmlMapping &mapping, MachineStats &out);
+bool map_tg43(const std::vector<uint8_t> &decoded, const XmlMapping &mapping, MachineStats &out);
+bool map_tgc0(const std::vector<uint8_t> &decoded, const XmlMapping &mapping, MachineStats &out);
+
+bool map_tr32(const std::vector<uint8_t> &decoded, MachineStats &out);
+bool map_tg43(const std::vector<uint8_t> &decoded, MachineStats &out);
+bool map_tgc0(const std::vector<uint8_t> &decoded, MachineStats &out);
+
+}  // namespace jutta_component
+}  // namespace esphome
+


### PR DESCRIPTION
## Summary
- add configuration flags for XML polling and bind them in the ESPHome component
- introduce robust DB-frame encoding/decoding helpers and an XML polling state machine that reuses the legacy UART handshake
- load J.O.E. XML mappings, publish numeric ESPHome sensors, and document the new workflow in German

## Testing
- not run (hardware dependent)


------
https://chatgpt.com/codex/tasks/task_e_68e0476d63a08328bc8fd9f86d972ad8