### PR TITLE
fix: ignore frame header byte when parsing XML stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ jutta_proto:
 - Die Datei muss nicht angepasst werden – einfach die unveränderte App-Exportdatei referenzieren.
 - Der tatsächlich genutzte Pfad wird in der Konfigurationsausgabe als `XML mapping Quelle` protokolliert.
 
+#### CODEX-Anweisung (J.O.E.-XML ohne `includes`)
+
+1. J.O.E.-XML in der App exportieren und unverändert ins ESPHome-Projekt legen.
+2. In der YAML `xml_mapping_path: <dateiname>.xml` setzen. Relativpfade beziehen sich auf den YAML-Ordner.
+3. Keine `esphome: includes:` und keine Laufzeit-Dateisysteme verwenden – die Komponente konvertiert die Datei beim Build automatisch in einen PROGMEM-String.
+4. Beim Start werden ausschließlich die Statistik-Banks `@TR:32`, `@TG:43` und `@TG:C0` geladen; Produkt-Kommandos aus der XML bleiben unberührt, damit bestehende Legacy-Abläufe unverändert weiterlaufen.
+5. Details zum C-/C#-Bundle und zur manuellen Abfrage findest du im Ordner `jura_joe_xml_bundle_final` (README & Beispiele).
+
 **Kurz-Dokumentation**
 
 1. XML in der J.O.E.-App exportieren.

--- a/docs/components/jutta_proto.md
+++ b/docs/components/jutta_proto.md
@@ -17,18 +17,30 @@ uart:
 jutta_proto:
   id: jura
   uart_id: jura_uart
-  jutta_xml_enable: true           # optional, default false
-  jutta_xml_poll_ms: 30000         # optional, poll interval in ms
-  jutta_xml_rx_timeout_ms: 900     # optional, frame timeout in ms
-  xml_path: "/data/jura_machine.xml"   # optional, override XML mapping path
+  enable_xml_poll: true            # optional, default false
+  xml_mapping_path: embedded       # optional, "embedded" nutzt die mitgelieferte XML
+  xml_poll_interval_ms: 30000      # optional, Pollintervall in ms (min. 25000)
 ```
 
 The component takes care of the handshake during startup. Once the handshake finishes, all brewing actions become available.
 
-When `jutta_xml_enable` is set to `true`, the component periodically polls the JURA statistics interface using DB framing.
-During initialization it scans the mapping file (default `/data/jura_machine.xml`, configurable via `xml_path`, typically a
-J.O.E. export) to discover the exact command strings and optional labels for the exposed statistics blocks. If the file is
-missing or malformed the defaults `@TR:32`, `@TG:43`, and `@TG:C0` are used and the sensors keep their generic names.
+When `enable_xml_poll` is set to `true`, the component periodically polls the JURA statistics interface using DB framing.
+During initialization it loads the mapping file referenced by `xml_mapping_path` (default `embedded`, which resolves to
+`esphome/components/jutta_proto/jura_mapping_embed.xml`). The file is read **at compile time**, embedded into the firmware
+image and parsed during boot to discover the exact command strings and optional labels for the exposed statistics blocks.
+If the XML is missing or malformed the defaults `@TR:32`, `@TG:43`, and `@TG:C0` are used and the sensors keep their
+generic names.
+
+### CODEX: J.O.E.-XML ohne `includes`
+
+1. Exportiere die gewünschte XML über die J.O.E.-App.
+2. Lege die unveränderte Datei im ESPHome-Projektordner ab (z. B. neben der YAML).
+3. Setze in der YAML den Pfad via `xml_mapping_path: mein_export.xml`. Relative Pfade werden gegen den YAML-Ordner
+   aufgelöst, absolute Pfade funktionieren ebenfalls.
+4. Keine zusätzlichen `esphome: includes:` oder Dateisystem-Zugriffe nötig – die Datei wird beim Kompilieren in einen
+   PROGMEM-String umgewandelt.
+5. Beim Booten wertet der Parser nur die Statistik-Banks (`@TR:32`, `@TG:43`, `@TG:C0`) aus. Produkt-Befehle aus der XML
+   bleiben unangetastet, damit Legacy-Flows unverändert bleiben.
 
 ### XML statistics sensors
 

--- a/esphome/components/jutta_proto/jutta_proto_xml.cpp
+++ b/esphome/components/jutta_proto/jutta_proto_xml.cpp
@@ -245,9 +245,10 @@ std::string make_identifier(const std::string &prefix, const std::string &value,
 }
 
 void add_fields_from_labels(XmlCommandMapping &mapping, const std::vector<std::string> &labels,
-                            const std::string &prefix, std::size_t field_size) {
+                            const std::string &prefix, std::size_t field_size,
+                            std::size_t base_offset = 0) {
   std::unordered_set<std::string> used;
-  std::size_t offset = 0;
+  std::size_t offset = base_offset;
   for (std::size_t i = 0; i < labels.size(); ++i) {
     XmlField field;
     field.label = labels[i];
@@ -460,7 +461,7 @@ bool parse_tr32_mapping(const std::string &xml, XmlCommandMapping &mapping) {
       labels.push_back("TR32 " + std::to_string(i + 1));
     }
   }
-  add_fields_from_labels(mapping, labels, "tr32", 2);
+  add_fields_from_labels(mapping, labels, "tr32", 2, 1);
   return true;
 }
 
@@ -498,7 +499,7 @@ bool parse_textitem_mapping(const std::string &xml, const std::string &command, 
       labels.push_back(prefix + " " + std::to_string(i + 1));
     }
   }
-  add_fields_from_labels(mapping, labels, to_lower_copy(prefix), field_size);
+  add_fields_from_labels(mapping, labels, to_lower_copy(prefix), field_size, 1);
   return true;
 }
 


### PR DESCRIPTION
## Summary
- skip the leading header byte in TR32/TG43/TGC0 frames when generating XML field mappings
- allow generated mappings to start at non-zero offsets so decoded counters populate sensors again

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e15a46b3c48328a0ffa5b2626ab205