### PR TITLE
Support JOE command XML and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Since newer models **do not use** this old V1-Protocol any more I started this p
 ### Aktivierung des XML-Pollings
 
 - `enable_xml_poll`: Schaltet den zusätzlichen XML-Pfad frei (Standard `false`).
-- `xml_mapping_path`: Dateipfad zum J.O.E.-Mapping (Standard `"/config/esphome/e6.xml"`).
+- `xml_mapping_path`: Dateipfad zum J.O.E.-Mapping (Standard `"/data/jura_machine.xml"`).
 - `xml_poll_interval_ms`: Abstand zwischen zwei Abfragen in Millisekunden (Standard `30000`).
 
 Beispiel-Konfiguration in ESPHome:
@@ -32,15 +32,21 @@ jutta_proto:
   id: jura_e6
   uart_id: uart_bus
   enable_xml_poll: true
-  xml_mapping_path: "/config/esphome/e6.xml"
+  xml_mapping: !include jura_joe_xml_bundle_final/joe_codes_example.xml
+  xml_mapping_path: "/data/jura_machine.xml"
   xml_poll_interval_ms: 30000
 ```
 
 ### Mapping-Datei
 
-- Das Mapping folgt der Struktur der veröffentlichten `jura_joe_xml_bundle_final`-Dateien.
-- Bei erfolgreichem Laden erscheint im Log eine Zeile wie `XML mapping loaded from /config/esphome/e6.xml (valid=1, fields=...)`.
-- Ist die Datei nicht vorhanden oder fehlerhaft, läuft die Komponente weiter – lediglich das XML-Polling bleibt inaktiv.
+- Das Repository enthält mit `jura_joe_xml_bundle_final/joe_codes_example.xml` eine aktuelle Beispiel-XML aus dem offiziellen
+  Bundle. Sie kann direkt via `!include` eingebettet werden und landet dadurch automatisch im Firmware-Image.
+- Die Parser unterstützen sowohl die klassischen `<frame ...>`-Blöcke (für Statistik-Zähler) als auch `<command ...>`-Einträge
+  aus neueren J.O.E.-Exports.
+- Bei erfolgreichem Laden erscheint im Log eine Zeile wie `XML mapping loaded from /data/jura_machine.xml (stats=yes, fields=10/6/3, commands=42)`.
+- Enthält die XML ausschließlich Kommandos, bleibt das Statistik-Polling deaktiviert – die Kommandoliste steht trotzdem im Log
+  zur Verfügung.
+- Ist die Datei nicht vorhanden oder fehlerhaft, läuft die Komponente weiter; XML-Polling und Kommandoliste bleiben dann inaktiv.
 
 ### Automatisch erzeugte Sensoren
 
@@ -297,9 +303,12 @@ registriert und bleiben dauerhaft sichtbar.
 1. **Feature aktivieren:** Die Standardwerte werden über `esphome/components/jutta_proto/jutta_config.h` gesteuert. Dort
    können `JUTTA_XML_ENABLE`, `JUTTA_XML_POLL_MS` und `JUTTA_XML_RX_TIMEOUT_MS` bei Bedarf angepasst werden. Voreinstellung ist
    `JUTTA_XML_ENABLE 1`, sodass der XML-Pfad ohne weitere Änderungen aktiv ist.
-2. **XML-Mapping bereitstellen:** Exportiere in der J.O.E.-App die Maschinen-XML und kopiere die Datei als
-   `/data/jura_machine.xml` auf das ESPHome-Gerät. Falls die Datei fehlt oder unvollständig ist, werden Standardbefehle und
-   generische Labels verwendet.
+2. **XML-Mapping bereitstellen:** Exportiere in der J.O.E.-App die Maschinen-XML und binde die Datei über die YAML-Option
+   `xml_mapping: !include <pfad-zur-xml>` ein (z. B. `!include jura_joe_xml_bundle_final/joe_codes_example.xml`). Die Firmware
+   übernimmt die Daten beim Flashen automatisch und stellt sie zur Laufzeit unter dem logischen Pfad `/data/jura_machine.xml`
+   bereit. Enthält die Datei ausschließlich `<command>`-Einträge, bleiben die Statistik-Zähler zwar deaktiviert, die Kommandonamen
+   werden aber protokolliert und stehen für manuelle Sequenzen bereit. Fehlt die Datei oder ist sie unvollständig, setzt die
+   Firmware auf Standardbefehle und generische Labels zurück.
 3. **Zyklische Abfrage beobachten:** Nach erfolgreichem Legacy-Handshake erscheinen im Log Einträge wie `XML poll start`,
    `TX_DB "@TR:32"`, `RX_DB decoded_len=21 expected=21` sowie `publish TR32=[…]`. Bei einem Timeout wird `RX_DB timeout`
    ausgegeben. Nur wenn alle drei Blöcke korrekt gelesen werden, werden neue Werte veröffentlicht.
@@ -307,15 +316,16 @@ registriert und bleiben dauerhaft sichtbar.
 #### XML-Pfad konfigurieren
 
 * Standardpfad für das Mapping ist `/data/jura_machine.xml`.
-* Über die YAML-Option `xml_path` kann ein alternativer Speicherort angegeben werden:
+* Über die YAML-Option `xml_mapping_path` kann ein alternativer Gerätepfad angegeben werden:
 
   ```yaml
   jutta_proto:
     id: jura1
