### PR TITLE
Improve XML mapping fallback parsing

### DIFF
--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -24,6 +24,7 @@ constexpr uint32_t MACHINE_DATA_REQUEST_TIMEOUT_MS = 2000;
 const char *const MACHINE_DATA_COMMAND = "&STAT?\r\n";
 constexpr uint32_t XML_RESPONSE_TIMEOUT_MS = 1400;
 constexpr uint32_t XML_INTER_COMMAND_DELAY_MS = 180;
+constexpr size_t XML_COMMAND_COUNT = 3;
 
 template<typename AppT>
 auto try_register_sensor(AppT &app, sensor::Sensor *sensor, long)
@@ -233,6 +234,13 @@ void JuraComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "  Detected device: (pending)");
   }
 
+  if (this->enable_xml_poll_) {
+    // Stelle sicher, dass der aktuelle Status des XML-Mappings bereits zur
+    // Konfigurationsausgabe geladen und die Sensoren angelegt wurden.
+    this->ensure_xml_mapping_loaded_();
+    this->ensure_xml_sensors_created_();
+  }
+
   const char *state = "unknown";
   switch (this->handshake_stage_) {
     case HandshakeStage::IDLE:
@@ -281,8 +289,20 @@ void JuraComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "  XML polling: %s", this->enable_xml_poll_ ? "enabled" : "disabled");
   ESP_LOGCONFIG(TAG, "  XML mapping Quelle: %s", this->xml_mapping_path_.c_str());
   ESP_LOGCONFIG(TAG, "  XML poll interval: %u ms", static_cast<unsigned>(this->xml_poll_interval_ms_));
-  ESP_LOGCONFIG(TAG, "  XML mapping loaded: %s",
-                YESNO(this->xml_mapping_loaded_ && this->xml_mapping_.valid));
+  if (this->enable_xml_poll_) {
+    this->log_xml_mapping_status_(true);
+    ESP_LOGCONFIG(TAG, "  XML mapping loaded: %s", YESNO(this->xml_mapping_loaded_));
+    ESP_LOGCONFIG(TAG, "  XML mapping valid: %s", YESNO(this->xml_mapping_.valid));
+    ESP_LOGCONFIG(TAG, "  XML mapping commands: TR32=%s (%u Felder), TG43=%s (%u Felder), TGC0=%s (%u Felder)",
+                  YESNO(!this->xml_mapping_.tr32.empty()),
+                  static_cast<unsigned>(this->xml_mapping_.tr32.fields.size()),
+                  YESNO(!this->xml_mapping_.tg43.empty()),
+                  static_cast<unsigned>(this->xml_mapping_.tg43.fields.size()),
+                  YESNO(!this->xml_mapping_.tgc0.empty()),
+                  static_cast<unsigned>(this->xml_mapping_.tgc0.fields.size()));
+  } else {
+    ESP_LOGCONFIG(TAG, "  XML mapping loaded: %s", YESNO(false));
+  }
   ESP_LOGCONFIG(TAG, "  XML sensors: %u", static_cast<unsigned>(this->xml_sensors_.size()));
 }
 
