### PR TITLE
Robuste XML-Sensorverarbeitung für Jutta-Protokoll

### DIFF
--- a/docs/components/jutta_proto.md
+++ b/docs/components/jutta_proto.md
@@ -209,3 +209,17 @@ jedoch, dass GCC oder Clang bei der Vorlagendeduktion scheitern.
 **Lösung.** Die Attribut-Erkennung ignoriert nun das Tag-Präfix, sobald hinter dem Tag-Namen kein `=` folgt. Dadurch werden auch J.O.E.-
 Exporte mit vollständig großgeschriebenen `BANK`-Tags korrekt ausgewertet, die Sensorfelder werden wieder angelegt und der Status
 wechselt auf `XML mapping valid: YES`.
+
+### XML-Statuswerte als Sensoren
+
+* Die Befehle `@TR:32`, `@TG:43` und `@TG:C0` werden mit flexiblen Rahmenlängen verarbeitet. Antworten, die den erwarteten Mindestumfang
+  erreichen und mit dem Startbyte `0x26` beginnen, werden auch dann ausgewertet, wenn zusätzliche Bytes folgen. Erst wenn der Frame zu kurz ist
+  oder der Marker fehlt, erscheint eine Warnung.
+* Vor jedem XML-Kommando wird der UART-Empfangspuffer geleert, zwischen den Abfragen liegt eine nicht-blockierende Pause von 25 ms und das
+  Timeout pro Kommando wurde auf 1 s gesetzt. So bleiben die Antworten sauber getrennt und kommen auch bei langsameren Maschinen stabil an.
+* Das XML-Mapping markiert veröffentlichte Felder explizit. Für diese Felder legt die Komponente numerische Sensoren mit Namen im Schema
+  `Jura E6 <Label>` und eindeutiger `unique_id` an. Zähler erhalten den Status `total_increasing`, Messwerte den Status `measurement`.
+* Werte werden nur veröffentlicht, wenn sie sich tatsächlich geändert haben und innerhalb der hinterlegten Plausibilitätsgrenzen liegen.
+  Ausreißer (z. B. fehlerhafte Counter-Werte) werden im Debug-Log dokumentiert, aber nicht an Home Assistant weitergegeben.
+* Die YAML-Integration bleibt unverändert: Die Mapping-Datei wird per `!include` ins Projekt übernommen und zur Laufzeit unter
+  `/config/esphome/e6.xml` geladen. Der Legacy-Handshake und alle klassischen Befehle funktionieren weiterhin wie bisher.

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -24,8 +24,8 @@ constexpr size_t HANDSHAKE_LOG_PREVIEW_LIMIT = 64;
 constexpr uint32_t MACHINE_DATA_QUERY_INTERVAL_MS = 30000;
 constexpr uint32_t MACHINE_DATA_REQUEST_TIMEOUT_MS = 2000;
 const char *const MACHINE_DATA_COMMAND = "&STAT?\r\n";
-constexpr uint32_t XML_RESPONSE_TIMEOUT_MS = 1400;
-constexpr uint32_t XML_INTER_COMMAND_DELAY_MS = 180;
+constexpr uint32_t XML_RESPONSE_TIMEOUT_MS = 1000;
+constexpr uint32_t XML_INTER_COMMAND_DELAY_MS = 25;
 constexpr size_t XML_COMMAND_COUNT = 3;
 
 template<typename AppT>
@@ -599,7 +599,29 @@ void JuraComponent::ensure_xml_sensors_created_() {
       return;
     }
     for (const auto &field : mapping.fields) {
-      this->get_or_create_sensor_(field.name, field.label);
+      if (!field.publish_sensor) {
+        continue;
+      }
+      sensor::Sensor *sensor = this->get_or_create_sensor_(field);
+      if (sensor == nullptr) {
+        continue;
+      }
+      XmlSensorMetadata meta;
+      meta.sensor = sensor;
+      meta.kind = field.sensor_kind;
+      meta.has_min = field.has_min;
+      meta.min_value = field.min_value;
+      meta.has_max = field.has_max;
+      meta.max_value = field.max_value;
+      std::string base_label = field.label.empty() ? field.name : field.label;
+      meta.label = std::string("Jura E6 ") + base_label;
+      if (field.has_accuracy) {
+        meta.accuracy_decimals = field.accuracy_decimals;
+      } else {
+        meta.accuracy_decimals = (field.sensor_kind == XmlField::SensorKind::Measurement) ? 2 : 0;
+      }
+      meta.unit = field.unit;
+      this->xml_sensor_meta_[field.name] = meta;
     }
   };
   ensure_block(this->xml_mapping_.tr32);