-    xml_path: "/data/my_mapping/jura_map.xml"
+    xml_mapping_path: "/data/my_mapping/jura_map.xml"
   ```
 
-* Die referenzierte Datei muss vorab mit `uploadfs` oder über das ESPHome Dashboard auf das Gerät kopiert werden.
+* Die referenzierte Datei wird automatisch über `xml_mapping: !include ...` in die Firmware eingebettet; ein separates
+  Hochladen ist nicht erforderlich.
 
 #### Fehlersuche
 

--- a/docs/components/jutta_proto.md
+++ b/docs/components/jutta_proto.md
@@ -17,18 +17,42 @@ uart:
 jutta_proto:
   id: jura
   uart_id: jura_uart
-  jutta_xml_enable: true           # optional, default false
-  jutta_xml_poll_ms: 30000         # optional, poll interval in ms
-  jutta_xml_rx_timeout_ms: 900     # optional, frame timeout in ms
-  xml_path: "/data/jura_machine.xml"   # optional, override XML mapping path
+  enable_xml_poll: true                 # optional, default false
+  xml_poll_interval_ms: 30000           # optional, poll interval in ms
+  xml_mapping: !include jura_joe_xml_bundle_final/joe_codes_example.xml   # optional, XML aus dem Repo-Bundle laden
+  xml_mapping_path: "/data/jura_machine.xml"  # optional, Pfad auf dem Gerät
 ```
 
 The component takes care of the handshake during startup. Once the handshake finishes, all brewing actions become available.
 
-When `jutta_xml_enable` is set to `true`, the component periodically polls the JURA statistics interface using DB framing.
-During initialization it scans the mapping file (default `/data/jura_machine.xml`, configurable via `xml_path`, typically a
-J.O.E. export) to discover the exact command strings and optional labels for the exposed statistics blocks. If the file is
-missing or malformed the defaults `@TR:32`, `@TG:43`, and `@TG:C0` are used and the sensors keep their generic names.
+Wenn `enable_xml_poll` auf `true` gesetzt ist, fragt die Komponente zyklisch die JURA-Statistik via DB-Framing ab. Beim Start
+analysiert sie die Mapping-Datei (Standard `/data/jura_machine.xml`, per `xml_mapping_path` anpassbar) und erkennt sowohl
+klassische `<frame ...>`-Blöcke für Statistikfelder als auch `<command ...>`-Einträge aus den aktuellen
+`jura_joe_xml_bundle_final`-Exports. Werden Frames gefunden, ersetzen deren Labels die Standardnamen der Sensoren. Liegen nur
+Kommandos vor, bleibt das Polling deaktiviert – die Liste der Kommandos wird dennoch geladen und im Log ausgegeben.
+
+### Ablage der XML-Mapping-Datei
+
+Damit die XML beim Flashen automatisch übertragen wird, wird sie direkt in der YAML-Konfiguration referenziert. Mit
+`xml_mapping: !include <datei>` liest ESPHome die Datei beim Build ein und verpackt sie in der Firmware – beispielsweise über
+`!include jura_joe_xml_bundle_final/joe_codes_example.xml`, das dem Repository beiliegt. Beim Start lädt der Komponentencode
+das Mapping direkt aus dem eingebetteten Speicher und verwendet `/data/jura_machine.xml` als logischen Pfad. Wer einen anderen
+Gerätepfad benötigt, kann `xml_mapping_path` anpassen – der YAML-Inhalt wird trotzdem eingebettet.
+
+Ein minimales Beispiel mit eingebundenem Mapping:
+
+```yaml
+jutta_proto:
+  id: jura
+  uart_id: jura_uart
+  enable_xml_poll: true
+  xml_mapping: !include jura_joe_xml_bundle_final/joe_codes_example.xml
+```
+
+Das Log meldet nach dem Start `XML mapping loaded from /data/jura_machine.xml (stats=yes, …, commands=…)`. Schlägt das Laden
+fehl, erscheint eine Warnung mit dem in YAML hinterlegten Pfad. In diesem Fall sollte geprüft werden, ob die Datei korrekt
+eingebunden wurde (`esphome config <yaml>` zeigt die expandierte Konfiguration) und ob das XML gültige `<frame>`- oder
+`<command>`-Einträge enthält.
 
 ### XML statistics sensors
 

