### PR TITLE
Fix XML bank attribute parsing for uppercase JOE exports

### DIFF
--- a/docs/components/jutta_proto.md
+++ b/docs/components/jutta_proto.md
@@ -170,3 +170,15 @@ auf älteren Toolchains fehlerfrei kompilieren.
 Zusätzlich wurde die Hilfsfunktion zur Formatierung druckbarer Zeichen so angepasst, dass sie ohne nicht genutzten Template-Parameter
 auskommt. Damit bleibt die Ausgabe in den ESPHome-Logs (z. B. beim UART-Handshaking) unverändert, gleichzeitig verhindert die Änderung
 jedoch, dass GCC oder Clang bei der Vorlagendeduktion scheitern.
+
+### XML-Mapping der J.O.E.-Exporte
+
+**Symptom.** Im Log erscheint dauerhaft `XML mapping valid: NO`, obwohl die J.O.E.-XML-Datei korrekt geladen wurde. Alle Sensoren für
+`@TR:32`, `@TG:43` und `@TG:C0` bleiben inaktiv.
+
+**Ursache.** Der XML-Parser hat das erste Wort eines Tags irrtümlich als Attribut behandelt. Bei Exporten, die Großbuchstaben für
+`<BANK Command="…">` verwenden, wurde daher das `Command`-Attribut nicht erkannt und der zugehörige Block übersprungen.
+
+**Lösung.** Die Attribut-Erkennung ignoriert nun das Tag-Präfix, sobald hinter dem Tag-Namen kein `=` folgt. Dadurch werden auch J.O.E.-
+Exporte mit vollständig großgeschriebenen `BANK`-Tags korrekt ausgewertet, die Sensorfelder werden wieder angelegt und der Status
+wechselt auf `XML mapping valid: YES`.

--- a/esphome/components/jutta_proto/jutta_proto_xml.cpp
+++ b/esphome/components/jutta_proto/jutta_proto_xml.cpp
@@ -68,11 +68,19 @@ AttributeMap parse_attributes(const std::string &tag) {
     }
     std::string key = tag.substr(pos, name_end - pos);
     key = to_lower_copy(key);
-    pos = tag.find('=', name_end);
-    if (pos == std::string::npos) {
+    std::size_t equal_pos = tag.find('=', name_end);
+    if (equal_pos == std::string::npos) {
       break;
     }
-    ++pos;
+    std::size_t next_non_space = tag.find_first_not_of(" \t\r\n", name_end);
+    if (next_non_space == std::string::npos) {
+      break;
+    }
+    if (tag[next_non_space] != '=') {
+      pos = next_non_space;
+      continue;
+    }
+    pos = equal_pos + 1;
     pos = tag.find_first_not_of(" \t\r\n", pos);
     if (pos == std::string::npos) {
       break;


### PR DESCRIPTION
## Summary
- ensure XML attribute parsing skips the BANK tag name so command attributes from uppercase J.O.E. exports are detected
- document the resolved XML mapping issue and its symptoms for troubleshooting

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e12ca9cfe4832885f71e3df371501e