@@ -628,6 +650,8 @@ bool JuraComponent::ensure_xml_mapping_loaded_() {
   std::string xml_source(this->xml_mapping_data_, this->xml_mapping_length_);
   bool valid = load_mapping_from_string(xml_source);
   this->xml_mapping_ = get_xml_mapping();
+  this->xml_sensor_meta_.clear();
+  this->xml_last_published_values_.clear();
   this->xml_mapping_loaded_ = true;
   this->xml_mapping_logged_ = false;
   this->xml_stats_.clear();
@@ -735,7 +759,7 @@ void JuraComponent::handle_xml_cycle_(uint32_t now) {
       }
       const char *command = xml_command_for_index_(next_index);
       ESP_LOGD(TAG, "TX_DB \"%s\"", command);
-      this->coffee_maker_->connection->reset_db_rx_buffer();
+      this->coffee_maker_->connection->reset_all_rx_buffers();
       this->coffee_maker_->connection->tx_db_command(command);
       this->xml_cycle_.command_index = next_index;
       this->xml_cycle_.phase = XmlCycleState::Phase::WaitingForFrame;
@@ -803,58 +827,136 @@ void JuraComponent::publish_xml_stats_() {
   }
   const auto &stats = this->xml_stats_.values();
   for (const auto &entry : stats) {
+    if (this->xml_sensor_meta_.find(entry.first) == this->xml_sensor_meta_.end()) {
+      continue;
+    }
     this->publish_single_stat_(entry.first, entry.second.value, entry.second.label);
   }
 }
 
 void JuraComponent::publish_single_stat_(const std::string &name, double value, const std::string &label) {
-  auto *sensor = this->get_or_create_sensor_(name, label);
-  if (sensor == nullptr) {
-    ESP_LOGW(TAG, "XML field %s konnte nicht veröffentlicht werden", name.c_str());
+  (void) label;
+  auto meta_it = this->xml_sensor_meta_.find(name);
+  if (meta_it == this->xml_sensor_meta_.end()) {
+    ESP_LOGV(TAG, "XML field %s nicht zur Veröffentlichung markiert", name.c_str());
     return;
   }
-  float publish_value = static_cast<float>(value);
-  double rounded = std::round(value);
-  bool is_integer = std::fabs(value - rounded) < 0.0005;
-  uint32_t published_uint = 0;
-  if (is_integer) {
-    if (rounded < 0.0) {
-      rounded = 0.0;
-    }
-    if (rounded > static_cast<double>(std::numeric_limits<uint32_t>::max())) {
-      rounded = static_cast<double>(std::numeric_limits<uint32_t>::max());
-    }
-    published_uint = static_cast<uint32_t>(rounded);
-    publish_value = static_cast<float>(published_uint);
+  auto &meta = meta_it->second;
+  sensor::Sensor *sensor = meta.sensor;
+  if (sensor == nullptr) {
+    ESP_LOGW(TAG, "XML field %s ohne Sensor-Objekt", name.c_str());
+    return;
   }
-  sensor->publish_state(publish_value);
-  if (is_integer) {
-    ESP_LOGD(TAG, "XML publish_state: %s=%u", name.c_str(),
-             static_cast<unsigned>(published_uint));
+  if (meta.has_min && value < meta.min_value) {
+    ESP_LOGD(TAG, "XML field %s (%s) Wert %.3f unter Grenze %.3f (unterdrückt)", name.c_str(),
+             meta.label.c_str(), value, meta.min_value);
+    return;
+  }
+  if (meta.has_max && value > meta.max_value) {
+    ESP_LOGD(TAG, "XML field %s (%s) Wert %.3f über Grenze %.3f (unterdrückt)", name.c_str(),
+             meta.label.c_str(), value, meta.max_value);
+    return;
+  }
+  double tolerance = 0.0005;
+  if (meta.accuracy_decimals >= 0) {
+    double factor = std::pow(10.0, static_cast<double>(meta.accuracy_decimals));
+    if (factor > 0.0) {
+      tolerance = 0.5 / factor;
+    }
+  }
+  auto last_it = this->xml_last_published_values_.find(name);
+  if (last_it != this->xml_last_published_values_.end()) {
+    if (std::fabs(last_it->second - value) < tolerance) {
+      return;
+    }
+  }
+
+  double publish_double = value;
+  if (meta.accuracy_decimals <= 0) {
+    publish_double = std::round(value);
   } else {
-    ESP_LOGD(TAG, "XML publish_state: %s=%.3f", name.c_str(), static_cast<double>(publish_value));
+    double factor = std::pow(10.0, static_cast<double>(meta.accuracy_decimals));
+    publish_double = std::round(value * factor) / factor;
+  }
+  float publish_value = static_cast<float>(publish_double);
+  this->xml_last_published_values_[name] = publish_double;
+  sensor->publish_state(publish_value);
+  if (meta.accuracy_decimals <= 0) {
+    ESP_LOGD(TAG, "XML publish_state: %s (%s)=%lld", name.c_str(), meta.label.c_str(),
+             static_cast<long long>(std::llround(publish_double)));
+  } else {
+    ESP_LOGD(TAG, "XML publish_state: %s (%s)=%.3f", name.c_str(), meta.label.c_str(), publish_double);
   }
 }
 
-sensor::Sensor *JuraComponent::get_or_create_sensor_(const std::string &name, const std::string &label) {
+sensor::Sensor *JuraComponent::get_or_create_sensor_(const XmlField &field) {
+  const std::string &name = field.name;
+  std::string base_label = field.label.empty() ? field.name : field.label;
+  std::string label = std::string("Jura E6 ") + base_label;
+  sensor::Sensor *sensor_obj = nullptr;
   auto it = this->xml_sensors_.find(name);
   if (it != this->xml_sensors_.end()) {
-    if (!label.empty() && this->xml_sensor_labels_[name] != label) {
-      it->second->set_name(label);
-      this->xml_sensor_labels_[name] = label;
-    }
-    return it->second;
+    sensor_obj = it->second;
+  } else {
+    sensor_obj = new sensor::Sensor();
+    sensor_obj->set_internal(false);
+    try_set_parent(sensor_obj, this, 0);
+    register_sensor_with_app(sensor_obj);
+    this->xml_sensors_[name] = sensor_obj;
   }
-  auto *sensor_obj = new sensor::Sensor();
-  sensor_obj->set_accuracy_decimals(0);
-  sensor_obj->set_internal(false);
-  try_set_parent(sensor_obj, this, 0);
-  register_sensor_with_app(sensor_obj);
+  int accuracy = field.has_accuracy ? field.accuracy_decimals : (field.sensor_kind == XmlField::SensorKind::Measurement ? 2 : 0);
+  sensor_obj->set_accuracy_decimals(accuracy);
   std::string effective_label = label.empty() ? name : label;
   sensor_obj->set_name(effective_label);
+  std::string unique_id = field.unique_id.empty() ? this->make_sensor_unique_id_(field) : field.unique_id;
+  if (!unique_id.empty()) {
+    sensor_obj->set_unique_id(unique_id);
+  }
+  if (!field.unit.empty()) {
+    sensor_obj->set_unit_of_measurement(field.unit);
+  }
+  if (field.sensor_kind == XmlField::SensorKind::TotalIncreasing) {
+    sensor_obj->set_state_class(sensor::STATE_CLASS_TOTAL_INCREASING);
+  } else if (field.sensor_kind == XmlField::SensorKind::Measurement) {
+    sensor_obj->set_state_class(sensor::STATE_CLASS_MEASUREMENT);
+  }
   this->xml_sensor_labels_[name] = effective_label;
-  this->xml_sensors_[name] = sensor_obj;
   return sensor_obj;
+}
+
+std::string JuraComponent::make_sensor_unique_id_(const XmlField &field) const {
+  std::string base = field.unique_id;
+  if (base.empty()) {
+    base = field.label.empty() ? field.name : field.label;
+  }
+  if (base.empty()) {
+    base = field.name;
+  }
+  std::string sanitized;
+  sanitized.reserve(base.size() + 8);
+  bool last_was_underscore = false;
+  for (char ch : base) {
+    unsigned char c = static_cast<unsigned char>(ch);
+    if (std::isalnum(c) != 0) {
+      sanitized.push_back(static_cast<char>(std::tolower(c)));
+      last_was_underscore = false;
+    } else {
+      if (!last_was_underscore) {
+        sanitized.push_back('_');
+        last_was_underscore = true;
+      }
+    }
+  }
+  while (!sanitized.empty() && sanitized.back() == '_') {
+    sanitized.pop_back();
+  }
+  if (sanitized.empty()) {
+    sanitized = field.name;
+  }
+  if (sanitized.find("jura_e6_") == 0) {
+    return sanitized;
+  }
+  return std::string("jura_e6_") + sanitized;
 }
 
 const char *JuraComponent::xml_command_for_index_(size_t index) {

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -124,7 +124,8 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   void finish_xml_cycle_(uint32_t now, bool success);
   void publish_xml_stats_();
   void publish_single_stat_(const std::string &name, double value, const std::string &label);
-  sensor::Sensor *get_or_create_sensor_(const std::string &name, const std::string &label);
+  sensor::Sensor *get_or_create_sensor_(const XmlField &field);
+  std::string make_sensor_unique_id_(const XmlField &field) const;
   static const char *xml_command_for_index_(size_t index);
   static const char *xml_log_label_for_index_(size_t index);
   bool xml_command_has_mapping_(size_t index) const;
@@ -159,6 +160,19 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   Stats xml_stats_{};
   std::unordered_map<std::string, sensor::Sensor *> xml_sensors_{};
   std::unordered_map<std::string, std::string> xml_sensor_labels_{};
+  struct XmlSensorMetadata {
+    sensor::Sensor *sensor{nullptr};
+    XmlField::SensorKind kind{XmlField::SensorKind::None};
+    bool has_min{false};
+    double min_value{0.0};
+    bool has_max{false};
+    double max_value{0.0};
+    int accuracy_decimals{0};
+    std::string label;
+    std::string unit;
+  };
+  std::unordered_map<std::string, XmlSensorMetadata> xml_sensor_meta_{};
+  std::unordered_map<std::string, double> xml_last_published_values_{};
 
   struct XmlCycleState {
     enum class Phase { Idle, WaitingForFrame, DelayBeforeNext };

--- a/esphome/components/jutta_proto/jutta_proto_xml.cpp
+++ b/esphome/components/jutta_proto/jutta_proto_xml.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cmath>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -185,6 +186,15 @@ bool parse_size_t_attr(const AttributeMap &attrs, std::initializer_list<const ch
   return false;
 }
 
+bool parse_int_attr(const AttributeMap &attrs, std::initializer_list<const char *> keys, int &out) {
+  std::size_t tmp = 0;
+  if (!parse_size_t_attr(attrs, keys, tmp)) {
+    return false;
+  }
+  out = static_cast<int>(tmp);
+  return true;
+}
+
 bool parse_double_attr(const AttributeMap &attrs, std::initializer_list<const char *> keys, double &out) {
   for (const char *key : keys) {
     std::string value = attrs.get(key);
@@ -195,6 +205,24 @@ bool parse_double_attr(const AttributeMap &attrs, std::initializer_list<const ch
         out = parsed;
         return true;
       }
+    }
+  }
+  return false;
+}
+
+bool parse_bool_attr(const AttributeMap &attrs, std::initializer_list<const char *> keys, bool &out) {
+  for (const char *key : keys) {
+    std::string value = to_lower_copy(attrs.get(key));
+    if (value.empty()) {
+      continue;
+    }
+    if (value == "1" || value == "true" || value == "yes" || value == "on") {
+      out = true;
+      return true;
+    }
+    if (value == "0" || value == "false" || value == "no" || value == "off") {
+      out = false;
+      return true;
     }
   }
   return false;
@@ -355,6 +383,82 @@ bool parse_field_tag(const std::string &tag_text, XmlCommandMapping &mapping) {
   } else if (contains_percent_hint(field.name) || contains_percent_hint(field.label)) {
     field.scale = 0.01;
   }
+  std::string unit = attrs.get("unit");
+  trim(unit);
+  field.unit = unit;
+  std::string unique_id = attrs.get("unique_id");
+  trim(unique_id);
+  field.unique_id = unique_id;
+
+  auto decode_sensor_kind = [](const std::string &value) -> XmlField::SensorKind {
+    std::string lower = to_lower_copy(value);
+    if (lower == "counter" || lower == "total" || lower == "total_increasing" || lower == "sum") {
+      return XmlField::SensorKind::TotalIncreasing;
+    }
+    if (lower == "measurement" || lower == "measure" || lower == "value" || lower == "status") {
+      return XmlField::SensorKind::Measurement;
+    }
+    return XmlField::SensorKind::None;
+  };
+
+  std::string sensor_attr = attrs.get("sensor");
+  std::string publish_attr = attrs.get("publish");
+  std::string state_class_attr = attrs.get("state_class");
+  XmlField::SensorKind sensor_kind = XmlField::SensorKind::None;
+  if (!sensor_attr.empty()) {
+    sensor_kind = decode_sensor_kind(sensor_attr);
+  }
+  if (sensor_kind == XmlField::SensorKind::None && !publish_attr.empty()) {
+    sensor_kind = decode_sensor_kind(publish_attr);
+    if (sensor_kind == XmlField::SensorKind::None) {
+      std::string lower = to_lower_copy(publish_attr);
+      if (lower == "1" || lower == "true" || lower == "yes" || lower == "sensor") {
+        sensor_kind = XmlField::SensorKind::Measurement;
+      }
+    }
+  }
+  if (!state_class_attr.empty()) {
+    XmlField::SensorKind from_state = decode_sensor_kind(state_class_attr);
+    if (from_state != XmlField::SensorKind::None) {
+      sensor_kind = from_state;
+    }
+  }
+
+  field.sensor_kind = sensor_kind;
+  field.publish_sensor = sensor_kind != XmlField::SensorKind::None;
+
+  double min_value = field.min_value;
+  if (parse_double_attr(attrs, {"min", "min_value"}, min_value)) {
+    field.min_value = min_value;
+    field.has_min = true;
+  }
+  double max_value = field.max_value;
+  if (parse_double_attr(attrs, {"max", "max_value"}, max_value)) {
+    field.max_value = max_value;
+    field.has_max = true;
+  }
+  int decimals = field.accuracy_decimals;
+  if (parse_int_attr(attrs, {"decimals", "precision"}, decimals)) {
+    field.accuracy_decimals = decimals;
+    field.has_accuracy = true;
+  }
+
+  if (!field.has_min && field.sensor_kind == XmlField::SensorKind::TotalIncreasing) {
+    field.has_min = true;
+    field.min_value = 0.0;
+  }
+  if (!field.has_max && field.sensor_kind == XmlField::SensorKind::TotalIncreasing) {
+    field.has_max = true;
+    field.max_value = 1000000.0;
+  }
+  if (field.sensor_kind == XmlField::SensorKind::Measurement && !field.has_max &&
+      (contains_percent_hint(field.name) || contains_percent_hint(field.label) || std::fabs(field.scale - 0.01) < 1e-9)) {
+    field.has_min = true;
+    field.min_value = 0.0;
+    field.has_max = true;
+    field.max_value = 250.0;
+  }
+
   mapping.fields.push_back(field);
   return true;
 }
@@ -641,9 +745,20 @@ bool parse_payload(const std::vector<uint8_t> &decoded, const XmlCommandMapping 
     std::string payload_ascii = format_ascii_string(decoded);
     ESP_LOGD(TAG, "XML %s payload ASCII: %s", command_label, payload_ascii.c_str());
   }
+  if (decoded.empty() || decoded[0] != 0x26) {
+    ESP_LOGW(TAG, "XML %s: fehlender 0x26 Marker (decoded_len=%u)", command_label,
+             static_cast<unsigned>(decoded.size()));
+    return false;
+  }
+  if (expected_len != 0 && decoded.size() < expected_len) {
+    ESP_LOGW(TAG,
+             "XML %s: decoded_len (%u) < expected_len (%u)",
+             command_label, static_cast<unsigned>(decoded.size()), static_cast<unsigned>(expected_len));
+    return false;
+  }
   if (expected_len != 0 && decoded.size() != expected_len) {
     std::string mismatch_head = format_hex_head(decoded, 32);
-    ESP_LOGW(TAG,
+    ESP_LOGD(TAG,
              "XML %s: decoded_len (%u) != expected_len (%u), head32=%s",
              command_label, static_cast<unsigned>(decoded.size()), static_cast<unsigned>(expected_len),
              mismatch_head.c_str());

--- a/esphome/components/jutta_proto/jutta_proto_xml.h
+++ b/esphome/components/jutta_proto/jutta_proto_xml.h
@@ -10,12 +10,24 @@ namespace esphome {
 namespace jutta_component {
 
 struct XmlField {
+  enum class SensorKind { None, Measurement, TotalIncreasing };
+
   std::string name;
   std::string label;
   std::size_t offset{0};
   std::size_t size{0};
   bool little_endian{false};
   double scale{1.0};
+  bool publish_sensor{false};
+  SensorKind sensor_kind{SensorKind::None};
+  bool has_min{false};
+  double min_value{0.0};
+  bool has_max{false};
+  double max_value{0.0};
+  bool has_accuracy{false};
+  int accuracy_decimals{0};
+  std::string unit;
+  std::string unique_id;
 };
 
 struct XmlCommandMapping {


### PR DESCRIPTION
## Zusammenfassung
- XML-Rahmen für @TR:32/@TG:43/@TG:C0 werden toleranter ausgewertet und nur bei echten Fehlern gewarnt
- Numerische Sensoren aus dem Mapping erhalten eindeutige Namen/IDs, Plausibilitätsfilter sowie Änderungs-Erkennung
- Dokumentation zur neuen XML-Sensorabfrage ergänzt

## Tests
- Keine Tests ausgeführt (nicht vorhanden)

------
https://chatgpt.com/codex/tasks/task_e_68e272cae280832889e061581e6be19f