### PR TITLE
Ensure XML mapping is initialized before configuration logging

### DIFF
--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -233,6 +233,18 @@ void JuraComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "  Detected device: (pending)");
   }
 
+  if (this->enable_xml_poll_) {
+    // Stelle sicher, dass der aktuelle Status des XML-Mappings bereits zur
+    // Konfigurationsausgabe geladen und protokolliert wurde. Andernfalls sieht
+    // es so aus, als wäre kein Mapping verfügbar, obwohl es kurz darauf in
+    // setup() geladen wird.
+    if (!this->xml_mapping_loaded_) {
+      this->ensure_xml_mapping_loaded_();
+    }
+    this->log_xml_mapping_status_();
+    this->ensure_xml_sensors_created_();
+  }
+
   const char *state = "unknown";
   switch (this->handshake_stage_) {
     case HandshakeStage::IDLE:


### PR DESCRIPTION
## Summary
- ensure the XML mapping is loaded, logged, and sensors are created before dumping the configuration when XML polling is enabled

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e0fda36c7c83289ad88bb50117b2f4