--- a/esphome/components/jutta_proto/__init__.py
+++ b/esphome/components/jutta_proto/__init__.py
@@ -22,6 +22,7 @@ CONF_MACHINE_DATA = "machine_data"
 CONF_ENABLE_XML_POLL = "enable_xml_poll"
 CONF_XML_MAPPING_PATH = "xml_mapping_path"
 CONF_XML_POLL_INTERVAL_MS = "xml_poll_interval_ms"
+CONF_XML_MAPPING_INLINE = "xml_mapping"
 
 jutta_component_ns = cg.esphome_ns.namespace("jutta_component")
 jutta_proto_ns = cg.global_ns.namespace("jutta_proto")
@@ -95,7 +96,8 @@ CONFIG_SCHEMA = (
             cv.GenerateID(): cv.declare_id(JuraComponent),
             cv.Optional(CONF_MACHINE_DATA): text_sensor.text_sensor_schema(),
             cv.Optional(CONF_ENABLE_XML_POLL, default=False): cv.boolean,
-            cv.Optional(CONF_XML_MAPPING_PATH, default="/config/esphome/e6.xml"): cv.string,
+            cv.Optional(CONF_XML_MAPPING_PATH, default="/data/jura_machine.xml"): cv.string,
+            cv.Optional(CONF_XML_MAPPING_INLINE): cv.string,
             cv.Optional(CONF_XML_POLL_INTERVAL_MS, default=30000): cv.All(
                 cv.positive_int, cv.Range(min=25000)
             ),
@@ -243,6 +245,8 @@ async def to_code(config):
 
     cg.add(var.set_enable_xml_poll(config[CONF_ENABLE_XML_POLL]))
     cg.add(var.set_xml_mapping_path(cg.std_string(config[CONF_XML_MAPPING_PATH])))
+    if CONF_XML_MAPPING_INLINE in config:
+        cg.add(var.set_xml_mapping_blob(cg.std_string(config[CONF_XML_MAPPING_INLINE])))
     cg.add(var.set_xml_poll_interval(config[CONF_XML_POLL_INTERVAL_MS]))
 
     if CONF_MACHINE_DATA in config:

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -281,8 +281,9 @@ void JuraComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "  XML polling: %s", this->enable_xml_poll_ ? "enabled" : "disabled");
   ESP_LOGCONFIG(TAG, "  XML mapping path: %s", this->xml_mapping_path_.c_str());
   ESP_LOGCONFIG(TAG, "  XML poll interval: %u ms", static_cast<unsigned>(this->xml_poll_interval_ms_));
-  ESP_LOGCONFIG(TAG, "  XML mapping loaded: %s",
-                YESNO(this->xml_mapping_loaded_ && this->xml_mapping_.valid));
+  ESP_LOGCONFIG(TAG, "  XML mapping loaded: %s", YESNO(this->xml_mapping_loaded_));
+  ESP_LOGCONFIG(TAG, "  XML statistics available: %s", YESNO(this->xml_mapping_.valid));
+  ESP_LOGCONFIG(TAG, "  XML commands: %u", static_cast<unsigned>(this->xml_mapping_.commands.size()));
   ESP_LOGCONFIG(TAG, "  XML sensors: %u", static_cast<unsigned>(this->xml_sensors_.size()));
 }
 