@@ -569,10 +589,13 @@ void JuraComponent::publish_machine_data_(const std::string &response) {
 }
 
 void JuraComponent::ensure_xml_sensors_created_() {
-  if (!this->enable_xml_poll_ || !this->xml_mapping_.valid) {
+  if (!this->enable_xml_poll_) {
     return;
   }
   auto ensure_block = [&](const XmlCommandMapping &mapping) {
+    if (mapping.empty()) {
+      return;
+    }
     for (const auto &field : mapping.fields) {
       this->get_or_create_sensor_(field.name, field.label);
     }
@@ -594,7 +617,7 @@ bool JuraComponent::ensure_xml_mapping_loaded_() {
     ESP_LOGW(TAG, "Kein XML-Mapping verfügbar (Quelle: %s)",
              this->xml_mapping_path_.c_str());
     this->xml_mapping_loaded_ = true;
-    this->xml_mapping_.valid = false;
+    this->xml_mapping_ = {};
     this->xml_stats_.clear();
     this->log_xml_mapping_status_();
     return false;
@@ -606,9 +629,6 @@ bool JuraComponent::ensure_xml_mapping_loaded_() {
   this->xml_mapping_loaded_ = true;
   this->xml_mapping_logged_ = false;
   this->xml_stats_.clear();
-  if (!valid) {
-    this->xml_mapping_.valid = false;
-  }
   this->log_xml_mapping_status_();
   if (this->xml_mapping_.valid) {
     this->ensure_xml_sensors_created_();
@@ -616,12 +636,15 @@ bool JuraComponent::ensure_xml_mapping_loaded_() {
   return this->xml_mapping_.valid;
 }
 
-void JuraComponent::log_xml_mapping_status_() {
-  if (this->xml_mapping_logged_) {
+void JuraComponent::log_xml_mapping_status_(bool force) {
+  if (this->xml_mapping_logged_ && !force) {
     return;
   }
-  ESP_LOGI(TAG, "XML mapping valid=%d, cmds=<@TR:32, @TG:43, @TG:C0>",
-           static_cast<int>(this->xml_mapping_.valid));
+  ESP_LOGCONFIG(TAG,
+                "  XML mapping Status: geladen=%s, gültig=%s, TR32=%s, TG43=%s, TGC0=%s",
+                YESNO(this->xml_mapping_loaded_), YESNO(this->xml_mapping_.valid),
+                YESNO(!this->xml_mapping_.tr32.empty()), YESNO(!this->xml_mapping_.tg43.empty()),
+                YESNO(!this->xml_mapping_.tgc0.empty()));
   this->xml_mapping_logged_ = true;
 }
 
@@ -659,8 +682,15 @@ void JuraComponent::start_xml_cycle_(uint32_t now) {
   }
   this->xml_cycle_.reset();
   this->xml_cycle_.phase = XmlCycleState::Phase::WaitingForFrame;
-  this->xml_cycle_.command_index = 0;
-  const char *command = xml_command_for_index_(0);
+  size_t first_index = this->first_mapped_xml_command_index_();
+  if (first_index >= XML_COMMAND_COUNT) {
+    ESP_LOGW(TAG, "XML Polling übersprungen - kein Mapping aktiv");
+    this->xml_cycle_.reset();
+    this->xml_next_poll_ = now + this->xml_poll_interval_ms_;
+    return;
+  }
+  this->xml_cycle_.command_index = first_index;
+  const char *command = xml_command_for_index_(first_index);
   ESP_LOGD(TAG, "TX_DB \"%s\"", command);
   this->coffee_maker_->connection->reset_all_rx_buffers();
   this->coffee_maker_->connection->tx_db_command(command);
@@ -696,8 +726,8 @@ void JuraComponent::handle_xml_cycle_(uint32_t now) {
           static_cast<int32_t>(now - this->xml_cycle_.next_action_ms) < 0) {
         return;
       }
-      size_t next_index = this->xml_cycle_.command_index + 1;
-      if (next_index >= 3) {
+      size_t next_index = this->next_mapped_xml_command_index_(this->xml_cycle_.command_index);
+      if (next_index >= XML_COMMAND_COUNT) {
         this->finish_xml_cycle_(now, true);
         return;
       }
@@ -733,6 +763,9 @@ void JuraComponent::finish_xml_cycle_(uint32_t now, bool success) {
   bool any_value = false;
 
   auto handle_response = [&](size_t index, bool (*parser)(const std::vector<uint8_t> &, Stats &)) {
+    if (!this->xml_command_has_mapping_(index)) {
+      return;
+    }
     const auto &response = this->xml_cycle_.responses[index];
     const char *label = xml_log_label_for_index_(index);
     if (response.empty()) {
@@ -817,6 +850,41 @@ const char *JuraComponent::xml_log_label_for_index_(size_t index) {
     return "?";
   }
   return LABELS[index];
+}
+
+bool JuraComponent::xml_command_has_mapping_(size_t index) const {
+  switch (index) {
+    case 0:
+      return !this->xml_mapping_.tr32.empty();
+    case 1:
+      return !this->xml_mapping_.tg43.empty();
+    case 2:
+      return !this->xml_mapping_.tgc0.empty();
+    default:
+      break;
+  }
+  return false;
+}
+
+size_t JuraComponent::first_mapped_xml_command_index_() const {
+  for (size_t i = 0; i < XML_COMMAND_COUNT; ++i) {
+    if (this->xml_command_has_mapping_(i)) {
+      return i;
+    }
+  }
+  return XML_COMMAND_COUNT;
+}
+
+size_t JuraComponent::next_mapped_xml_command_index_(size_t index) const {
+  if (index >= XML_COMMAND_COUNT) {
+    return XML_COMMAND_COUNT;
+  }
+  for (size_t i = index + 1; i < XML_COMMAND_COUNT; ++i) {
+    if (this->xml_command_has_mapping_(i)) {
+      return i;
+    }
+  }
+  return XML_COMMAND_COUNT;
 }
 
 void JuraComponent::XmlCycleState::reset() {

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -115,7 +115,7 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   void publish_machine_data_(const std::string &response);
   void process_xml_polling();
   bool ensure_xml_mapping_loaded_();
-  void log_xml_mapping_status_();
+  void log_xml_mapping_status_(bool force = false);
   void ensure_xml_sensors_created_();
   void reset_xml_cycle_state_();
   void start_xml_cycle_(uint32_t now);
@@ -127,6 +127,9 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   sensor::Sensor *get_or_create_sensor_(const std::string &name, const std::string &label);
   static const char *xml_command_for_index_(size_t index);
   static const char *xml_log_label_for_index_(size_t index);
+  bool xml_command_has_mapping_(size_t index) const;
+  size_t first_mapped_xml_command_index_() const;
+  size_t next_mapped_xml_command_index_(size_t index) const;
 
   std::unique_ptr<::jutta_proto::JuttaConnection> connection_;
   std::unique_ptr<::jutta_proto::CoffeeMaker> coffee_maker_;

--- a/esphome/components/jutta_proto/jutta_proto_xml.cpp
+++ b/esphome/components/jutta_proto/jutta_proto_xml.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <initializer_list>
+#include <sstream>
 #include <unordered_map>
 
 #include "esphome/core/log.h"
@@ -14,6 +15,17 @@ namespace jutta_component {
 
 namespace {
 static const char *const TAG = "jutta_proto.xml";
+
+constexpr std::size_t DEFAULT_TR32_COUNT = 10;
+constexpr std::size_t DEFAULT_TG43_COUNT = 6;
+constexpr std::size_t DEFAULT_TGC0_COUNT = 3;
+
+constexpr std::size_t MAX_TR32_COUNT = 64;
+constexpr std::size_t MAX_TG43_COUNT = 16;
+constexpr std::size_t MAX_TGC0_COUNT = 16;
+
+constexpr std::size_t FIELD_WIDTH_16BIT = 2;
+constexpr std::size_t FIELD_WIDTH_32BIT = 4;
 
 std::string to_lower_copy(const std::string &input) {
   std::string result = input;
@@ -30,6 +42,31 @@ void trim(std::string &value) {
     return;
   }
   value = value.substr(begin, end - begin + 1);
+}
+
+std::string tidy_label(std::string value) {
+  std::string result;
+  result.reserve(value.size() * 2);
+  char prev = 0;
+  for (char ch : value) {
+    if (ch == '_' || ch == '-') {
+      if (!result.empty() && result.back() != ' ') {
+        result.push_back(' ');
+      }
+      prev = ' ';
+      continue;
+    }
+    if (std::isupper(static_cast<unsigned char>(ch)) != 0 && prev != 0 &&
+        std::islower(static_cast<unsigned char>(prev)) != 0) {
+      if (!result.empty() && result.back() != ' ') {
+        result.push_back(' ');
+      }
+    }
+    result.push_back(ch);
+    prev = ch;
+  }
+  trim(result);
+  return result;
 }
 
 struct AttributeMap {
@@ -229,6 +266,156 @@ bool parse_command_block(const std::string &content, const std::string &target_i
   return found;
 }
 
+std::string extract_block(const std::string &xml, const std::string &lower_xml, const std::string &tag) {
+  std::string tag_lower = "<" + tag;
+  std::size_t begin = lower_xml.find(tag_lower);
+  if (begin == std::string::npos) {
+    return {};
+  }
+  std::size_t open_end = lower_xml.find('>', begin);
+  if (open_end == std::string::npos) {
+    return {};
+  }
+  std::string close_tag = "</" + tag + ">";
+  std::size_t close_pos = lower_xml.find(close_tag, open_end);
+  if (close_pos == std::string::npos) {
+    return {};
+  }
+  return xml.substr(open_end + 1, close_pos - open_end - 1);
+}
+
+std::vector<std::string> collect_tag_values(const std::string &content, const std::string &tag,
+                                            std::initializer_list<const char *> attribute_priority) {
+  std::vector<std::string> values;
+  std::string lower = to_lower_copy(content);
+  std::string needle = "<" + tag;
+  std::size_t pos = 0;
+  while (true) {
+    std::size_t tag_pos = lower.find(needle, pos);
+    if (tag_pos == std::string::npos) {
+      break;
+    }
+    std::size_t tag_end = lower.find('>', tag_pos);
+    if (tag_end == std::string::npos) {
+      break;
+    }
+    std::string tag_text = content.substr(tag_pos, tag_end - tag_pos + 1);
+    auto attrs = parse_attributes(tag_text);
+    std::string chosen;
+    for (const char *key : attribute_priority) {
+      chosen = attrs.get(key);
+      trim(chosen);
+      if (!chosen.empty()) {
+        break;
+      }
+    }
+    if (!chosen.empty()) {
+      values.push_back(tidy_label(chosen));
+    }
+    pos = tag_end + 1;
+  }
+  return values;
+}
+
+std::string extract_bank_block(const std::string &xml, const std::string &lower_xml, const std::string &command) {
+  std::string lowered_command = to_lower_copy(command);
+  std::size_t pos = 0;
+  while (true) {
+    std::size_t bank_pos = lower_xml.find("<bank", pos);
+    if (bank_pos == std::string::npos) {
+      break;
+    }
+    std::size_t tag_end = lower_xml.find('>', bank_pos);
+    if (tag_end == std::string::npos) {
+      break;
+    }
+    std::string tag_text = xml.substr(bank_pos, tag_end - bank_pos + 1);
+    auto attrs = parse_attributes(tag_text);
+    std::string cmd = to_lower_copy(attrs.get("command"));
+    if (cmd == lowered_command) {
+      if (tag_end > bank_pos && lower_xml[tag_end - 1] == '/') {
+        return {};
+      }
+      std::size_t close_pos = lower_xml.find("</bank", tag_end);
+      if (close_pos == std::string::npos) {
+        return {};
+      }
+      return xml.substr(tag_end + 1, close_pos - tag_end - 1);
+    }
+    pos = tag_end + 1;
+  }
+  return {};
+}
+
+std::vector<std::string> collect_tr32_labels(const std::string &xml) {
+  std::vector<std::string> labels;
+  std::string lower_xml = to_lower_copy(xml);
+
+  auto total_values = collect_tag_values(xml, "totalcounter", {"name", "text"});
+  if (!total_values.empty()) {
+    labels.push_back(total_values.front());
+  }
+
+  std::string products_block = extract_block(xml, lower_xml, "products");
+  if (!products_block.empty()) {
+    auto product_values = collect_tag_values(products_block, "product", {"name", "text"});
+    labels.insert(labels.end(), product_values.begin(), product_values.end());
+  }
+
+  return labels;
+}
+
+std::vector<std::string> collect_textitem_labels(const std::string &xml, const std::string &command) {
+  std::string lower_xml = to_lower_copy(xml);
+  std::string bank_block = extract_bank_block(xml, lower_xml, command);
+  if (bank_block.empty()) {
+    return {};
+  }
+  return collect_tag_values(bank_block, "textitem", {"label", "type", "name", "text"});
+}
+
+std::string default_label_for_index(const std::string &display_prefix, std::size_t index) {
+  std::ostringstream stream;
+  stream << display_prefix << ' ' << (index + 1);
+  return stream.str();
+}
+
+XmlCommandMapping build_sequential_mapping(const std::string &name_prefix, const std::string &display_prefix,
+                                           std::size_t field_width, std::size_t count,
+                                           const std::vector<std::string> &labels) {
+  XmlCommandMapping mapping;
+  if (count == 0) {
+    return mapping;
+  }
+  mapping.fields.reserve(count);
+  for (std::size_t i = 0; i < count; ++i) {
+    XmlField field;
+    std::ostringstream name_stream;
+    name_stream << name_prefix << '_' << (i + 1);
+    field.name = name_stream.str();
+    if (i < labels.size() && !labels[i].empty()) {
+      field.label = labels[i];
+    } else {
+      field.label = default_label_for_index(display_prefix, i);
+    }
+    field.offset = i * field_width;
+    field.size = field_width;
+    field.little_endian = false;
+    field.scale = 1.0;
+    mapping.fields.push_back(field);
+  }
+  return mapping;
+}
+
+XmlMapping build_default_mapping() {
+  XmlMapping mapping;
+  mapping.tr32 = build_sequential_mapping("tr32", "TR32", FIELD_WIDTH_16BIT, DEFAULT_TR32_COUNT, {});
+  mapping.tg43 = build_sequential_mapping("tg43", "TG43", FIELD_WIDTH_16BIT, DEFAULT_TG43_COUNT, {});
+  mapping.tgc0 = build_sequential_mapping("tgc0", "TGC0", FIELD_WIDTH_32BIT, DEFAULT_TGC0_COUNT, {});
+  mapping.valid = true;
+  return mapping;
+}
+
 XmlMapping g_mapping;
 bool g_mapping_loaded = false;
 
@@ -279,23 +466,76 @@ const std::unordered_map<std::string, StatValue> &Stats::values() const { return
 
 bool load_mapping_from_string(const std::string &xml) {
   g_mapping = XmlMapping{};
-  bool tr32_found = parse_command_block(xml, "@tr:32", g_mapping.tr32);
-  bool tg43_found = parse_command_block(xml, "@tg:43", g_mapping.tg43);
-  bool tgc0_found = parse_command_block(xml, "@tg:c0", g_mapping.tgc0);
 
-  g_mapping.valid = tr32_found && tg43_found && tgc0_found && !g_mapping.tr32.empty() && !g_mapping.tg43.empty() &&
-                    !g_mapping.tgc0.empty();
+  bool tr32_cmd_found = parse_command_block(xml, "@tr:32", g_mapping.tr32);
+  bool tg43_cmd_found = parse_command_block(xml, "@tg:43", g_mapping.tg43);
+  bool tgc0_cmd_found = parse_command_block(xml, "@tg:c0", g_mapping.tgc0);
+
+  std::string lower_xml = to_lower_copy(xml);
+  bool has_tr32 = lower_xml.find("@tr:32") != std::string::npos;
+  bool has_tg43 = lower_xml.find("@tg:43") != std::string::npos;
+  bool has_tgc0 = lower_xml.find("@tg:c0") != std::string::npos;
+
+  if ((!tr32_cmd_found || g_mapping.tr32.empty()) && has_tr32) {
+    auto tr32_labels = collect_tr32_labels(xml);
+    if (tr32_labels.size() > MAX_TR32_COUNT) {
+      ESP_LOGW(TAG, "XML Mapping @TR:32 enthält %u Einträge, auf %u gekürzt",
+               static_cast<unsigned>(tr32_labels.size()), static_cast<unsigned>(MAX_TR32_COUNT));
+      tr32_labels.resize(MAX_TR32_COUNT);
+    }
+    std::size_t tr32_count = !tr32_labels.empty() ? tr32_labels.size() : DEFAULT_TR32_COUNT;
+    if (tr32_count > MAX_TR32_COUNT) {
+      tr32_count = MAX_TR32_COUNT;
+    }
+    g_mapping.tr32 = build_sequential_mapping("tr32", "TR32", FIELD_WIDTH_16BIT, tr32_count, tr32_labels);
+  }
+  if ((!tg43_cmd_found || g_mapping.tg43.empty()) && has_tg43) {
+    auto tg43_labels = collect_textitem_labels(xml, "@tg:43");
+    if (tg43_labels.size() > MAX_TG43_COUNT) {
+      ESP_LOGW(TAG, "XML Mapping @TG:43 enthält %u Einträge, auf %u gekürzt",
+               static_cast<unsigned>(tg43_labels.size()), static_cast<unsigned>(MAX_TG43_COUNT));
+      tg43_labels.resize(MAX_TG43_COUNT);
+    }
+    std::size_t tg43_count = !tg43_labels.empty() ? tg43_labels.size() : DEFAULT_TG43_COUNT;
+    if (tg43_count > MAX_TG43_COUNT) {
+      tg43_count = MAX_TG43_COUNT;
+    }
+    g_mapping.tg43 = build_sequential_mapping("tg43", "TG43", FIELD_WIDTH_16BIT, tg43_count, tg43_labels);
+  }
+  if ((!tgc0_cmd_found || g_mapping.tgc0.empty()) && has_tgc0) {
+    auto tgc0_labels = collect_textitem_labels(xml, "@tg:c0");
+    if (tgc0_labels.size() > MAX_TGC0_COUNT) {
+      ESP_LOGW(TAG, "XML Mapping @TG:C0 enthält %u Einträge, auf %u gekürzt",
+               static_cast<unsigned>(tgc0_labels.size()), static_cast<unsigned>(MAX_TGC0_COUNT));
+      tgc0_labels.resize(MAX_TGC0_COUNT);
+    }
+    std::size_t tgc0_count = !tgc0_labels.empty() ? tgc0_labels.size() : DEFAULT_TGC0_COUNT;
+    if (tgc0_count > MAX_TGC0_COUNT) {
+      tgc0_count = MAX_TGC0_COUNT;
+    }
+    g_mapping.tgc0 = build_sequential_mapping("tgc0", "TGC0", FIELD_WIDTH_32BIT, tgc0_count, tgc0_labels);
+  }
+
+  if (!has_tr32 && !has_tg43 && !has_tgc0) {
+    ESP_LOGW(TAG, "XML Mapping enthält keine bekannten Kommandos, verwende Standardzuordnung");
+    g_mapping = build_default_mapping();
+  } else {
+    if (has_tr32 && g_mapping.tr32.empty()) {
+      ESP_LOGW(TAG, "XML Mapping @TR:32 ohne Felder, verwende Standardzuordnung");
+      g_mapping.tr32 = build_sequential_mapping("tr32", "TR32", FIELD_WIDTH_16BIT, DEFAULT_TR32_COUNT, {});
+    }
+    if (has_tg43 && g_mapping.tg43.empty()) {
+      ESP_LOGW(TAG, "XML Mapping @TG:43 ohne Felder, verwende Standardzuordnung");
+      g_mapping.tg43 = build_sequential_mapping("tg43", "TG43", FIELD_WIDTH_16BIT, DEFAULT_TG43_COUNT, {});
+    }
+    if (has_tgc0 && g_mapping.tgc0.empty()) {
+      ESP_LOGW(TAG, "XML Mapping @TG:C0 ohne Felder, verwende Standardzuordnung");
+      g_mapping.tgc0 = build_sequential_mapping("tgc0", "TGC0", FIELD_WIDTH_32BIT, DEFAULT_TGC0_COUNT, {});
+    }
+  }
+
+  g_mapping.valid = !g_mapping.tr32.empty() || !g_mapping.tg43.empty() || !g_mapping.tgc0.empty();
   g_mapping_loaded = true;
-
-  if (!tr32_found || g_mapping.tr32.empty()) {
-    ESP_LOGW(TAG, "XML Mapping enthält keine Felder für @TR:32");
-  }
-  if (!tg43_found || g_mapping.tg43.empty()) {
-    ESP_LOGW(TAG, "XML Mapping enthält keine Felder für @TG:43");
-  }
-  if (!tgc0_found || g_mapping.tgc0.empty()) {
-    ESP_LOGW(TAG, "XML Mapping enthält keine Felder für @TG:C0");
-  }
   return g_mapping.valid;
 }
 


### PR DESCRIPTION
## Summary
- generate sequential XML mappings from product and maintenance sections when explicit <cmd>/<field> definitions are missing, keeping support for existing detailed mappings
- tidy extracted labels, cap extreme entry counts, and fall back to default command definitions so XML polling reliably produces sensors

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e0fda36c7c83289ad88bb50117b2f4