### PR TITLE
Allow configuring XML sensors via YAML

### DIFF
--- a/docs/components/jutta_proto.md
+++ b/docs/components/jutta_proto.md
@@ -20,6 +20,15 @@ jutta_proto:
   enable_xml_poll: true            # optional, default false
   xml_mapping_path: embedded       # optional, "embedded" nutzt die mitgelieferte XML
   xml_poll_interval_ms: 30000      # optional, Pollintervall in ms (min. 25000)
+  xml_sensors:                     # optional – verknüpft YAML-Sensoren mit XML-Feldern
+    - field: tr32_total_products
+      name: "Gesamtbezüge"
+      unit_of_measurement: "Bezüge"
+      accuracy_decimals: 0
+    - field: tgc0_bean_container
+      name: "Füllstand Bohnen"
+      icon: "mdi:coffee"
+      accuracy_decimals: 1
 ```
 
 The component takes care of the handshake during startup. Once the handshake finishes, all brewing actions become available.
@@ -88,6 +97,38 @@ verarbeiten kann, gelten die folgenden Eckpunkte:
 
 Lieferte die XML sprechende Labels, ersetzen diese automatisch die Standardnamen. Die Sensoren behalten ihre eindeutigen
 IDs auch dann, wenn die Bezeichnung in der XML nachträglich angepasst wird.
+
+#### YAML-Verknüpfung der XML-Werte
+
+Damit die Messwerte auch als Entitäten in Home Assistant auftauchen, muss jeder gewünschte Zähler explizit in der YAML
+angelegt werden. Das geschieht über die neue Liste `xml_sensors` innerhalb des `jutta_proto`-Blocks. Jeder Eintrag
+benötigt den Schlüssel `field`, der exakt dem Feldnamen aus dem XML-Mapping entsprechen muss (z. B.
+`tr32_total_products`, `tg43_filter`, `tgc0_bean_container`). Die Feldnamen leiten sich aus den XML-Labels ab und werden
+im ESPHome-Log beim Laden des Mappings ausgegeben. Zusätzlich lassen sich wie gewohnt `name`, `icon`,
+`unit_of_measurement` oder `accuracy_decimals` setzen.
+
+Beispiel:
+
+```yaml
+jutta_proto:
+  id: jura
+  uart_id: jura_uart
+  enable_xml_poll: true
+  xml_sensors:
+    - field: tr32_total_products
+      name: "Bezüge gesamt"
+    - field: tg43_filter
+      name: "Filterwechsel"
+      unit_of_measurement: "Zyklen"
+    - field: tgc0_bean_container
+      name: "Bohnenfüllstand"
+      unit_of_measurement: "%"
+      accuracy_decimals: 1
+```
+
+Wenn ein konfigurierter Feldname im Mapping fehlt, meldet der Logger dies einmalig beim Start. Ist ein Feld vorhanden,
+aber kein Sensor in `xml_sensors` hinterlegt, bleibt der Wert intern und wird protokolliert, jedoch nicht an Home
+Assistant übergeben – Legacy-Funktionen sind davon unberührt.
 
 ### Robuste XML-Frames (CODEX)
 

--- a/esphome/components/jutta_proto/__init__.py
+++ b/esphome/components/jutta_proto/__init__.py
@@ -3,7 +3,7 @@ import os
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
-from esphome.components import text_sensor, uart
+from esphome.components import sensor, text_sensor, uart
 from esphome.const import CONF_ID
 from esphome.core import CORE
 
@@ -27,6 +27,8 @@ CONF_MACHINE_DATA = "machine_data"
 CONF_ENABLE_XML_POLL = "enable_xml_poll"
 CONF_XML_MAPPING_PATH = "xml_mapping_path"
 CONF_XML_POLL_INTERVAL_MS = "xml_poll_interval_ms"
+CONF_XML_SENSORS = "xml_sensors"
+CONF_FIELD = "field"
 
 jutta_component_ns = cg.esphome_ns.namespace("jutta_component")
 jutta_proto_ns = cg.global_ns.namespace("jutta_proto")
@@ -94,6 +96,9 @@ SEQUENCE_COMMAND_EXPRESSIONS = {
 JURA_COMPONENT_IDS = []
 
 
+XML_SENSOR_SCHEMA = sensor.sensor_schema().extend({cv.Required(CONF_FIELD): cv.string})
+
+
 CONFIG_SCHEMA = (
     cv.Schema(
         {
@@ -104,6 +109,7 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_XML_POLL_INTERVAL_MS, default=30000): cv.All(
                 cv.positive_int, cv.Range(min=25000)
             ),
+            cv.Optional(CONF_XML_SENSORS, default=[]): cv.ensure_list(XML_SENSOR_SCHEMA),
         }
     )
     .extend(uart.UART_DEVICE_SCHEMA)
@@ -301,8 +307,14 @@ async def to_code(config):
     cg.add(var.set_xml_poll_interval(config[CONF_XML_POLL_INTERVAL_MS]))
 
     if CONF_MACHINE_DATA in config:
-        sensor = await text_sensor.new_text_sensor(config[CONF_MACHINE_DATA])
-        cg.add(var.set_machine_data_sensor(sensor))
+        machine_sensor = await text_sensor.new_text_sensor(config[CONF_MACHINE_DATA])
+        cg.add(var.set_machine_data_sensor(machine_sensor))
+
+    for xml_sensor in config.get(CONF_XML_SENSORS, []):
+        sensor_conf = xml_sensor.copy()
+        field_name = sensor_conf.pop(CONF_FIELD)
+        sens = await sensor.new_sensor(sensor_conf)
+        cg.add(var.add_configured_xml_sensor(cg.std_string(field_name), sens))
 
 
 async def _get_parent(config):

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -99,35 +99,6 @@ auto try_register_sensor(AppT &app, sensor::Sensor *sensor, double)
   app.register_entity(sensor);
 }
 
-template<typename AppT>
-void try_register_sensor(AppT &, sensor::Sensor *, ...) {}
-
-inline void register_sensor_with_app(sensor::Sensor *sensor) {
-  if (sensor == nullptr) {
-    return;
-  }
-#ifdef __GXX_RTTI
-  if (auto *component = dynamic_cast<Component *>(sensor)) {
-    App.register_component(component);
-  }
-#else
-  // Ohne RTTI können wir keinen sicheren Cross-Cast durchführen. In diesem Fall
-  // verzichten wir lediglich darauf, die Komponente bei App zu registrieren.
-  // Dies entspricht dem Verhalten, das auch mit dem Stub-Sensortyp greift, der
-  // nicht von Component erbt.
-#endif
-  try_register_sensor(App, sensor, 0L);
-}
-
-template<typename SensorT>
-auto try_set_parent(SensorT *sensor, Component *parent, int)
-    -> decltype(sensor->set_parent(parent), void()) {
-  sensor->set_parent(parent);
-}
-
-template<typename SensorT>
-void try_set_parent(SensorT *, Component *, ...) {}
-
 std::string format_printable_char(uint8_t byte) {
   switch (byte) {
     case '\r':
@@ -233,12 +204,7 @@ const char *JuraComponent::handshake_stage_name(JuraComponent::HandshakeStage st
   return "unknown";
 }
 
-JuraComponent::~JuraComponent() {
-  for (auto &entry : this->xml_sensors_) {
-    delete entry.second;
-  }
-  this->xml_sensors_.clear();
-}
+JuraComponent::~JuraComponent() { this->xml_sensors_.clear(); }
 
 void JuraComponent::setup() {
   if (this->parent_ == nullptr) {
@@ -817,6 +783,17 @@ bool JuraComponent::process_tgc0_response_(const std::vector<uint8_t> &decoded) 
   return any_value;
 }
 
+void JuraComponent::add_configured_xml_sensor(const std::string &field, sensor::Sensor *sensor) {
+  if (field.empty() || sensor == nullptr) {
+    return;
+  }
+  this->xml_sensors_[field] = sensor;
+  this->xml_unconfigured_sensor_logged_.erase(field);
+  if (this->xml_sensor_meta_.find(field) != this->xml_sensor_meta_.end()) {
+    this->get_or_create_sensor_(field, field);
+  }
+}
+
 void JuraComponent::register_xml_sensor_(const XmlField &field, XmlSensorKind kind) {
   auto &meta = this->xml_sensor_meta_[field.name];
   meta.kind = kind;
@@ -854,6 +831,17 @@ void JuraComponent::ensure_xml_sensors_created_() {
   ensure_block(this->xml_mapping_.tr32, XmlSensorKind::Counter);
   ensure_block(this->xml_mapping_.tg43, XmlSensorKind::Counter);
   ensure_block(this->xml_mapping_.tgc0, XmlSensorKind::Measurement);
+
+  for (const auto &entry : this->xml_sensors_) {
+    if (this->xml_sensor_meta_.find(entry.first) != this->xml_sensor_meta_.end()) {
+      continue;
+    }
+    if (this->xml_missing_sensor_logged_[entry.first]) {
+      continue;
+    }
+    ESP_LOGW(TAG, "XML Sensor %s ist im aktuellen Mapping nicht vorhanden", entry.first.c_str());
+    this->xml_missing_sensor_logged_[entry.first] = true;
+  }
 }
 
 bool JuraComponent::ensure_xml_mapping_loaded_() {
@@ -870,6 +858,7 @@ bool JuraComponent::ensure_xml_mapping_loaded_() {
     this->xml_mapping_loaded_ = true;
     this->xml_mapping_ = {};
     this->xml_stats_.clear();
+    this->xml_missing_sensor_logged_.clear();
     this->log_xml_mapping_status_();
     return false;
   }
@@ -882,6 +871,7 @@ bool JuraComponent::ensure_xml_mapping_loaded_() {
   this->xml_stats_.clear();
   this->xml_sensor_meta_.clear();
   this->tgc0_filters_.clear();
+  this->xml_missing_sensor_logged_.clear();
   this->log_xml_mapping_status_();
   if (this->xml_mapping_.valid) {
     this->ensure_xml_sensors_created_();
@@ -1097,7 +1087,12 @@ void JuraComponent::publish_single_stat_(const std::string &name, double value, 
   auto &meta = meta_it->second;
   auto *sensor = this->get_or_create_sensor_(name, label);
   if (sensor == nullptr) {
-    ESP_LOGW(TAG, "XML field %s konnte nicht veröffentlicht werden", name.c_str());
+    auto logged_it = this->xml_unconfigured_sensor_logged_.find(name);
+    bool already_logged = logged_it != this->xml_unconfigured_sensor_logged_.end() && logged_it->second;
+    if (!already_logged) {
+      ESP_LOGD(TAG, "XML Feld %s ist nicht in der YAML als Sensor verlinkt – Wert wird verworfen", name.c_str());
+      this->xml_unconfigured_sensor_logged_[name] = true;
+    }
     return;
   }
   double min_value = meta.min_value;
@@ -1136,54 +1131,32 @@ void JuraComponent::publish_single_stat_(const std::string &name, double value, 
 }
 
 sensor::Sensor *JuraComponent::get_or_create_sensor_(const std::string &name, const std::string &label) {
-  std::string effective_label = label.empty() ? name : label;
-  auto meta_it = this->xml_sensor_meta_.find(name);
-  const XmlSensorMeta *meta = meta_it != this->xml_sensor_meta_.end() ? &meta_it->second : nullptr;
-  int accuracy = meta != nullptr ? meta->accuracy_decimals : 0;
-  sensor::StateClass state_class = sensor::StateClass::STATE_CLASS_NONE;
-  if (meta != nullptr) {
-    state_class = meta->kind == XmlSensorKind::Counter
-                      ? sensor::StateClass::STATE_CLASS_TOTAL_INCREASING
-                      : sensor::StateClass::STATE_CLASS_MEASUREMENT;
-  }
-  std::string unique_id = std::string("Jura E6 ") + effective_label;
-
+  (void) label;
   auto it = this->xml_sensors_.find(name);
-  if (it != this->xml_sensors_.end()) {
-    auto *sensor_obj = it->second;
-    sensor_obj->set_unique_id(unique_id);
-    sensor_obj->set_accuracy_decimals(accuracy);
-    sensor_obj->set_state_class(state_class);
-    if (meta != nullptr && meta->has_unit) {
-      sensor_obj->set_unit_of_measurement(meta->unit_of_measurement);
-    }
-    if (meta != nullptr && meta->has_icon) {
-      sensor_obj->set_icon(meta->icon);
-    }
-    auto label_it = this->xml_sensor_labels_.find(name);
-    if (label_it == this->xml_sensor_labels_.end() || label_it->second != effective_label) {
-      sensor_obj->set_name(effective_label);
-      this->xml_sensor_labels_[name] = effective_label;
-    }
-    return sensor_obj;
+  if (it == this->xml_sensors_.end()) {
+    return nullptr;
+  }
+  auto *sensor_obj = it->second;
+  if (sensor_obj == nullptr) {
+    return nullptr;
   }
 
-  auto *sensor_obj = new sensor::Sensor();
-  sensor_obj->set_accuracy_decimals(accuracy);
-  sensor_obj->set_state_class(state_class);
-  sensor_obj->set_internal(false);
-  sensor_obj->set_unique_id(unique_id);
-  if (meta != nullptr && meta->has_unit) {
-    sensor_obj->set_unit_of_measurement(meta->unit_of_measurement);
+  auto meta_it = this->xml_sensor_meta_.find(name);
+  if (meta_it != this->xml_sensor_meta_.end()) {
+    const auto &meta = meta_it->second;
+    sensor_obj->set_accuracy_decimals(meta.accuracy_decimals);
+    sensor::StateClass state_class = meta.kind == XmlSensorKind::Counter
+                                         ? sensor::StateClass::STATE_CLASS_TOTAL_INCREASING
+                                         : sensor::StateClass::STATE_CLASS_MEASUREMENT;
+    sensor_obj->set_state_class(state_class);
+    if (meta.has_unit) {
+      sensor_obj->set_unit_of_measurement(meta.unit_of_measurement);
+    }
+    if (meta.has_icon) {
+      sensor_obj->set_icon(meta.icon);
+    }
   }
-  if (meta != nullptr && meta->has_icon) {
-    sensor_obj->set_icon(meta->icon);
-  }
-  try_set_parent(sensor_obj, this, 0);
-  register_sensor_with_app(sensor_obj);
-  sensor_obj->set_name(effective_label);
-  this->xml_sensor_labels_[name] = effective_label;
-  this->xml_sensors_[name] = sensor_obj;
+
   return sensor_obj;
 }
 

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -129,6 +129,7 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
     this->xml_mapping_length_ = length;
   }
   void set_xml_poll_interval(uint32_t interval_ms) { this->xml_poll_interval_ms_ = interval_ms; }
+  void add_configured_xml_sensor(const std::string &field, sensor::Sensor *sensor);
 
  protected:
   enum class HandshakeStage { IDLE, HELLO, SEND_T1, WAIT_T2, SEND_T2, WAIT_T3, SEND_T3, DONE, FAILED };
@@ -192,7 +193,6 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   XmlMapping xml_mapping_{};
   Stats xml_stats_{};
   std::unordered_map<std::string, sensor::Sensor *> xml_sensors_{};
-  std::unordered_map<std::string, std::string> xml_sensor_labels_{};
   struct Tgc0FilterState {
     std::deque<float> window;
     uint8_t consecutive_valid{0};
@@ -200,6 +200,8 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   };
   std::unordered_map<std::string, Tgc0FilterState> tgc0_filters_{};
   std::unordered_map<std::string, XmlSensorMeta> xml_sensor_meta_{};
+  std::unordered_map<std::string, bool> xml_missing_sensor_logged_{};
+  std::unordered_map<std::string, bool> xml_unconfigured_sensor_logged_{};
 
   struct XmlCycleState {
     enum class Phase { Idle, WaitingForFrame, DelayBeforeNext };


### PR DESCRIPTION
## Summary
- allow the `jutta_proto` component to declare XML-linked sensors from YAML via a new `xml_sensors` list
- update the runtime component to use user-provided sensors, apply XML metadata, and log missing mappings once
- document how to link Home Assistant sensors to XML fields with configuration examples

## Testing
- python -m compileall esphome/components/jutta_proto/__init__.py

------
https://chatgpt.com/codex/tasks/task_e_68e287aafea08328a82287c518eeebac