@@ -591,17 +592,25 @@ bool JuraComponent::ensure_xml_mapping_loaded_() {
     return this->xml_mapping_.valid;
   }
   XmlMapping mapping;
-  if (!load_xml_mapping(this->xml_mapping_path_, mapping)) {
+  bool loaded = false;
+  if (this->xml_mapping_has_blob_) {
+    loaded = load_xml_mapping_from_content(this->xml_mapping_path_, this->xml_mapping_blob_, mapping);
+  } else {
+    loaded = load_xml_mapping(this->xml_mapping_path_, mapping);
+  }
+  if (!loaded) {
     ESP_LOGW(TAG, "Failed to load XML mapping at %s", this->xml_mapping_path_.c_str());
     this->xml_mapping_loaded_ = false;
     this->xml_mapping_.valid = false;
+    this->xml_mapping_.has_commands = false;
+    this->xml_mapping_.commands.clear();
     this->xml_mapping_logged_ = false;
     this->xml_stats_.clear();
     this->log_xml_mapping_status_();
     return false;
   }
   this->xml_mapping_ = std::move(mapping);
-  this->xml_mapping_loaded_ = this->xml_mapping_.valid;
+  this->xml_mapping_loaded_ = true;
   this->xml_mapping_logged_ = false;
   this->xml_stats_.clear();
   this->log_xml_mapping_status_();
@@ -612,11 +621,24 @@ void JuraComponent::log_xml_mapping_status_() {
   if (this->xml_mapping_logged_) {
     return;
   }
-  ESP_LOGI(TAG, "XML mapping loaded from %s (valid=%d, fields=%u/%u/%u)",
-           this->xml_mapping_path_.c_str(), static_cast<int>(this->xml_mapping_.valid),
+  const std::string &source = this->xml_mapping_.source_path.empty() ? this->xml_mapping_path_
+                                                                     : this->xml_mapping_.source_path;
+  if (!this->xml_mapping_loaded_) {
+    ESP_LOGW(TAG, "XML mapping not available at %s", source.c_str());
+    this->xml_mapping_logged_ = true;
+    return;
+  }
+  ESP_LOGI(TAG, "XML mapping loaded from %s (stats=%s, fields=%u/%u/%u, commands=%u)", source.c_str(),
+           YESNO(this->xml_mapping_.valid),
            static_cast<unsigned>(this->xml_mapping_.tr32_fields.fields.size()),
            static_cast<unsigned>(this->xml_mapping_.tg43_fields.fields.size()),
-           static_cast<unsigned>(this->xml_mapping_.tgc0_fields.fields.size()));
+           static_cast<unsigned>(this->xml_mapping_.tgc0_fields.fields.size()),
+           static_cast<unsigned>(this->xml_mapping_.commands.size()));
+  if (!this->xml_mapping_.valid && this->xml_mapping_.has_commands) {
+    ESP_LOGI(TAG,
+             "XML mapping %s liefert %u Kommando-Einträge, enthält jedoch keine Statistik-Frames. XML-Polling bleibt deaktiviert.",
+             source.c_str(), static_cast<unsigned>(this->xml_mapping_.commands.size()));
+  }
   this->xml_mapping_logged_ = true;
 }
 

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -96,6 +96,10 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   void set_machine_data_sensor(text_sensor::TextSensor *sensor) { this->machine_data_sensor_ = sensor; }
   void set_enable_xml_poll(bool enabled) { this->enable_xml_poll_ = enabled; }
   void set_xml_mapping_path(const std::string &path) { this->xml_mapping_path_ = path; }
+  void set_xml_mapping_blob(const std::string &blob) {
+    this->xml_mapping_blob_ = blob;
+    this->xml_mapping_has_blob_ = true;
+  }
   void set_xml_poll_interval(uint32_t interval_ms) { this->xml_poll_interval_ms_ = interval_ms; }
 
  protected:
@@ -142,7 +146,9 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
 
   bool enable_xml_poll_{false};
   uint32_t xml_poll_interval_ms_{30000};
-  std::string xml_mapping_path_{"/config/esphome/e6.xml"};
+  std::string xml_mapping_path_{"/data/jura_machine.xml"};
+  std::string xml_mapping_blob_{};
+  bool xml_mapping_has_blob_{false};
   uint32_t xml_next_poll_{0};
   bool xml_mapping_logged_{false};
   bool xml_mapping_loaded_{false};

--- a/esphome/components/jutta_proto/jutta_proto_xml.cpp
+++ b/esphome/components/jutta_proto/jutta_proto_xml.cpp
@@ -113,10 +113,15 @@ bool parse_double(const AttributeMap &attrs, std::initializer_list<const char *>
 }
 
 bool load_file_content(const std::string &path, std::string &content) {
+  if (path.empty()) {
+    return false;
+  }
+
 #ifdef USE_FILESYSTEM
   if (auto *fs = esphome::filesystem::global_filesystem; fs != nullptr) {
     auto file = fs->open(path.c_str(), "r");
     if (file) {
+      ESP_LOGI(TAG, "Lade XML Mapping aus '%s' (Filesystem)", path.c_str());
       std::ostringstream stream;
       while (file.available()) {
         stream << static_cast<char>(file.read());
@@ -126,10 +131,13 @@ bool load_file_content(const std::string &path, std::string &content) {
     }
   }
 #endif
+
   std::ifstream file(path, std::ios::binary);
   if (!file.is_open()) {
     return false;
   }
+
+  ESP_LOGI(TAG, "Lade XML Mapping aus '%s'", path.c_str());
   std::ostringstream stream;
   stream << file.rdbuf();
   content = stream.str();
@@ -191,13 +199,20 @@ bool map_fields(const std::vector<uint8_t> &decoded, const XmlCommandMapping &ma
 
 XmlCommandMapping *mapping_for_id(XmlMapping &mapping, const std::string &id) {
   std::string lowered = to_lower(id);
-  if (lowered == "tr32") {
+  std::string canonical;
+  canonical.reserve(lowered.size());
+  for (char ch : lowered) {
+    if (std::isalnum(static_cast<unsigned char>(ch)) != 0) {
+      canonical.push_back(ch);
+    }
+  }
+  if (canonical == "tr32") {
     return &mapping.tr32_fields;
   }
-  if (lowered == "tg43") {
+  if (canonical == "tg43") {
     return &mapping.tg43_fields;
   }
-  if (lowered == "tgc0") {
+  if (canonical == "tgc0") {
     return &mapping.tgc0_fields;
   }
   return nullptr;
@@ -286,6 +301,52 @@ bool parse_fields(const std::string &content, XmlCommandMapping &mapping) {
   return !mapping.fields.empty();
 }
 
+bool parse_commands(const std::string &content, std::vector<XmlCommand> &commands) {
+  std::string lower = to_lower(content);
+  std::size_t search_pos = 0;
+  bool any = false;
+  while (true) {
+    std::size_t command_pos = lower.find("<command", search_pos);
+    if (command_pos == std::string::npos) {
+      break;
+    }
+    std::size_t tag_end = lower.find('>', command_pos);
+    if (tag_end == std::string::npos) {
+      break;
+    }
+    std::string tag_text = content.substr(command_pos, tag_end - command_pos + 1);
+    auto attrs = parse_attributes(tag_text);
+
+    XmlCommand command;
+    command.name = attrs.get("name");
+    trim(command.name);
+    command.code = attrs.get("code");
+    trim(command.code);
+    if (command.code.empty()) {
+      ESP_LOGW(TAG, "XML Kommando ohne 'code' ignoriert");
+      search_pos = tag_end + 1;
+      continue;
+    }
+    if (command.name.empty()) {
+      command.name = command.code;
+    }
+
+    std::string mode = attrs.get("mode");
+    trim(mode);
+    std::string lowered_mode = to_lower(mode);
+    if (lowered_mode == "plain" || lowered_mode == "raw") {
+      command.db_mode = false;
+    } else {
+      command.db_mode = true;
+    }
+
+    commands.push_back(command);
+    any = true;
+    search_pos = tag_end + 1;
+  }
+  return any;
+}
+
 bool parse_xml_mapping_content(const std::string &content, XmlMapping &mapping) {
   std::string lower = to_lower(content);
   std::size_t search_pos = 0;
@@ -320,10 +381,26 @@ bool parse_xml_mapping_content(const std::string &content, XmlMapping &mapping) 
     search_pos = close_pos + 7;
   }
   mapping.valid = any_fields;
-  return mapping.valid;
+  mapping.commands.clear();
+  mapping.has_commands = parse_commands(content, mapping.commands);
+  return mapping.valid || mapping.has_commands;
 }
 
 }  // namespace
+
+bool load_xml_mapping_from_content(const std::string &source_label, const std::string &content,
+                                   XmlMapping &mapping) {
+  mapping = XmlMapping{};
+  mapping.source_path = source_label;
+  if (!parse_xml_mapping_content(content, mapping)) {
+    ESP_LOGW(TAG, "XML Mapping %s enthält keine bekannten Felder oder Kommandos", source_label.c_str());
+    mapping.valid = false;
+    mapping.has_commands = false;
+    mapping.commands.clear();
+    return false;
+  }
+  return true;
+}
 
 bool load_xml_mapping(const std::string &path, XmlMapping &mapping) {
   std::string content;
@@ -332,19 +409,24 @@ bool load_xml_mapping(const std::string &path, XmlMapping &mapping) {
     mapping.valid = false;
     return false;
   }
-  mapping = XmlMapping{};
-  mapping.source_path = path;
-  if (!parse_xml_mapping_content(content, mapping)) {
-    ESP_LOGW(TAG, "XML Mapping %s enthält keine bekannten Felder", path.c_str());
-    mapping.valid = false;
-    return false;
-  }
-  return true;
+  return load_xml_mapping_from_content(path, content, mapping);
 }
 
 namespace {
 XmlMapping g_current_mapping{};
 bool g_has_mapping = false;
+}
+
+bool load_xml_mapping_from_content(const std::string &source_label, const std::string &content) {
+  XmlMapping mapping;
+  if (!load_xml_mapping_from_content(source_label, content, mapping)) {
+    g_has_mapping = false;
+    g_current_mapping = XmlMapping{};
+    return false;
+  }
+  g_current_mapping = mapping;
+  g_has_mapping = mapping.valid;
+  return g_has_mapping;
 }
 
 bool load_xml_mapping(const std::string &path) {

--- a/esphome/components/jutta_proto/jutta_proto_xml.h
+++ b/esphome/components/jutta_proto/jutta_proto_xml.h
@@ -24,12 +24,20 @@ struct XmlCommandMapping {
   std::vector<XmlField> fields;
 };
 
+struct XmlCommand {
+  std::string name;
+  std::string code;
+  bool db_mode{true};
+};
+
 struct XmlMapping {
   bool valid{false};
   std::string source_path;
   XmlCommandMapping tr32_fields;
   XmlCommandMapping tg43_fields;
   XmlCommandMapping tgc0_fields;
+  bool has_commands{false};
+  std::vector<XmlCommand> commands;
 };
 
 struct StatValue {
@@ -49,6 +57,9 @@ class MachineStats {
   std::unordered_map<std::string, StatValue> values_{};
 };
 
+bool load_xml_mapping_from_content(const std::string &source_label, const std::string &content,
+                                   XmlMapping &mapping);
+bool load_xml_mapping_from_content(const std::string &source_label, const std::string &content);
 bool load_xml_mapping(const std::string &path, XmlMapping &mapping);
 bool load_xml_mapping(const std::string &path);
 const XmlMapping &get_loaded_xml_mapping();


### PR DESCRIPTION
## Summary
- extend the XML loader to understand `<command>` entries from J.O.E. exports and keep track of command availability
- improve logging so command-only mappings are recognised while statistics polling remains disabled when no frames exist
- update the README and component docs to reference `jura_joe_xml_bundle_final/joe_codes_example.xml` and explain the new behaviour

## Testing
- esphome compile sample.yaml *(fails: `esphome` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0528c5ed48328a6f1b66845f7ee5b