### PR TITLE
Revert "Ensure XML mapping is initialized before configuration logging"

### DIFF
--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -233,18 +233,6 @@ void JuraComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "  Detected device: (pending)");
   }
 
-  if (this->enable_xml_poll_) {
-    // Stelle sicher, dass der aktuelle Status des XML-Mappings bereits zur
-    // Konfigurationsausgabe geladen und protokolliert wurde. Andernfalls sieht
-    // es so aus, als wäre kein Mapping verfügbar, obwohl es kurz darauf in
-    // setup() geladen wird.
-    if (!this->xml_mapping_loaded_) {
-      this->ensure_xml_mapping_loaded_();
-    }
-    this->log_xml_mapping_status_();
-    this->ensure_xml_sensors_created_();
-  }
-
   const char *state = "unknown";
   switch (this->handshake_stage_) {
     case HandshakeStage::IDLE:


### PR DESCRIPTION
Reverts Murmeltier-86/protocol-cpp_ESPHome#199