### PR TITLE
Vereinfache Einbindung der JOE-XML-Datei

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Since newer models **do not use** this old V1-Protocol any more I started this p
 ### Aktivierung des XML-Pollings
 
 - `enable_xml_poll`: Schaltet den zusätzlichen XML-Pfad frei (Standard `false`).
-- `xml_mapping_path`: Dateipfad zum J.O.E.-Mapping (Standard `"/config/esphome/e6.xml"`).
 - `xml_poll_interval_ms`: Abstand zwischen zwei Abfragen in Millisekunden (Standard `30000`).
 
 Beispiel-Konfiguration in ESPHome:
@@ -32,15 +31,25 @@ jutta_proto:
   id: jura_e6
   uart_id: uart_bus
   enable_xml_poll: true
-  xml_mapping_path: "/config/esphome/e6.xml"
+  xml_mapping_path: joe_export.xml  # Pfad zur exportierten J.O.E.-XML
   xml_poll_interval_ms: 30000
 ```
 
 ### Mapping-Datei
 
-- Das Mapping folgt der Struktur der veröffentlichten `jura_joe_xml_bundle_final`-Dateien.
-- Bei erfolgreichem Laden erscheint im Log eine Zeile wie `XML mapping loaded from /config/esphome/e6.xml (valid=1, fields=...)`.
-- Ist die Datei nicht vorhanden oder fehlerhaft, läuft die Komponente weiter – lediglich das XML-Polling bleibt inaktiv.
+- Die Komponente bindet die exportierte J.O.E.-XML-Datei direkt per `incbin` in die Firmware ein.
+- Standardmäßig wird `esphome/components/jutta_proto/jura_mapping_embed.xml` genutzt (enthält eine unveränderte Original-Exportdatei).
+- Über den YAML-Parameter `xml_mapping_path` kann ein alternativer Pfad angegeben werden; der Codegenerator setzt daraus automatisch das Build-Flag `-DJURA_XML_MAPPING_INCLUDE="<Pfad>"`.
+- Pfadangaben können absolut oder relativ zum Projektverzeichnis erfolgen (bei Leerzeichen bitte durch Anführungszeichen schützen); relative Pfade werden zum YAML-Verzeichnis aufgelöst.
+- Es ist keine manuelle Anpassung der XML nötig – einfach die aus der App exportierte Datei referenzieren.
+- Der konfigurierte Pfad erscheint zusätzlich im Log (`XML mapping include`).
+
+**Kurz-Dokumentation**
+
+1. XML in der J.O.E.-App exportieren.
+2. Datei ins ESPHome-Projekt kopieren (oder absoluten Pfad merken).
+3. Im YAML `xml_mapping_path` auf diese Datei verweisen – fertig.
+4. Beim Kompilieren wird die Datei automatisch eingebunden, vom Parser ausgewertet und anschließend als numerische Sensorwerte veröffentlicht.
 
 ### Automatisch erzeugte Sensoren
 
@@ -290,41 +299,25 @@ ESPHome handles dependency management, compilation, and flashing of the firmware
 
 ### XML-Zähler automatisch bereitstellen
 
-Die Firmware kann die JURA-internen XML-Zähler zyklisch abfragen und als numerische Sensoren in Home Assistant zur Verfügung
-stellen. Dafür ist keine zusätzliche YAML-Konfiguration nötig – alle Sensorinstanzen werden während `setup()` angelegt,
-registriert und bleiben dauerhaft sichtbar.
+Die Firmware kann die JURA-internen XML-Zähler zyklisch abfragen und als numerische Sensoren in Home Assistant zur Verfügung stellen. Dafür ist keine zusätzliche YAML-Konfiguration nötig – alle Sensorinstanzen werden während `setup()` angelegt, registriert und bleiben dauerhaft sichtbar.
 
-1. **Feature aktivieren:** Die Standardwerte werden über `esphome/components/jutta_proto/jutta_config.h` gesteuert. Dort
-   können `JUTTA_XML_ENABLE`, `JUTTA_XML_POLL_MS` und `JUTTA_XML_RX_TIMEOUT_MS` bei Bedarf angepasst werden. Voreinstellung ist
-   `JUTTA_XML_ENABLE 1`, sodass der XML-Pfad ohne weitere Änderungen aktiv ist.
-2. **XML-Mapping bereitstellen:** Exportiere in der J.O.E.-App die Maschinen-XML und kopiere die Datei als
-   `/data/jura_machine.xml` auf das ESPHome-Gerät. Falls die Datei fehlt oder unvollständig ist, werden Standardbefehle und
-   generische Labels verwendet.
-3. **Zyklische Abfrage beobachten:** Nach erfolgreichem Legacy-Handshake erscheinen im Log Einträge wie `XML poll start`,
-   `TX_DB "@TR:32"`, `RX_DB decoded_len=21 expected=21` sowie `publish TR32=[…]`. Bei einem Timeout wird `RX_DB timeout`
-   ausgegeben. Nur wenn alle drei Blöcke korrekt gelesen werden, werden neue Werte veröffentlicht.
+**Konfiguration**
 
-#### XML-Pfad konfigurieren
+* Die J.O.E.-XML (nur `@TR:32`, `@TG:43`, `@TG:C0`) wird automatisch als Binärressource eingebettet.
+* In der ESPHome-YAML muss lediglich `xml_mapping_path` auf die exportierte Datei zeigen.
+* Keine Dateisysteme erforderlich.
 
-* Standardpfad für das Mapping ist `/data/jura_machine.xml`.
-* Über die YAML-Option `xml_path` kann ein alternativer Speicherort angegeben werden:
+**Ablauf**
 
-  ```yaml
-  jutta_proto:
-    id: jura1
-    xml_path: "/data/my_mapping/jura_map.xml"
-  ```
+* Nach Legacy-Handshake wird das Mapping aus dem eingebetteten String geladen.
+* Alle 30 s werden die drei DB-Kommandos gepollt; Frames werden ohne feste Länge gelesen (CRLF oder Gap).
+* Die numerischen Felder werden gemäß Mapping (offset/size/endian/scale) extrahiert und als Sensoren veröffentlicht.
 
-* Die referenzierte Datei muss vorab mit `uploadfs` oder über das ESPHome Dashboard auf das Gerät kopiert werden.
+**Troubleshooting**
 
-#### Fehlersuche
-
-* **Sensoren tauchen nicht auf:** Prüfe, ob das Feature aktiviert ist und ob beim Start Meldungen zur Sensorregistrierung
-  erscheinen. Sensorinstanzen werden vor dem ersten Home-Assistant-Connect erstellt und mit `set_internal(false)` sichtbar
-  gemacht.
-* **Keine Werteaktualisierung:** Achte auf Logzeilen zu `RX_DB timeout` oder `decoded_len=… expected=…`. Bei laufenden
-  XML-Polls sollten andere Aufgaben den UART nicht nutzen; der Code setzt während eines Polls ein internes Busy-Flag und
-  blockiert konkurrierende Leser.
+* Log sollte **keine** „expected length“-Warnungen mehr enthalten.
+* Bei „RX_DB timeout @TG:43/@TG:C0“: `xml_poll_interval_ms` erhöhen und inter-Command-Delay (150–200 ms) prüfen.
+* Wenn Sensoren in HA fehlen: prüfen, ob `publish_state` nach Parse wirklich aufgerufen wird (Log hinzufügen).
 
 #### Datenrahmen-Handling
 

--- a/esphome/components/jutta_proto/__init__.py
+++ b/esphome/components/jutta_proto/__init__.py
@@ -1,8 +1,13 @@
+import os
+
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
 from esphome.components import text_sensor, uart
 from esphome.const import CONF_ID
+from esphome.core import CORE
+
+COMPONENT_DIR = os.path.dirname(__file__)
 
 DEPENDENCIES = ["uart"]
 AUTO_LOAD = ["uart"]
@@ -95,7 +100,7 @@ CONFIG_SCHEMA = (
             cv.GenerateID(): cv.declare_id(JuraComponent),
             cv.Optional(CONF_MACHINE_DATA): text_sensor.text_sensor_schema(),
             cv.Optional(CONF_ENABLE_XML_POLL, default=False): cv.boolean,
-            cv.Optional(CONF_XML_MAPPING_PATH, default="/config/esphome/e6.xml"): cv.string,
+            cv.Optional(CONF_XML_MAPPING_PATH, default="embedded"): cv.string,
             cv.Optional(CONF_XML_POLL_INTERVAL_MS, default=30000): cv.All(
                 cv.positive_int, cv.Range(min=25000)
             ),
@@ -242,7 +247,24 @@ async def to_code(config):
     await uart.register_uart_device(var, config)
 
     cg.add(var.set_enable_xml_poll(config[CONF_ENABLE_XML_POLL]))
-    cg.add(var.set_xml_mapping_path(cg.std_string(config[CONF_XML_MAPPING_PATH])))
+    mapping_path = config[CONF_XML_MAPPING_PATH]
+    if mapping_path == "embedded":
+        resolved_path = os.path.join(COMPONENT_DIR, "jura_mapping_embed.xml")
+    else:
+        resolved_path = mapping_path
+        if not os.path.isabs(resolved_path):
+            resolved_path = os.path.join(CORE.relative_config_path, resolved_path)
+
+    if not os.path.exists(resolved_path):
+        raise cv.Invalid(
+            "Die angegebene XML-Datei '{}' (aufgelöst zu '{}') wurde nicht gefunden".format(
+                mapping_path, resolved_path
+            )
+        )
+
+    cg.add(var.set_xml_mapping_path(cg.std_string(resolved_path)))
+    normalized_path = resolved_path.replace("\\", "\\\\").replace('"', '\\"')
+    cg.add_build_flag('-DJURA_XML_MAPPING_INCLUDE="{}"'.format(normalized_path))
     cg.add(var.set_xml_poll_interval(config[CONF_XML_POLL_INTERVAL_MS]))
 
     if CONF_MACHINE_DATA in config:

--- a/esphome/components/jutta_proto/jura_mapping_embed.cpp
+++ b/esphome/components/jutta_proto/jura_mapping_embed.cpp
@@ -1,0 +1,44 @@
+#include "esphome/components/jutta_proto/jura_mapping_embed.h"
+
+#include <cstddef>
+#include <cstdint>
+
+#ifndef JURA_XML_MAPPING_INCLUDE
+#define JURA_XML_MAPPING_INCLUDE "esphome/components/jutta_proto/jura_mapping_embed.xml"
+#endif
+
+namespace {
+
+constexpr const char *kXmlMappingIncludePath = JURA_XML_MAPPING_INCLUDE;
+
+extern "C" {
+extern const std::uint8_t jura_xml_mapping_start[];
+extern const std::uint8_t jura_xml_mapping_end[];
+}
+
+asm(
+    ".section .rodata\n"
+    ".global jura_xml_mapping_start\n"
+    "jura_xml_mapping_start:\n"
+    ".incbin " JURA_XML_MAPPING_INCLUDE "\n"
+    ".global jura_xml_mapping_end\n"
+    "jura_xml_mapping_end:\n"
+    ".byte 0\n");
+
+}  // namespace
+
+namespace esphome {
+namespace jutta_component {
+
+const char *get_joe_xml_data() {
+  return reinterpret_cast<const char *>(jura_xml_mapping_start);
+}
+
+std::size_t get_joe_xml_length() {
+  return static_cast<std::size_t>(jura_xml_mapping_end - jura_xml_mapping_start);
+}
+
+const char *get_joe_xml_include_path() { return kXmlMappingIncludePath; }
+
+}  // namespace jutta_component
+}  // namespace esphome

--- a/esphome/components/jutta_proto/jura_mapping_embed.h
+++ b/esphome/components/jutta_proto/jura_mapping_embed.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <cstddef>
+
+namespace esphome {
+namespace jutta_component {
+
+const char *get_joe_xml_data();
+std::size_t get_joe_xml_length();
+const char *get_joe_xml_include_path();
+
+}  // namespace jutta_component
+}  // namespace esphome
+

--- a/esphome/components/jutta_proto/jura_mapping_embed.xml
+++ b/esphome/components/jutta_proto/jura_mapping_embed.xml
@@ -1,0 +1,399 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<JOE Version="2" Group="EF532V2" dated="07.06.2019" xmlns="http://www.top-tronic.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.top-tronic.com/ joe_control.xsd">
+
+  <PRODUCTS>
+    <TOTALCOUNTER Code="00" Name="Total Products" Text="29" PosCSV="1"/>
+    <PRODUCT Code="02" Name="Espresso" Text="9" P_Kind="C" DoubleProduct="false" PictureIdle="espresso_1.png" PictureProgress="espresso_1_" PieChart="C" PosIdle="1" PosRondel="1" PosCSV="2" ProductSettings="true">
+      <PRESELECTION double="12"/>
+      <COFFEE_STRENGTH Text="93" Argument="F3" Default="06">
+        <ITEM Name="1" Value="01" Text="54"/>
+        <ITEM Name="2" Value="02" Text="54"/>
+        <ITEM Name="3" Value="03" Text="55"/>
+        <ITEM Name="4" Value="04" Text="55"/>
+        <ITEM Name="5" Value="05" Text="56"/>
+        <ITEM Name="6" Value="06" Text="56"/>
+        <ITEM Name="7" Value="07" Text="57"/>
+        <ITEM Name="8" Value="08" Text="57"/>
+      </COFFEE_STRENGTH>
+      <WATER_AMOUNT Text="94" Argument="F4" Value="45" Min="15" Max="80" Step="5" ProgressAdjust="3C" PictureProgressFrom="00" PictureProgressTo="10"/>
+      <TEMPERATURE Argument="F7" Text="95" Default="02">
+        <ITEM Name="Normal" Value="01" Text="31"/>
+        <ITEM Name="High" Value="02" Text="32"/>
+      </TEMPERATURE>
+    </PRODUCT>
+    <PRODUCT Code="03" Name="Coffee" Text="10" P_Kind="C" DoubleProduct="false" PictureIdle="kaffee_1.png" PictureProgress="kaffee_1_" PieChart="C" PosIdle="2" PosRondel="2" PosCSV="3" ProductSettings="true">
+      <PRESELECTION double="13"/>
+      <COFFEE_STRENGTH Text="93" Argument="F3" Default="04">
+        <ITEM Name="1" Value="01" Text="54"/>
+        <ITEM Name="2" Value="02" Text="54"/>
+        <ITEM Name="3" Value="03" Text="55"/>
+        <ITEM Name="4" Value="04" Text="55"/>
+        <ITEM Name="5" Value="05" Text="56"/>
+        <ITEM Name="6" Value="06" Text="56"/>
+        <ITEM Name="7" Value="07" Text="57"/>
+        <ITEM Name="8" Value="08" Text="57"/>
+      </COFFEE_STRENGTH>
+      <WATER_AMOUNT Text="94" Argument="F4" Value="100" Min="25" Max="240" Step="5" ProgressAdjust="3C" PictureProgressFrom="00" PictureProgressTo="10"/>
+      <TEMPERATURE Argument="F7" Text="95" Default="01">
+        <ITEM Name="Normal" Value="01" Text="31"/>
+        <ITEM Name="High" Value="02" Text="32"/>
+      </TEMPERATURE>
+    </PRODUCT>
+    <PRODUCT Code="04" Name="Cappuccino" Text="11" P_Kind="CM" DoubleProduct="false" PictureIdle="cappuccino_1.png" PictureProgress="cappuccino_1_" PieChart="M" PosIdle="3" PosRondel="3" PosCSV="4" ProductSettings="true">
+      <COFFEE_STRENGTH Text="93" Argument="F3" Default="06">
+        <ITEM Name="1" Value="01" Text="54"/>
+        <ITEM Name="2" Value="02" Text="54"/>
+        <ITEM Name="3" Value="03" Text="55"/>
+        <ITEM Name="4" Value="04" Text="55"/>
+        <ITEM Name="5" Value="05" Text="56"/>
+        <ITEM Name="6" Value="06" Text="56"/>
+        <ITEM Name="7" Value="07" Text="57"/>
+        <ITEM Name="8" Value="08" Text="57"/>
+      </COFFEE_STRENGTH>
+      <WATER_AMOUNT Text="94" Argument="F4" Value="60" Min="25" Max="240" Step="5" ProgressAdjust="37" PictureProgressFrom="07" PictureProgressTo="19"/>
+      <TEMPERATURE Argument="F7" Text="95" Default="01">
+        <ITEM Name="Normal" Value="01" Text="31"/>
+        <ITEM Name="High" Value="02" Text="32"/>
+      </TEMPERATURE>
+      <MILK_FOAM_AMOUNT Text="96" Argument="F6" Value="14" Min="3" Max="120" Step="1" ProgressAdjust="34" TextUnit="282" PictureProgressFrom="00" PictureProgressTo="06"/>
+    </PRODUCT>
+     <PRODUCT Code="06" Name="Espresso Macchiato" Text="53" P_Kind="CM" DoubleProduct="false" PictureIdle="espresso_macchiato_1.png" PictureProgress="espresso_macchiato_1_" PieChart="M" PosIdle="4" PosRondel="4" PosCSV="5" ProductSettings="true" Active="true">
+      <COFFEE_STRENGTH Text="93" Argument="F3" Default="06" >
+        <ITEM Name="1" Value="01" Text="54"/>
+        <ITEM Name="2" Value="02" Text="54"/>
+        <ITEM Name="3" Value="03" Text="55"/>
+        <ITEM Name="4" Value="04" Text="55"/>
+        <ITEM Name="5" Value="05" Text="56"/>
+        <ITEM Name="6" Value="06" Text="56"/>
+        <ITEM Name="7" Value="07" Text="57"/>
+        <ITEM Name="8" Value="08" Text="57"/>
+      </COFFEE_STRENGTH>
+      <WATER_AMOUNT Text="94" Argument="F4" Value="25" Min="15" Max="80" Step="5" ProgressAdjust="37" PictureProgressFrom="03" PictureProgressTo="10"/>
+      <TEMPERATURE Argument="F7" Text="95" Default="02" >
+        <ITEM Name="Normal" Value="01" Text="31"/>
+        <ITEM Name="High" Value="02" Text="32"/>
+      </TEMPERATURE>
+      <MILK_FOAM_AMOUNT Text="96" Argument="F6" Value="3" Min="1" Max="120" Step="1" ProgressAdjust="34" TextUnit="282" PictureProgressFrom="00" PictureProgressTo="02"/>
+    </PRODUCT>
+    <PRODUCT Code="08" Name="Milk Foam" Text="52" P_Kind="M" DoubleProduct="false" PictureIdle="milchschaum_long_1.png" PictureProgress="milchschaum_long_1_" PieChart="M" PosIdle="5" PosRondel="5" PosCSV="6" ProductSettings="true">
+      <MILK_FOAM_AMOUNT Text="96" Argument="F6" Value="20" Min="1" Max="120" Step="1" ProgressAdjust="34" TextUnit="282" PictureProgressFrom="00" PictureProgressTo="20"/>
+    </PRODUCT>
+    <PRODUCT Code="0D" Name="Hotwater Portion(normal)" Text="16" P_Kind="T" DoubleProduct="false" PictureIdle="heisswasser_long.png" PictureProgress="heisswasser_long_" PieChart="T" PosIdle="7" PosRondel="7" PosCSV="8" ProductSettings="false" Active="false">
+      <WATER_AMOUNT Text="94" Argument="F4" Value="220" Min="25" Max="450" Step="5" ProgressAdjust="41" PictureProgressFrom="00" PictureProgressTo="20"/>
+      <TEMPERATURE Argument="F7" Text="95" Default="01">
+        <ITEM Name="Low" Value="00" Text="30"/>
+        <ITEM Name="Normal" Value="01" Text="31"/>
+        <ITEM Name="High" Value="02" Text="32"/>
+      </TEMPERATURE>
+    </PRODUCT>
+     <PRODUCT Code="28" Name="Cafe Barista" Text="73" P_Kind="C" DoubleProduct="false" PictureIdle="cafe_barista_1.png" PictureProgress="cafe_barista_1_" PieChart="C" PosIdle="8" PosRondel="8" PosCSV="9" ProductSettings="true">
+      <COFFEE_STRENGTH Text="93" Argument="F3" Default="06">
+        <ITEM Name="1" Value="01" Text="54"/>
+        <ITEM Name="2" Value="02" Text="54"/>
+        <ITEM Name="3" Value="03" Text="55"/>
+        <ITEM Name="4" Value="04" Text="55"/>
+        <ITEM Name="5" Value="05" Text="56"/>
+        <ITEM Name="6" Value="06" Text="56"/>
+        <ITEM Name="7" Value="07" Text="57"/>
+        <ITEM Name="8" Value="08" Text="57"/>
+      </COFFEE_STRENGTH>
+      <WATER_AMOUNT Text="94" Argument="F4" Value="60" Min="25" Max="240" Step="5" ProgressAdjust="3C" PictureProgressFrom="00" PictureProgressTo="05"/>
+      <BYPASS Text="103" Argument="F10" Value="40" Min="0" Max="240" Step="5" ProgressAdjust="41" PictureProgressFrom="06" PictureProgressTo="10"/>
+      <TEMPERATURE Argument="F7" Text="95" Default="01">
+        <ITEM Name="Normal" Value="01" Text="31"/>
+        <ITEM Name="High" Value="02" Text="32"/>
+      </TEMPERATURE>
+    </PRODUCT>
+    <PRODUCT Code="29" Name="Barista Lungo" Text="74" P_Kind="C" DoubleProduct="false" PictureIdle="lungo_barista_1.png" PictureProgress="lungo_barista_1_" PieChart="C" PosIdle="9" PosRondel="9" PosCSV="10" ProductSettings="true">
+      <COFFEE_STRENGTH Text="93" Argument="F3" Default="06">
+        <ITEM Name="1" Value="01" Text="54"/>
+        <ITEM Name="2" Value="02" Text="54"/>
+        <ITEM Name="3" Value="03" Text="55"/>
+        <ITEM Name="4" Value="04" Text="55"/>
+        <ITEM Name="5" Value="05" Text="56"/>
+        <ITEM Name="6" Value="06" Text="56"/>
+        <ITEM Name="7" Value="07" Text="57"/>
+        <ITEM Name="8" Value="08" Text="57"/>
+      </COFFEE_STRENGTH>
+      <WATER_AMOUNT Text="94" Argument="F4" Value="120" Min="25" Max="240" Step="5" ProgressAdjust="3C" PictureProgressFrom="00" PictureProgressTo="05"/>
+      <BYPASS Text="103" Argument="F10" Value="100" Min="0" Max="240" Step="5" ProgressAdjust="41" PictureProgressFrom="06" PictureProgressTo="10"/>
+      <TEMPERATURE Argument="F7" Text="95" Default="01">
+        <ITEM Name="Normal" Value="01" Text="31"/>
+        <ITEM Name="High" Value="02" Text="32"/>
+      </TEMPERATURE>
+    </PRODUCT>
+  <PRODUCT Code="30" Name="Espresso Doppio" Text="150" P_Kind="C" DoubleProduct="false" PictureIdle="espresso_doppio_1.png" PictureProgress="kaffee_1_" PieChart="C" PosIdle="10" PosRondel="10" PosCSV="11" ProductSettings="true" Active="true">
+      <COFFEE_STRENGTH Text="93" Argument="F3" Default="06" >
+        <ITEM Name="1" Value="01" Text="54"/>
+        <ITEM Name="2" Value="02" Text="54"/>
+        <ITEM Name="3" Value="03" Text="55"/>
+        <ITEM Name="4" Value="04" Text="55"/>
+        <ITEM Name="5" Value="05" Text="56"/>
+        <ITEM Name="6" Value="06" Text="56"/>
+        <ITEM Name="7" Value="07" Text="57"/>
+        <ITEM Name="8" Value="08" Text="57"/>
+      </COFFEE_STRENGTH>
+      <WATER_AMOUNT Text="94" Argument="F4" Value="90" Min="30" Max="160" Step="5" ProgressAdjust="3C" PictureProgressFrom="00" PictureProgressTo="10"/>
+      <TEMPERATURE Argument="F7" Text="95" Default="01">
+        <ITEM Name="Normal" Value="01" Text="31"/>
+        <ITEM Name="High" Value="02" Text="32" />
+      </TEMPERATURE>
+    </PRODUCT>     
+    <PRODUCT Code="12" Name="2 Espressi" Text="18" P_Kind="C" DoubleProduct="true" PictureIdle="espresso_2.png" PictureProgress="espresso_1_" PieChart="C" PosIdle="11" PosRondel="11" PosCSV="12" ProductSettings="false">
+      <WATER_AMOUNT Text="94" Argument="F4" Value="45" Min="15" Max="80" Step="5" ProgressAdjust="3C" PictureProgressFrom="00" PictureProgressTo="10"/>
+      <TEMPERATURE Argument="F7" Text="95" Default="02">
+        <ITEM Name="Normal" Value="01" Text="31"/>
+        <ITEM Name="High" Value="02" Text="32"/>
+      </TEMPERATURE>
+    </PRODUCT>
+    <PRODUCT Code="13" Name="2 Coffee" Text="19" P_Kind="C" DoubleProduct="true" PictureIdle="kaffee_2.png" PictureProgress="kaffee_1_" PieChart="C" PosIdle="12" PosRondel="12" PosCSV="13" ProductSettings="false">
+      <WATER_AMOUNT Text="94" Argument="F4" Value="100" Min="25" Max="240" Step="5" ProgressAdjust="3C" PictureProgressFrom="00" PictureProgressTo="10"/>
+      <TEMPERATURE Argument="F7" Text="95" Default="01">
+        <ITEM Name="Normal" Value="01" Text="31"/>
+        <ITEM Name="High" Value="02" Text="32"/>
+      </TEMPERATURE>
+    </PRODUCT>
+  </PRODUCTS>
+
+  <STATISTIC>
+     <BANK Command="@TS:01" Name="Remote Screen"/>
+    <PRODUCTCOUNTER>
+      <BANK Command="@TR:32" Name="Product counter for Statistic"/>
+    </PRODUCTCOUNTER>
+    <MAINTENANCEPAGE>
+      <BANK Command="@TG:43" Name="Maintenance Counter">
+        <TEXTITEM Type="Cleaning" Text="33"/>
+        <TEXTITEM Type="FilterChange" Text="34"/>
+        <TEXTITEM Type="Decalc" Text="35"/>
+        <TEXTITEM Type="CappuRinse" Text="40"/>
+        <TEXTITEM Type="CoffeeRinse" Text="36"/>
+        <TEXTITEM Type="CappuClean" Text="41"/>
+      </BANK>
+      <BANK Command="@TG:C0" Name="Maintenance Percent">
+        <TEXTITEM Type="Cleaning" Text="37"/>
+        <TEXTITEM Type="FilterChange" Text="39"/>
+        <TEXTITEM Type="Decalc" Text="38"/>
+      </BANK>
+    </MAINTENANCEPAGE>
+      <BANK Command="@TS:00" Name="Release Keys" />
+  </STATISTIC>
+
+  <ALERTS>
+
+    <ALERT Bit="0" Name="insert tray" Title="42" Message="47" Picture="restwasserschale_zurueck.png" Type="block"/>
+    <ALERT Bit="1" Name="fill water" Title="43" Message="48" Picture="wasser_fuellen_filter.png" Type="block"/>
+    <ALERT Bit="2" Name="empty grounds" Title="44" Message="49" Picture="kaffeesatzbehaelter_leeren.png" Type="block"/>
+    <ALERT Bit="3" Name="empty tray" Title="45" Message="50" Picture="restwasserschale_leeren.png" Type="block"/>
+    <ALERT Bit="4" Name="insert coffee bin" Title="46" Message="51" Picture="kaffeesatzbehaelter_fehlt.png" Type="block"/>
+    <ALERT Bit="5" Name="outlet missing" Title="200" Message="201" Picture="frontabdeckung_schliessen.png"/>
+    <ALERT Bit="6" Name="rear cover missing" Title="202" Message="203" Picture="abdeckung_rueck_schliessen.png"/>
+    <ALERT Bit="7" Name="milk alert" Title="104" Message="105" Picture="milch_leer.png"/>
+    <ALERT Bit="8" Name="fill system" Title="337" Message="242" Type="block"/>
+    <ALERT Bit="9" Name="system filling" Title="112" Message="113" Picture="system_filling.png"/>
+    <ALERT Bit="10" Name="no beans" Title="88" Message="89" Picture="bohnen_einfuellen.png" Type="info"/>
+    <ALERT Bit="11" Name="welcome" Title="171" Message="172"/>
+    <ALERT Bit="12" Name="heating up" Title="108" Message="109" Picture="geraet_heizt_auf.png" Type="block"/>
+    <ALERT Bit="13" Name="coffee ready" Title="110" Message="111"/>
+    <ALERT Bit="14" Name="no milk (milk sensor)" Title="104" Message="105" Picture="milch_leer.png" Blocked="M" Disabled="0406070A2E" Type="info"/>
+    <ALERT Bit="15" Name="error milk (milk sensor)" Title="173" Message="174" Picture="alarm_signal.png" Blocked="M" Disabled="0406070A2E" Type="info"/>
+    <ALERT Bit="16" Name="no signal (milk sensor)" Title="175" Message="176" Picture="alarm_signal.png" Blocked="M" Disabled="0406070A2E" Type="info"/>
+    <ALERT Bit="17" Name="please wait" Title="177" Message="178" Picture="wait_icon.png" Type="block"/>
+    <ALERT Bit="18" Name="coffee rinsing" Title="179" Message="180" Picture="kaffee_spuelung.png"/>
+    <ALERT Bit="19" Name="ventilation closed" Title="181" Message="182" Picture="ventiports.png"/>
+    <ALERT Bit="20" Name="close powder cover" Title="183" Message="184" Picture="gemahlenerkaffee_schliessen.png"/>
+    <ALERT Bit="21" Name="fill powder" Title="185" Message="186" Picture="gemahlenerkaffee_hinzufuegen.png"/>
+    <ALERT Bit="22" Name="system emptying" Title="187" Message="188" Picture="system_empty.png"/>
+    <ALERT Bit="23" Name="not enough powder" Title="189" Message="190" Picture="gemahlenerkaffee_nicht_genug.png"/>
+    <ALERT Bit="24" Name="remove water tank" Title="191" Message="192" Picture="wassertank_entfernen.png"/>
+    <ALERT Bit="25" Name="press rinse" Title="193" Message="194" Picture="pflege_druecken.png"/>
+    <ALERT Bit="26" Name="goodbye" Title="195" Message="196"/>
+    <ALERT Bit="27" Name="periphery alert" Title="122" Message="123" Picture="alarm_signal.png" Blocked="M" Type="info"/>
+    <ALERT Bit="28" Name="powder product" Title="197" Message="198" Picture="gemahlenerkaffee_hinzufuegen.png"/>
+    <ALERT Bit="29" Name="program-mode status" Title="106" Message="107" Type="block"/>
+    <ALERT Bit="30" Name="error status" Title="124" Message="125" Picture="alarm_signal.png" Type="block"/>
+    <ALERT Bit="31" Name="enjoy product" Title="114" Message="115"/>
+    <ALERT Bit="32" Name="filter alert" Title="92" Message="210" Picture="filter_wechseln.png" Type="ip" ProcessButton="70" Process="FilterChange" ShopButton="71" ShopURL="www.jura.com/joe-filtersmart" CancelButton="72"/>
+    <ALERT Bit="33" Name="decalc alert" Title="126" Message="213" Picture="entkalkung.png" Type="ip" ProcessButton="207" Process="Decalc" ShopButton="71" ShopURL="www.jura.com/joe-descale" CancelButton="72" />
+    <ALERT Bit="34" Name="cleaning alert" Title="128" Message="211" Picture="geraet_reinigen.png" Type="ip" ProcessButton="206" Process="Cleaning" ShopButton="71" ShopURL="www.jura.com/joe-cleaning" CancelButton="72" />
+    <ALERT Bit="35" Name="cappu rinse alert" Title="130" Message="212" Picture="milchsystem_spuelung.png" Type="ip" ProcessButton="208" Process="CappuRinse" CancelButton="72" />
+    <ALERT Bit="36" Name="energy safe" Title="132" Message="133"/>
+    <ALERT Bit="37" Name="active RF filter" Title="273" Message="274"/>
+    <ALERT Bit="38" Name="RemoteScreen" Title="275" Message="276"/>
+    <ALERT Bit="39" Name="LockedKeys" Title="277" Message="278"/>
+    <ALERT Bit="40" Name="close tab" Title="199" Message="138" Picture="hahn_schliessen.png" Type="block"/>
+    <ALERT Bit="41" Name="cappu clean alert" Title="134" Message="214" Picture="milchsystem_reinigung_alarm.png" Type="ip" ProcessButton="206" Process="CappuClean"  ShopButton="71" ShopURL="www.jura.com/joe-milkclean" CancelButton="72" />
+    <ALERT Bit="42" Name="Info - cappu clean alert" Title="134" Message="214"/>
+    <ALERT Bit="43" Name="Info - coffee clean alert" Title="128" Message="211"/>
+    <ALERT Bit="44" Name="Info - decalc alert" Title="126" Message="213"/>
+    <ALERT Bit="45" Name="Info - filter used up alert" Title="92" Message="210"/>
+    <ALERT Bit="46" Name="steam ready" Title="279" Message="280"/>
+    <ALERT Bit="47" Name="SwitchOff Delay active" Title="177" Message="209" Picture="alarm_signal.png" Type="block"/>
+  </ALERTS>
+  
+
+  <PROGRESS_STATE_INTAKE>
+    <ENJOYSCREEN Value="3E" Name="Enjoy" Title="114" Message="115"/>
+    <STATE Value="01" Name="Insert Tray" Title="42" Message="47" Picture="restwasserschale_zurueck.png" />
+    <STATE Value="02" Name="Fill watertank" Title="43" Picture="wasser_fuellen_filter.png"/>
+    <STATE Value="03" Name="Empty grounds"  Title="44" Message="49" Picture="kaffeesatzbehaelter_leeren.png"/>
+    <STATE Value="04" Name="Empty tray" Title="45" Message="50" Picture="restwasserschale_leeren.png"/>
+    <STATE Value="08" Name="Insert grounds box" Title="44" Message="49" Picture="kaffeesatzbehaelter_zurueck.png"/>
+    <STATE Value="09" Name="Close nozzle cover" Title="200" Message="201" Picture="frontabdeckung_schliessen.png"/>
+    <STATE Value="0A" Name="Close bean cover" Title="243" Picture="bohnenbehaelter_schliessen.png"/>
+    <STATE Value="0B" Name="Cappurinse finished" Title="270" Picture="bereit.png"/>
+    <STATE Value="0C" Name="Close tap" Title="138" Picture="hahn_schliessen.png"/>
+    <STATE Value="0D" Name="Open tap" Title="140" Picture="hahn_oeffnen.png"/>
+    <STATE Value="0E" Name ="Alert"/>
+    <STATE Value="0F" Name="Close powder cover" Title="137" Picture="gemahlenerkaffee_schliessen.png"/>
+    <STATE Value="10" Name="Add powder coffee" Title="137" Picture="gemahlenerkaffee_hinzufuegen.png" />
+    <STATE Value="11" Name="Filling process" Title="112"  Picture="system_filling.png"/>
+    <STATE Value="12" Name="System emptying" Title="120" Message="121" Picture="system_empty.png"/>
+    <STATE Value="13" Name="Add beans" Title="136" Picture="bohnen_einfuellen.png"/>
+    <STATE Value="14" Name="Not enough powder" Title="189" Message="139" Picture="gemahlenerkaffee_nicht_genug.png"/>
+    <STATE Value="15" Name="Waiting" Title="177" Picture="wait_icon.png"/>
+    <STATE Value="16" Name="Remove watertank" Title="142" Picture="wassertank_entfernen.png"/>
+    
+    <STATE Value="20" Name="Startup"/>
+    <STATE Value="21" Name="Heating Up" Title="108" Message="109" Progress="true" Picture="geraet_heizt_auf.png" />
+    <STATE Value="22" Name="Press Button" Title="337"/>
+    <STATE Value="23" Name="Rinse process" Title="143" Picture="auslauf_spuelen.png"/>
+    <STATE Value="24" Name="Coffee Ready" Title="110"/>
+    <STATE Value="25" Name="Shut down" />
+    <STATE Value="26" Name="Press Rinse" Title="193" Picture="pflege_druecken.png" AcceptCommand="@TG:10"/>
+    
+    <STATE Value="2D" Name="No milk" Title="104" Picture="milch_leer.png" />
+    <STATE Value="2E" Name="Error milk" Title="173" Picture="milch_leer.png"/>
+    <STATE Value="2F" Name="No signal milk" Title="244" Picture="milch_leer.png"/>
+
+    <STATE Value="4A" Name="Cappu Clean request"/>
+    
+    <STATE Value="50" Name="Decalcify Start" Title="337" Picture="entkalkung.png"/>
+    <STATE Value="51" Name="Decalcify materials" Title="337" Picture="entkalkung.png"/>
+    <STATE Value="52" Name="Decalcify empty tray" Title="45" Message="50" Picture="restwasserschale_leeren.png"/>
+    <STATE Value="53" Name="Decalcify add fluid" Title="226" Picture="mittel_in_tank.png"/>
+    <STATE Value="54" Name="Decalcify Process" Title="290" Picture="entkalkung.png"/>
+    <STATE Value="55" Name="Rinse watertank" Title="337" Picture="entkalkung.png"/>
+    <STATE Value="56" Name="Descale finished" Title="269" Picture="bereit.png"/>
+
+    <STATE Value="5A" Name="Connect the milk tube"/>
+    <STATE Value="5C" Name="RF-ID Filter used up"/>
+    <STATE Value="5D" Name="RF-ID Filter locked"/>
+
+    <STATE Value="60" Name="Filter Rinse start" Title="337" Picture="filter_wechseln.png"/>
+    <STATE Value="61" Name="Filter Rinse materials" Title="337" Picture="filter_wechseln.png"/>
+    <STATE Value="62" Name="Filter Rinse change" Title="337" Picture="filter_wechseln.png"/>
+    <STATE Value="63" Name="Filter Rinse process" Title="232" Picture="filter_wechseln.png"/>
+    
+    <STATE Value="65" Name="Filter Rinse finished" Title="267" Picture="bereit.png"/>
+    <STATE Value="66" Name="Remove Filter" Title="227" Picture="filter_entfernen.png" />
+    <STATE Value="67" Name="Filter Rinse insert" Title="233" Picture="filter_einsetzen.png" />
+
+    <STATE Value="70" Name="Cleaning Start" Title="337" Picture="geraet_reinigen.png"/>
+    <STATE Value="71" Name="Cleaning materials" Title="337" Picture="geraet_reinigen.png"/>
+    <STATE Value="72" Name="Cleaning empty tray" Title="45" Message="50" Picture="restwasserschale_leeren.png"/>
+    <STATE Value="73" Name="Cleaning press button" Title="337" Picture="geraet_reinigen.png"/>
+    <STATE Value="74" Name="Cleaning Process" Title="289" Picture="geraet_reinigen.png"/>
+    <STATE Value="75" Name="Cleaning add tablet" Title="236" Picture="tablette_einwerfen.png"/>
+    <STATE Value="76" Name="Cleaning Process finished" Title="221" Message="268" Picture="bereit.png" />
+    
+    <STATE Value="90" Name="Cappu Clean Start" Title="337" Picture="milchsystem_reinigung_alarm.png"/>
+    <STATE Value="91" Name="Cappu Clean materials" Title="337" Picture="milchsystem_reinigung_alarm.png"/>
+    <STATE Value="92" Name="Cappu Clean add cleaner" Title="239" Picture="mittel_fuellen.png"/>
+    <STATE Value="93" Name="Cappu Clean process" Title="291" Picture="milchsystem_reinigung_alarm.png"/>
+    <STATE Value="94" Name="Cappu Clean add water" Title="240" Picture="mittel_fuellen.png"/>
+    <STATE Value="95" Name="Cappu Clean finish" Title="238" Message="271" Picture="bereit.png" />
+    
+    <STATE Value="9A" Name="Cappu Rinse process" Title="292" Picture="milchsystem_spuelung.png"/>
+    
+    <STATE Value="A1" Name="Set Hotwater Nozzle"/>
+    <STATE Value="A2" Name="Set Milk Nozzle"/>
+    <STATE Value="A3" Name="Set Nozzle to Milk Position"/>
+    <STATE Value="A4" Name="Set Nozzle to Foam Position"/>
+    
+    <STATE Value="C7" Name="Longpress Saved" />
+    <STATE Value="C9" Name="Enough Milk/Water/Coffee"/>
+    
+    <STATE Value="E1" Name ="Warning"/>
+    <STATE Value="E2" Name ="Action"/>
+    <STATE Value="E3" Name ="Info"/>
+    <STATE Value="E4" Name ="Filter error"/>
+    <STATE Value="E5" Name ="Filter thanks"/>
+    <STATE Value="E6" Name ="Too Hot"/>
+    
+    <STATE Value="FF" Name="P_Mode" Title="106" Message="107"/>
+  
+  </PROGRESS_STATE_INTAKE>
+
+  <PROCESSES>
+    <PROCESS Type="FilterChange" ExecuteCommand="@TG:26" Title="232" Progress="false" PDF_Text="217" PDFURL="www.jura.com/manual-e6v19" Video_Text="218" VideoURL="www.jura.com/yt-e6filter" Picture="filter_wechseln.png"/>
+    <PROCESS Type="Cleaning" ExecuteCommand="@TG:24" Title="221" Progress="true" PDF_Text="217" PDFURL="www.jura.com/manual-e6v19" Video_Text="218" VideoURL="www.jura.com/yt-e6cleaning" Picture="geraet_reinigen.png"/>
+    <PROCESS Type="Decalc" ExecuteCommand="@TG:25" Title="224" Progress="true" PDF_Text="217" PDFURL="www.jura.com/manual-e6v19" Video_Text="218" VideoURL="www.jura.com/yt-e6descale" Picture="entkalkung.png"/>
+    <PROCESS Type="CappuRinse" ExecuteCommand="@TG:23" Title="237" Progress="true" Picture="milchsystem_spuelung.png"/>
+    <PROCESS Type="CappuClean" ExecuteCommand="@TG:21" Title="238" Progress="true" PDF_Text="217" PDFURL="www.jura.com/manual-e6v19" Video_Text="218" VideoURL="www.jura.com/yt-e6milkclean" Picture="milchsystem_reinigung_alarm.png"/>
+  </PROCESSES>
+
+   <MACHINESETTINGS Productprogramming="true">
+    <BANK Name="Setting" Command="@TM:00,FC" CommandArgument="02080913" />
+    
+    <SLIDER Name="Hardness" SliderType="StepSlider" Pos="1" P_Argument="02" Text="2" Default="16" Min="1" Max="30" Step="1" TextUnit="5" Mask="FF"/>
+
+
+    <SLIDER Name="AutoOFF" SliderType="ItemSlider" Pos="2" P_Argument="13" Text="1" Default="1E">
+      <ITEM Name="15min" Text="256" Value="0F"/>
+      <ITEM Name="30min" Text="257" Value="1E"/>
+      <ITEM Name="1h" Text="258" Value="213C"/>
+      <ITEM Name="2h" Text="259" Value="2178"/>
+      <ITEM Name="3h" Text="260" Value="21B4"/>
+      <ITEM Name="4h" Text="261" Value="21F0"/>
+      <ITEM Name="5h" Text="262" Value="22012C"/>
+      <ITEM Name="6h" Text="263" Value="220168"/>
+      <ITEM Name="7h" Text="264" Value="2201A4"/>
+      <ITEM Name="8h" Text="265" Value="2201E0"/>
+      <ITEM Name="9h" Text="266" Value="22021C"/>
+    </SLIDER>
+    
+    <SWITCH Name="Units" Pos="3" P_Argument="08" Text="4" Default="00">
+      <ITEM Name="ML" Text="6" Value="00"/>
+      <ITEM Name="OZ" Text="7" Value="01"/>
+    </SWITCH>
+
+    <COMBOBOX Name="Language" Pos="4" P_Argument="09" Text="3" Read="TM:09" Default="02">
+      <ITEM Name="German" Text="245" Value="01"/>
+      <ITEM Name="English" Text="246" Value="02"/>
+      <ITEM Name="French" Text="247" Value="03"/>
+      <ITEM Name="Italian" Text="248" Value="04"/>
+      <ITEM Name="Dutch" Text="249" Value="05"/>
+      <ITEM Name="Spanish" Text="250" Value="06"/>
+      <ITEM Name="Portuguese" Text="251" Value="07"/>
+      <ITEM Name="Swedish" Text="253" Value="09"/>
+      <ITEM Name="Russian" Text="252" Value="08"/>
+      <ITEM Name="Polish" Text="254" Value="0A"/>
+      <ITEM Name="Esti" Text="288" Value="0B"/>
+    </COMBOBOX>
+     
+ 
+  </MACHINESETTINGS>
+
+  <MAINTENANCEINSTRUCTIONS>
+    <BUTTON Name="FilterChange" Pos="1" Text="58" MessageText="215" Title="216" Type="FilterChange" ProcessButton="" Video_Text="218" VideoURL="www.jura.com/yt-e6filter" Shop_Text="219" ShopURL="www.jura.com/joe-filtersmart" Progress="true"/>
+    <BUTTON Name="Cleaning" Pos="2" Text="59" MessageText="220" Title="221" Type="Cleaning"  ProcessButton="366" Process="Cleaning"  Video_Text="218" VideoURL="www.jura.com/yt-e6cleaning" Shop_Text="219" ShopURL="www.jura.com/joe-cleaning" Progress="true"/>
+    <BUTTON Name="CappuClean" Pos="3" Text="61" MessageText="214" Title="238" Type="CappuClean" ProcessButton="61" Process="CappuClean" Video_Text="218" VideoURL="www.jura.com/yt-e6milkclean" Shop_Text="219" ShopURL="www.jura.com/joe-milkclean" Progress="false"/>
+    <BUTTON Name="Decalc" Pos="4" Text="63" MessageText="223" Title="222" Type="Decalc" ProcessButton="371" Process="Decalc" Video_Text="218" VideoURL="www.jura.com/yt-e6descale" Shop_Text="219" ShopURL="www.jura.com/joe-descale" Progress="true"/>
+  </MAINTENANCEINSTRUCTIONS>
+
+
+  <PREDICTIVEMAINTENANCE>
+    <PREDICTIVEBUTTON Name="FilterChange" Text="358" MessageText="359" Title="360" Picture="filter_wechseln.png"  Shop_Text="219" ShopURL="www.jura.com/joe-filtersmart" ProcessButton="" Process="FilterChange" Video_Text="" VideoURL="" Threshold="80" DismissCheckbox="362" CancelButton="72" />
+    <PREDICTIVEBUTTON Name="Cleaning" Text="363" MessageText="364" Title="365" Picture="geraet_reinigen.png" Shop_Text="219" ShopURL="www.jura.com/joe-cleaning" ProcessButton="366" Process="Cleaning" Video_Text="" VideoURL="" Threshold="80" DismissCheckbox="367" CancelButton="72" />
+    <PREDICTIVEBUTTON Name="Decalc" Text="368" MessageText="369" Title="370" Picture="entkalkung.png"  Shop_Text="219" ShopURL="www.jura.com/joe-descale" ProcessButton="371" Process="Decalc" Video_Text="" VideoURL="" Threshold="80" DismissCheckbox="372" CancelButton="72" />
+  </PREDICTIVEMAINTENANCE>
+
+  <MAINTENANCELIFETIME>
+    <!-- Lifetime counted in days -->
+    <LIFETIME Name="FilterChange" Text="373" MessageText="374" Title="375" Picture="filter_wechseln.png"  Shop_Text="219" ShopURL="www.jura.com/joe-filtersmart" ProcessButton="" Process="FilterChange" Video_Text="" VideoURL="" Lifetime="90" DismissCheckbox="377" CancelButton="72" />
+  </MAINTENANCELIFETIME>
+
+  <MANUALS>
+    <LINK Name="manual.coffeeMachineManual" URL="www.jura.com/manual-e6v19"/>
+  </MANUALS>
+</JOE>

--- a/esphome/components/jutta_proto/jutta_connection.cpp
+++ b/esphome/components/jutta_proto/jutta_connection.cpp
@@ -459,6 +459,38 @@ void JuttaConnection::flush_serial_input() const {
     }
 }
 
+void JuttaConnection::flush_db_rx_queue() {
+    if (!this->db_rx_queue_.empty()) {
+        ESP_LOGD(TAG, "Clearing %zu gepufferte DB-Byte%s.", this->db_rx_queue_.size(),
+                 this->db_rx_queue_.size() == 1 ? "" : "s");
+        this->db_rx_queue_.clear();
+    }
+
+    std::array<uint8_t, 4> discard{};
+    while (true) {
+        size_t read = this->serial.read_serial(discard);
+        if (read == 0) {
+            break;
+        }
+        std::vector<uint8_t> filtered;
+        filtered.reserve(read);
+        size_t dropped = this->filter_tx_echo_(discard.data(), read, filtered);
+        if (dropped > 0) {
+            ESP_LOGVV(TAG, "During DB flush dropped %zu echo byte%s.", dropped,
+                      dropped == 1 ? "" : "s");
+        }
+        if (!filtered.empty()) {
+            ESP_LOGVV(TAG, "Discarded %zu DB byte%s while flushing.", filtered.size(),
+                      filtered.size() == 1 ? "" : "s");
+        }
+    }
+}
+
+void JuttaConnection::flush_all_rx() {
+    this->flush_serial_input();
+    this->flush_db_rx_queue();
+}
+
 void JuttaConnection::reinject_decoded_front(const std::string& data) const {
     if (data.empty()) {
         return;
@@ -549,7 +581,7 @@ void JuttaConnection::tx_db_command(const std::string& ascii) {
 bool JuttaConnection::read_db_frame(std::vector<uint8_t>& decoded, uint32_t timeout_ms) {
     decoded.clear();
 
-    constexpr uint32_t GAP_MS = 20;
+    constexpr uint32_t GAP_MS = 25;
     enum class FrameEnd { None, Gap, Terminator, Timeout };
 
     FrameEnd end_reason = FrameEnd::None;

--- a/esphome/components/jutta_proto/jutta_connection.hpp
+++ b/esphome/components/jutta_proto/jutta_connection.hpp
@@ -220,6 +220,8 @@ class JuttaConnection {
     [[nodiscard]] bool read_decoded_unsafe(std::vector<uint8_t>& data) const;
 
     void flush_serial_input() const;
+    void flush_db_rx_queue();
+    void flush_all_rx();
 
     /**
      * Encodes the given byte into 4 JUTTA bytes and writes them to the coffee maker.

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -1,4 +1,5 @@
 #include "esphome/components/jutta_proto/jutta_proto.h"
+#include "esphome/components/jutta_proto/jura_mapping_embed.h"
 
 #include <algorithm>
 #include <array>
@@ -22,7 +23,7 @@ constexpr size_t HANDSHAKE_LOG_PREVIEW_LIMIT = 64;
 constexpr uint32_t MACHINE_DATA_QUERY_INTERVAL_MS = 30000;
 constexpr uint32_t MACHINE_DATA_REQUEST_TIMEOUT_MS = 2000;
 const char *const MACHINE_DATA_COMMAND = "&STAT?\r\n";
-constexpr uint32_t XML_RESPONSE_TIMEOUT_MS = 1000;
+constexpr uint32_t XML_RESPONSE_TIMEOUT_MS = 1400;
 constexpr uint32_t XML_INTER_COMMAND_DELAY_MS = 180;
 
 template<typename AppT>
@@ -193,6 +194,9 @@ void JuraComponent::setup() {
 
   this->reset_xml_cycle_state_();
   this->xml_next_poll_ = esphome::millis();
+  if (this->xml_mapping_path_ == "embedded") {
+    this->xml_mapping_path_ = get_joe_xml_include_path();
+  }
   if (this->enable_xml_poll_) {
     this->ensure_xml_mapping_loaded_();
     this->ensure_xml_sensors_created_();
@@ -279,7 +283,7 @@ void JuraComponent::dump_config() {
   }
 
   ESP_LOGCONFIG(TAG, "  XML polling: %s", this->enable_xml_poll_ ? "enabled" : "disabled");
-  ESP_LOGCONFIG(TAG, "  XML mapping path: %s", this->xml_mapping_path_.c_str());
+  ESP_LOGCONFIG(TAG, "  XML mapping include: %s", this->xml_mapping_path_.c_str());
   ESP_LOGCONFIG(TAG, "  XML poll interval: %u ms", static_cast<unsigned>(this->xml_poll_interval_ms_));
   ESP_LOGCONFIG(TAG, "  XML mapping loaded: %s",
                 YESNO(this->xml_mapping_loaded_ && this->xml_mapping_.valid));
@@ -439,6 +443,9 @@ void JuraComponent::process_handshake() {
         this->handshake_stage_ = HandshakeStage::DONE;
         this->handshake_buffer_.clear();
         this->handshake_deadline_ = 0;
+        if (this->enable_xml_poll_) {
+          this->ensure_xml_mapping_loaded_();
+        }
       } else {
         this->restart_handshake("failed to send @t3");
       }
@@ -569,18 +576,14 @@ void JuraComponent::ensure_xml_sensors_created_() {
   if (!this->enable_xml_poll_ || !this->xml_mapping_.valid) {
     return;
   }
-  auto ensure_field = [&](const XmlField &field) {
-    this->get_or_create_sensor_(field.name, field.label);
+  auto ensure_block = [&](const XmlCommandMapping &mapping) {
+    for (const auto &field : mapping.fields) {
+      this->get_or_create_sensor_(field.name, field.label);
+    }
   };
-  for (const auto &field : this->xml_mapping_.tr32_fields.fields) {
-    ensure_field(field);
-  }
-  for (const auto &field : this->xml_mapping_.tg43_fields.fields) {
-    ensure_field(field);
-  }
-  for (const auto &field : this->xml_mapping_.tgc0_fields.fields) {
-    ensure_field(field);
-  }
+  ensure_block(this->xml_mapping_.tr32);
+  ensure_block(this->xml_mapping_.tg43);
+  ensure_block(this->xml_mapping_.tgc0);
 }
 
 bool JuraComponent::ensure_xml_mapping_loaded_() {
@@ -590,21 +593,31 @@ bool JuraComponent::ensure_xml_mapping_loaded_() {
   if (this->xml_mapping_loaded_) {
     return this->xml_mapping_.valid;
   }
-  XmlMapping mapping;
-  if (!load_xml_mapping(this->xml_mapping_path_, mapping)) {
-    ESP_LOGW(TAG, "Failed to load XML mapping at %s", this->xml_mapping_path_.c_str());
-    this->xml_mapping_loaded_ = false;
+
+  auto *xml_ptr = get_joe_xml_data();
+  std::size_t xml_len = get_joe_xml_length();
+  if (xml_ptr == nullptr || xml_len == 0) {
+    ESP_LOGW(TAG, "Kein eingebettetes XML-Mapping vorhanden");
+    this->xml_mapping_loaded_ = true;
     this->xml_mapping_.valid = false;
-    this->xml_mapping_logged_ = false;
     this->xml_stats_.clear();
     this->log_xml_mapping_status_();
     return false;
   }
-  this->xml_mapping_ = std::move(mapping);
-  this->xml_mapping_loaded_ = this->xml_mapping_.valid;
+
+  std::string xml_source(xml_ptr, xml_len);
+  bool valid = load_mapping_from_string(xml_source);
+  this->xml_mapping_ = get_xml_mapping();
+  this->xml_mapping_loaded_ = true;
   this->xml_mapping_logged_ = false;
   this->xml_stats_.clear();
+  if (!valid) {
+    this->xml_mapping_.valid = false;
+  }
   this->log_xml_mapping_status_();
+  if (this->xml_mapping_.valid) {
+    this->ensure_xml_sensors_created_();
+  }
   return this->xml_mapping_.valid;
 }
 
@@ -612,11 +625,8 @@ void JuraComponent::log_xml_mapping_status_() {
   if (this->xml_mapping_logged_) {
     return;
   }
-  ESP_LOGI(TAG, "XML mapping loaded from %s (valid=%d, fields=%u/%u/%u)",
-           this->xml_mapping_path_.c_str(), static_cast<int>(this->xml_mapping_.valid),
-           static_cast<unsigned>(this->xml_mapping_.tr32_fields.fields.size()),
-           static_cast<unsigned>(this->xml_mapping_.tg43_fields.fields.size()),
-           static_cast<unsigned>(this->xml_mapping_.tgc0_fields.fields.size()));
+  ESP_LOGI(TAG, "XML mapping valid=%d, cmds=<@TR:32, @TG:43, @TG:C0>",
+           static_cast<int>(this->xml_mapping_.valid));
   this->xml_mapping_logged_ = true;
 }
 
@@ -657,6 +667,7 @@ void JuraComponent::start_xml_cycle_(uint32_t now) {
   this->xml_cycle_.command_index = 0;
   const char *command = xml_command_for_index_(0);
   ESP_LOGD(TAG, "TX_DB \"%s\"", command);
+  this->coffee_maker_->connection->flush_all_rx();
   this->coffee_maker_->connection->tx_db_command(command);
   this->xml_cycle_.deadline_ms = now + XML_RESPONSE_TIMEOUT_MS;
   this->xml_cycle_.next_action_ms = 0;
@@ -697,6 +708,7 @@ void JuraComponent::handle_xml_cycle_(uint32_t now) {
       }
       const char *command = xml_command_for_index_(next_index);
       ESP_LOGD(TAG, "TX_DB \"%s\"", command);
+      this->coffee_maker_->connection->flush_db_rx_queue();
       this->coffee_maker_->connection->tx_db_command(command);
       this->xml_cycle_.command_index = next_index;
       this->xml_cycle_.phase = XmlCycleState::Phase::WaitingForFrame;
@@ -725,27 +737,21 @@ bool JuraComponent::try_receive_xml_frame_(uint32_t now) {
 void JuraComponent::finish_xml_cycle_(uint32_t now, bool success) {
   bool any_value = false;
 
-  auto handle_response = [&](size_t index, auto mapper) {
+  auto handle_response = [&](size_t index, bool (*parser)(const std::vector<uint8_t> &, Stats &)) {
     const auto &response = this->xml_cycle_.responses[index];
     const char *label = xml_log_label_for_index_(index);
     if (response.empty()) {
       ESP_LOGW(TAG, "XML %s: keine Daten empfangen", label);
       return;
     }
-    if (mapper(response, this->xml_mapping_, this->xml_stats_)) {
+    if (parser(response, this->xml_stats_)) {
       any_value = true;
     }
   };
 
-  handle_response(0,
-                   static_cast<bool (*)(const std::vector<uint8_t> &, const XmlMapping &, MachineStats &)>(
-                       map_tr32));
-  handle_response(1,
-                   static_cast<bool (*)(const std::vector<uint8_t> &, const XmlMapping &, MachineStats &)>(
-                       map_tg43));
-  handle_response(2,
-                   static_cast<bool (*)(const std::vector<uint8_t> &, const XmlMapping &, MachineStats &)>(
-                       map_tgc0));
+  handle_response(0, parse_TR32);
+  handle_response(1, parse_TG43);
+  handle_response(2, parse_TGC0);
 
   if (any_value) {
     this->publish_xml_stats_();

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -142,12 +142,12 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
 
   bool enable_xml_poll_{false};
   uint32_t xml_poll_interval_ms_{30000};
-  std::string xml_mapping_path_{"/config/esphome/e6.xml"};
+  std::string xml_mapping_path_{"embedded"};
   uint32_t xml_next_poll_{0};
   bool xml_mapping_logged_{false};
   bool xml_mapping_loaded_{false};
   XmlMapping xml_mapping_{};
-  MachineStats xml_stats_{};
+  Stats xml_stats_{};
   std::unordered_map<std::string, sensor::Sensor *> xml_sensors_{};
   std::unordered_map<std::string, std::string> xml_sensor_labels_{};
 

--- a/esphome/components/jutta_proto/jutta_proto_xml.cpp
+++ b/esphome/components/jutta_proto/jutta_proto_xml.cpp
@@ -2,16 +2,12 @@
 
 #include <algorithm>
 #include <cctype>
-#include <cmath>
-#include <cstdio>
+#include <cstdint>
 #include <cstdlib>
-#include <fstream>
-#include <sstream>
+#include <initializer_list>
+#include <unordered_map>
 
 #include "esphome/core/log.h"
-#ifdef USE_FILESYSTEM
-#include "esphome/components/filesystem/filesystem.h"
-#endif
 
 namespace esphome {
 namespace jutta_component {
@@ -19,11 +15,28 @@ namespace jutta_component {
 namespace {
 static const char *const TAG = "jutta_proto.xml";
 
+std::string to_lower_copy(const std::string &input) {
+  std::string result = input;
+  std::transform(result.begin(), result.end(), result.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return result;
+}
+
+void trim(std::string &value) {
+  auto begin = value.find_first_not_of(" \t\r\n");
+  auto end = value.find_last_not_of(" \t\r\n");
+  if (begin == std::string::npos || end == std::string::npos) {
+    value.clear();
+    return;
+  }
+  value = value.substr(begin, end - begin + 1);
+}
+
 struct AttributeMap {
   std::unordered_map<std::string, std::string> values;
 
   std::string get(const std::string &key) const {
-    auto it = this->values.find(key);
+    auto it = this->values.find(to_lower_copy(key));
     if (it != this->values.end()) {
       return it->second;
     }
@@ -31,26 +44,23 @@ struct AttributeMap {
   }
 };
 
-inline std::string to_lower(const std::string &input) {
-  std::string result = input;
-  std::transform(result.begin(), result.end(), result.begin(),
-                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-  return result;
-}
-
 AttributeMap parse_attributes(const std::string &tag) {
   AttributeMap map;
   std::size_t pos = 0;
   while (pos < tag.size()) {
-    std::size_t name_start = tag.find_first_not_of(" \t\r\n<", pos);
-    if (name_start == std::string::npos) {
+    pos = tag.find_first_not_of(" \t\r\n</", pos);
+    if (pos == std::string::npos) {
       break;
     }
-    std::size_t name_end = tag.find_first_of("= \t\r\n>", name_start);
+    if (tag[pos] == '>' || tag[pos] == '/') {
+      break;
+    }
+    std::size_t name_end = tag.find_first_of("= \t\r\n/>", pos);
     if (name_end == std::string::npos) {
       break;
     }
-    std::string key = to_lower(tag.substr(name_start, name_end - name_start));
+    std::string key = tag.substr(pos, name_end - pos);
+    key = to_lower_copy(key);
     pos = tag.find('=', name_end);
     if (pos == std::string::npos) {
       break;
@@ -61,30 +71,32 @@ AttributeMap parse_attributes(const std::string &tag) {
       break;
     }
     char quote = tag[pos];
-    if (quote == '\"' || quote == '\'') {
-      ++pos;
-    } else {
-      quote = ' ';
-    }
+    std::size_t value_begin = pos;
     std::size_t value_end;
-    if (quote == ' ') {
-      value_end = tag.find_first_of(" \t\r\n>", pos);
+    if (quote == '\"' || quote == '\'') {
+      ++value_begin;
+      value_end = tag.find(quote, value_begin);
+      if (value_end == std::string::npos) {
+        value_end = tag.size();
+      }
+      pos = value_end + 1;
     } else {
-      value_end = tag.find(quote, pos);
+      value_end = tag.find_first_of(" \t\r\n/>", value_begin);
+      if (value_end == std::string::npos) {
+        value_end = tag.size();
+      }
+      pos = value_end;
     }
-    if (value_end == std::string::npos) {
-      break;
-    }
-    std::string value = tag.substr(pos, value_end - pos);
+    std::string value = tag.substr(value_begin, value_end - value_begin);
+    trim(value);
     map.values[key] = value;
-    pos = value_end + 1;
   }
   return map;
 }
 
-bool parse_size_t(const AttributeMap &attrs, std::initializer_list<const char *> keys, std::size_t &out) {
+bool parse_size_t_attr(const AttributeMap &attrs, std::initializer_list<const char *> keys, std::size_t &out) {
   for (const char *key : keys) {
-    std::string value = attrs.get(to_lower(key));
+    std::string value = attrs.get(key);
     if (!value.empty()) {
       char *end = nullptr;
       auto parsed = std::strtoul(value.c_str(), &end, 0);
@@ -97,9 +109,9 @@ bool parse_size_t(const AttributeMap &attrs, std::initializer_list<const char *>
   return false;
 }
 
-bool parse_double(const AttributeMap &attrs, std::initializer_list<const char *> keys, double &out) {
+bool parse_double_attr(const AttributeMap &attrs, std::initializer_list<const char *> keys, double &out) {
   for (const char *key : keys) {
-    std::string value = attrs.get(to_lower(key));
+    std::string value = attrs.get(key);
     if (!value.empty()) {
       char *end = nullptr;
       auto parsed = std::strtod(value.c_str(), &end);
@@ -112,117 +124,56 @@ bool parse_double(const AttributeMap &attrs, std::initializer_list<const char *>
   return false;
 }
 
-bool load_file_content(const std::string &path, std::string &content) {
-#ifdef USE_FILESYSTEM
-  if (auto *fs = esphome::filesystem::global_filesystem; fs != nullptr) {
-    auto file = fs->open(path.c_str(), "r");
-    if (file) {
-      std::ostringstream stream;
-      while (file.available()) {
-        stream << static_cast<char>(file.read());
-      }
-      content = stream.str();
-      return true;
-    }
+bool contains_percent_hint(const std::string &value) {
+  if (value.find('%') != std::string::npos) {
+    return true;
   }
-#endif
-  std::ifstream file(path, std::ios::binary);
-  if (!file.is_open()) {
+  std::string lower = to_lower_copy(value);
+  return lower.find("percent") != std::string::npos || lower.find("prozent") != std::string::npos ||
+         lower.find("pct") != std::string::npos;
+}
+
+bool parse_field_tag(const std::string &tag_text, XmlCommandMapping &mapping) {
+  auto attrs = parse_attributes(tag_text);
+  XmlField field;
+  field.name = attrs.get("name");
+  trim(field.name);
+  if (field.name.empty()) {
+    ESP_LOGW(TAG, "XML Feld ohne 'name' ignoriert");
     return false;
   }
-  std::ostringstream stream;
-  stream << file.rdbuf();
-  content = stream.str();
+  field.label = attrs.get("label");
+  trim(field.label);
+  if (field.label.empty()) {
+    field.label = field.name;
+  }
+  parse_size_t_attr(attrs, {"offset", "byte", "start"}, field.offset);
+  if (!parse_size_t_attr(attrs, {"size", "bytes", "length"}, field.size)) {
+    ESP_LOGW(TAG, "XML Feld %s ohne gültige 'size'-Angabe ignoriert", field.name.c_str());
+    return false;
+  }
+  if (field.size != 1 && field.size != 2 && field.size != 4) {
+    ESP_LOGW(TAG, "XML Feld %s verwendet nicht unterstützte Größe %u", field.name.c_str(),
+             static_cast<unsigned>(field.size));
+    return false;
+  }
+  std::string endian = to_lower_copy(attrs.get("endian"));
+  if (endian == "le" || endian == "little") {
+    field.little_endian = true;
+  }
+  double scale = field.scale;
+  if (parse_double_attr(attrs, {"scale"}, scale)) {
+    field.scale = scale;
+  } else if (contains_percent_hint(field.name) || contains_percent_hint(field.label)) {
+    field.scale = 0.01;
+  }
+  mapping.fields.push_back(field);
   return true;
 }
 
-void trim(std::string &value) {
-  auto begin = value.find_first_not_of(" \t\r\n");
-  auto end = value.find_last_not_of(" \t\r\n");
-  if (begin == std::string::npos || end == std::string::npos) {
-    value.clear();
-  } else {
-    value = value.substr(begin, end - begin + 1);
-  }
-}
-
-bool decode_field_value(const XmlField &field, const std::vector<uint8_t> &decoded, double &value) {
-  if (field.byte_length == 0) {
-    return false;
-  }
-  std::size_t required = field.byte_offset + field.byte_length;
-  if (decoded.size() < required) {
-    return false;
-  }
-  std::uint64_t raw = 0;
-  for (std::size_t i = 0; i < field.byte_length; ++i) {
-    std::size_t index = field.little_endian ? (field.byte_offset + field.byte_length - 1 - i)
-                                           : (field.byte_offset + i);
-    raw = (raw << 8) | static_cast<std::uint64_t>(decoded[index]);
-  }
-  if (field.bit_length > 0) {
-    std::size_t shift = field.bit_offset;
-    raw >>= shift;
-    if (field.bit_length < 64U) {
-      std::uint64_t mask = (static_cast<std::uint64_t>(1) << field.bit_length) - 1ULL;
-      raw &= mask;
-    }
-  }
-  value = static_cast<double>(raw) * field.scale;
-  return true;
-}
-
-bool map_fields(const std::vector<uint8_t> &decoded, const XmlCommandMapping &mapping,
-                MachineStats &out, const char *label) {
+bool parse_fields_block(const std::string &content, XmlCommandMapping &mapping) {
   bool any = false;
-  for (const auto &field : mapping.fields) {
-    double numeric = 0.0;
-    if (!decode_field_value(field, decoded, numeric)) {
-      ESP_LOGW(TAG, "XML %s Feld %s konnte nicht gelesen werden (Offset=%u, Bytes=%u, Daten=%u)", label,
-               field.name.c_str(), static_cast<unsigned>(field.byte_offset),
-               static_cast<unsigned>(field.byte_length), static_cast<unsigned>(decoded.size()));
-      continue;
-    }
-    out.set_value(field.name, numeric, field.label);
-    any = true;
-  }
-  return any;
-}
-
-XmlCommandMapping *mapping_for_id(XmlMapping &mapping, const std::string &id) {
-  std::string lowered = to_lower(id);
-  if (lowered == "tr32") {
-    return &mapping.tr32_fields;
-  }
-  if (lowered == "tg43") {
-    return &mapping.tg43_fields;
-  }
-  if (lowered == "tgc0") {
-    return &mapping.tgc0_fields;
-  }
-  return nullptr;
-}
-
-}  // namespace
-
-void MachineStats::clear() { this->values_.clear(); }
-
-bool MachineStats::empty() const { return this->values_.empty(); }
-
-void MachineStats::set_value(const std::string &name, double value, const std::string &label) {
-  this->values_[name] = StatValue{value, label};
-}
-
-bool MachineStats::has_value(const std::string &name) const {
-  return this->values_.find(name) != this->values_.end();
-}
-
-const std::unordered_map<std::string, StatValue> &MachineStats::values() const { return this->values_; }
-
-namespace {
-
-bool parse_fields(const std::string &content, XmlCommandMapping &mapping) {
-  std::string lower = to_lower(content);
+  std::string lower = to_lower_copy(content);
   std::size_t search_pos = 0;
   while (true) {
     std::size_t field_pos = lower.find("<field", search_pos);
@@ -234,167 +185,144 @@ bool parse_fields(const std::string &content, XmlCommandMapping &mapping) {
       break;
     }
     std::string tag_text = content.substr(field_pos, tag_end - field_pos + 1);
-    auto attrs = parse_attributes(tag_text);
-    XmlField field;
-    field.name = attrs.get("name");
-    trim(field.name);
-    if (field.name.empty()) {
-      ESP_LOGW(TAG, "XML Feld ohne Namen ignoriert");
-      search_pos = tag_end + 1;
-      continue;
+    if (parse_field_tag(tag_text, mapping)) {
+      any = true;
     }
-    field.label = attrs.get("label");
-    trim(field.label);
-    if (field.label.empty()) {
-      field.label = field.name;
-    }
-    parse_size_t(attrs, {"byte", "offset", "start", "index"}, field.byte_offset);
-    parse_size_t(attrs, {"bits", "bit_length"}, field.bit_length);
-    parse_size_t(attrs, {"bit", "bit_offset"}, field.bit_offset);
-    if (!parse_size_t(attrs, {"bytes", "length", "size"}, field.byte_length)) {
-      if (field.bit_length > 0) {
-        field.byte_length = (field.bit_offset + field.bit_length + 7) / 8;
-      } else {
-        std::string type = to_lower(attrs.get("type"));
-        if (type.find("32") != std::string::npos) {
-          field.byte_length = 4;
-        } else if (type.find("16") != std::string::npos) {
-          field.byte_length = 2;
-        } else if (type.find("8") != std::string::npos || type == "u8") {
-          field.byte_length = 1;
-        }
-      }
-    }
-    if (field.byte_length == 0) {
-      field.byte_length = 2;
-    }
-    std::string endian = to_lower(attrs.get("endian"));
-    if (endian == "little" || attrs.get("little_endian") == "1") {
-      field.little_endian = true;
-    }
-    double scale = field.scale;
-    if (parse_double(attrs, {"scale", "factor", "multiplier"}, scale)) {
-      field.scale = scale;
-    }
-    double divisor = 0.0;
-    if (parse_double(attrs, {"divisor"}, divisor) && divisor != 0.0) {
-      field.scale /= divisor;
-    }
-    mapping.fields.push_back(field);
     search_pos = tag_end + 1;
   }
-  return !mapping.fields.empty();
+  return any;
 }
 
-bool parse_xml_mapping_content(const std::string &content, XmlMapping &mapping) {
-  std::string lower = to_lower(content);
+bool parse_command_block(const std::string &content, const std::string &target_id, XmlCommandMapping &mapping) {
+  std::string lower = to_lower_copy(content);
+  std::string lowered_id = to_lower_copy(target_id);
   std::size_t search_pos = 0;
-  bool any_fields = false;
+  bool found = false;
   while (true) {
-    std::size_t frame_pos = lower.find("<frame", search_pos);
-    if (frame_pos == std::string::npos) {
+    std::size_t cmd_pos = lower.find("<cmd", search_pos);
+    if (cmd_pos == std::string::npos) {
       break;
     }
-    std::size_t tag_end = lower.find('>', frame_pos);
+    std::size_t tag_end = lower.find('>', cmd_pos);
     if (tag_end == std::string::npos) {
       break;
     }
-    std::size_t close_pos = lower.find("</frame", tag_end);
-    if (close_pos == std::string::npos) {
-      break;
-    }
-    std::string tag_text = content.substr(frame_pos, tag_end - frame_pos + 1);
+    std::string tag_text = content.substr(cmd_pos, tag_end - cmd_pos + 1);
     auto attrs = parse_attributes(tag_text);
     std::string id = attrs.get("id");
     trim(id);
-    auto *command = mapping_for_id(mapping, id);
-    if (command == nullptr) {
-      ESP_LOGW(TAG, "Unbekannter Frame-Typ '%s'", id.c_str());
-      search_pos = close_pos + 7;
+    if (to_lower_copy(id) != lowered_id) {
+      search_pos = tag_end + 1;
       continue;
     }
-    std::string inner = content.substr(tag_end + 1, close_pos - tag_end - 1);
-    if (parse_fields(inner, *command)) {
-      any_fields = true;
+    std::size_t close_pos = lower.find("</cmd", tag_end);
+    if (close_pos == std::string::npos) {
+      ESP_LOGW(TAG, "XML CMD %s ohne schließendes </CMD>", id.c_str());
+      break;
     }
-    search_pos = close_pos + 7;
+    std::string inner = content.substr(tag_end + 1, close_pos - tag_end - 1);
+    parse_fields_block(inner, mapping);
+    found = true;
+    search_pos = close_pos + 5;
+    break;
   }
-  mapping.valid = any_fields;
-  return mapping.valid;
+  return found;
+}
+
+XmlMapping g_mapping;
+bool g_mapping_loaded = false;
+
+bool parse_payload(const std::vector<uint8_t> &decoded, const XmlCommandMapping &mapping, Stats &out,
+                   const char *log_label) {
+  if (mapping.empty()) {
+    ESP_LOGW(TAG, "XML %s: kein Mapping vorhanden", log_label);
+    return false;
+  }
+  bool any = false;
+  for (const auto &field : mapping.fields) {
+    if (field.offset + field.size > decoded.size()) {
+      ESP_LOGW(TAG, "XML %s Feld %s überläuft Frame (Offset=%u, Bytes=%u, Frame=%u)", log_label,
+               field.name.c_str(), static_cast<unsigned>(field.offset), static_cast<unsigned>(field.size),
+               static_cast<unsigned>(decoded.size()));
+      continue;
+    }
+    std::uint64_t raw = 0;
+    if (field.little_endian) {
+      for (std::size_t i = 0; i < field.size; ++i) {
+        raw |= static_cast<std::uint64_t>(decoded[field.offset + i]) << (8U * i);
+      }
+    } else {
+      for (std::size_t i = 0; i < field.size; ++i) {
+        raw = (raw << 8U) | static_cast<std::uint64_t>(decoded[field.offset + i]);
+      }
+    }
+    double value = static_cast<double>(raw) * field.scale;
+    out.set_value(field.name, value, field.label);
+    any = true;
+  }
+  return any;
 }
 
 }  // namespace
 
-bool load_xml_mapping(const std::string &path, XmlMapping &mapping) {
-  std::string content;
-  if (!load_file_content(path, content)) {
-    ESP_LOGW(TAG, "XML Mapping %s konnte nicht geladen werden", path.c_str());
-    mapping.valid = false;
+void Stats::clear() { this->values_.clear(); }
+
+bool Stats::empty() const { return this->values_.empty(); }
+
+void Stats::set_value(const std::string &name, double value, const std::string &label) {
+  this->values_[name] = StatValue{value, label};
+}
+
+bool Stats::has_value(const std::string &name) const { return this->values_.find(name) != this->values_.end(); }
+
+const std::unordered_map<std::string, StatValue> &Stats::values() const { return this->values_; }
+
+bool load_mapping_from_string(const std::string &xml) {
+  g_mapping = XmlMapping{};
+  bool tr32_found = parse_command_block(xml, "@tr:32", g_mapping.tr32);
+  bool tg43_found = parse_command_block(xml, "@tg:43", g_mapping.tg43);
+  bool tgc0_found = parse_command_block(xml, "@tg:c0", g_mapping.tgc0);
+
+  g_mapping.valid = tr32_found && tg43_found && tgc0_found && !g_mapping.tr32.empty() && !g_mapping.tg43.empty() &&
+                    !g_mapping.tgc0.empty();
+  g_mapping_loaded = true;
+
+  if (!tr32_found || g_mapping.tr32.empty()) {
+    ESP_LOGW(TAG, "XML Mapping enthält keine Felder für @TR:32");
+  }
+  if (!tg43_found || g_mapping.tg43.empty()) {
+    ESP_LOGW(TAG, "XML Mapping enthält keine Felder für @TG:43");
+  }
+  if (!tgc0_found || g_mapping.tgc0.empty()) {
+    ESP_LOGW(TAG, "XML Mapping enthält keine Felder für @TG:C0");
+  }
+  return g_mapping.valid;
+}
+
+const XmlMapping &get_xml_mapping() { return g_mapping; }
+
+bool parse_TR32(const std::vector<uint8_t> &decoded, Stats &out) {
+  if (!g_mapping_loaded) {
+    ESP_LOGW(TAG, "XML Mapping wurde nicht geladen");
     return false;
   }
-  mapping = XmlMapping{};
-  mapping.source_path = path;
-  if (!parse_xml_mapping_content(content, mapping)) {
-    ESP_LOGW(TAG, "XML Mapping %s enthält keine bekannten Felder", path.c_str());
-    mapping.valid = false;
+  return parse_payload(decoded, g_mapping.tr32, out, "TR32");
+}
+
+bool parse_TG43(const std::vector<uint8_t> &decoded, Stats &out) {
+  if (!g_mapping_loaded) {
+    ESP_LOGW(TAG, "XML Mapping wurde nicht geladen");
     return false;
   }
-  return true;
+  return parse_payload(decoded, g_mapping.tg43, out, "TG43");
 }
 
-namespace {
-XmlMapping g_current_mapping{};
-bool g_has_mapping = false;
-}
-
-bool load_xml_mapping(const std::string &path) {
-  XmlMapping mapping;
-  if (!load_xml_mapping(path, mapping)) {
-    g_has_mapping = false;
-    g_current_mapping = XmlMapping{};
+bool parse_TGC0(const std::vector<uint8_t> &decoded, Stats &out) {
+  if (!g_mapping_loaded) {
+    ESP_LOGW(TAG, "XML Mapping wurde nicht geladen");
     return false;
   }
-  g_current_mapping = mapping;
-  g_has_mapping = mapping.valid;
-  return g_has_mapping;
-}
-
-const XmlMapping &get_loaded_xml_mapping() { return g_current_mapping; }
-
-bool map_tr32(const std::vector<uint8_t> &decoded, const XmlMapping &mapping, MachineStats &out) {
-  return map_fields(decoded, mapping.tr32_fields, out, "TR32");
-}
-
-bool map_tg43(const std::vector<uint8_t> &decoded, const XmlMapping &mapping, MachineStats &out) {
-  return map_fields(decoded, mapping.tg43_fields, out, "TG43");
-}
-
-bool map_tgc0(const std::vector<uint8_t> &decoded, const XmlMapping &mapping, MachineStats &out) {
-  return map_fields(decoded, mapping.tgc0_fields, out, "TGC0");
-}
-
-bool map_tr32(const std::vector<uint8_t> &decoded, MachineStats &out) {
-  if (!g_has_mapping) {
-    ESP_LOGW(TAG, "Kein XML-Mapping geladen");
-    return false;
-  }
-  return map_tr32(decoded, g_current_mapping, out);
-}
-
-bool map_tg43(const std::vector<uint8_t> &decoded, MachineStats &out) {
-  if (!g_has_mapping) {
-    ESP_LOGW(TAG, "Kein XML-Mapping geladen");
-    return false;
-  }
-  return map_tg43(decoded, g_current_mapping, out);
-}
-
-bool map_tgc0(const std::vector<uint8_t> &decoded, MachineStats &out) {
-  if (!g_has_mapping) {
-    ESP_LOGW(TAG, "Kein XML-Mapping geladen");
-    return false;
-  }
-  return map_tgc0(decoded, g_current_mapping, out);
+  return parse_payload(decoded, g_mapping.tgc0, out, "TGC0");
 }
 
 }  // namespace jutta_component

--- a/esphome/components/jutta_proto/jutta_proto_xml.h
+++ b/esphome/components/jutta_proto/jutta_proto_xml.h
@@ -12,24 +12,22 @@ namespace jutta_component {
 struct XmlField {
   std::string name;
   std::string label;
-  std::size_t byte_offset{0};
-  std::size_t byte_length{0};
-  std::size_t bit_offset{0};
-  std::size_t bit_length{0};
+  std::size_t offset{0};
+  std::size_t size{0};
   bool little_endian{false};
   double scale{1.0};
 };
 
 struct XmlCommandMapping {
   std::vector<XmlField> fields;
+  bool empty() const { return this->fields.empty(); }
 };
 
 struct XmlMapping {
   bool valid{false};
-  std::string source_path;
-  XmlCommandMapping tr32_fields;
-  XmlCommandMapping tg43_fields;
-  XmlCommandMapping tgc0_fields;
+  XmlCommandMapping tr32;
+  XmlCommandMapping tg43;
+  XmlCommandMapping tgc0;
 };
 
 struct StatValue {
@@ -37,7 +35,7 @@ struct StatValue {
   std::string label;
 };
 
-class MachineStats {
+class Stats {
  public:
   void clear();
   bool empty() const;
@@ -49,17 +47,12 @@ class MachineStats {
   std::unordered_map<std::string, StatValue> values_{};
 };
 
-bool load_xml_mapping(const std::string &path, XmlMapping &mapping);
-bool load_xml_mapping(const std::string &path);
-const XmlMapping &get_loaded_xml_mapping();
+bool load_mapping_from_string(const std::string &xml);
+const XmlMapping &get_xml_mapping();
 
-bool map_tr32(const std::vector<uint8_t> &decoded, const XmlMapping &mapping, MachineStats &out);
-bool map_tg43(const std::vector<uint8_t> &decoded, const XmlMapping &mapping, MachineStats &out);
-bool map_tgc0(const std::vector<uint8_t> &decoded, const XmlMapping &mapping, MachineStats &out);
-
-bool map_tr32(const std::vector<uint8_t> &decoded, MachineStats &out);
-bool map_tg43(const std::vector<uint8_t> &decoded, MachineStats &out);
-bool map_tgc0(const std::vector<uint8_t> &decoded, MachineStats &out);
+bool parse_TR32(const std::vector<uint8_t> &decoded, Stats &out);
+bool parse_TG43(const std::vector<uint8_t> &decoded, Stats &out);
+bool parse_TGC0(const std::vector<uint8_t> &decoded, Stats &out);
 
 }  // namespace jutta_component
 }  // namespace esphome


### PR DESCRIPTION
## Summary
- entferne den Zusatz-Header und binde die J.O.E.-Exportdatei weiterhin automatisch als Binärressource ein
- lasse den YAML-Parameter `xml_mapping_path` auf den tatsächlichen XML-Pfad zeigen und validiere dessen Existenz
- aktualisiere die README-Beschreibung auf den neuen Ablauf ohne zusätzliche Includes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e06157b7448328bcded029a8bd19b4