### PR TITLE
Allow configuring XML sensors via YAML

### DIFF
--- a/docs/components/jutta_proto.md
+++ b/docs/components/jutta_proto.md
@@ -20,6 +20,13 @@ jutta_proto:
   enable_xml_poll: true            # optional, default false
   xml_mapping_path: embedded       # optional, "embedded" nutzt die mitgelieferte XML
   xml_poll_interval_ms: 30000      # optional, Pollintervall in ms (min. 25000)
+  xml_sensors:
+    - field: "TG43_Cleaning"
+      name: "Reinigungszähler"
+    - field: "TGC0_WaterTank"
+      name: "Wasserfüllstand"
+      unit_of_measurement: "%"
+      accuracy_decimals: 1
 ```
 
 The component takes care of the handshake during startup. Once the handshake finishes, all brewing actions become available.
@@ -77,6 +84,34 @@ verarbeiten kann, gelten die folgenden Eckpunkte:
 - **Logging.** Die Initialisierung protokolliert das geladene Mapping und die Anzahl der Sensoren. Für jeden veröffentlichen
   Wert bleibt die bestehende DEBUG-Zeile mit Feldname und Wert erhalten; Längenabweichungen der Rohframes erscheinen nur
   noch auf DEBUG-Level.
+
+#### Eigene Sensoren in YAML verknüpfen
+
+Über den neuen Abschnitt `xml_sensors` kannst du gezielt festlegen, welche Felder aus der Statistik in Home Assistant
+sichtbar werden sollen. Pro Eintrag wird ein klassisches ESPHome-Sensorobjekt erzeugt und mit dem jeweiligen XML-Feld
+verknüpft. Der Schlüssel `field` entspricht dem `name`-Attribut aus der XML-Datei (z. B. `<FIELD name="TG43_Cleaning" …/>`).
+Fehlt ein `FIELD`-Eintrag, verwendet der Parser automatisch einen sprechenden Namen auf Basis des Labels im XML – diese
+Bezeichner tauchen beim Booten im Debug-Log auf und können dort abgeschrieben werden.
+
+```yaml
+jutta_proto:
+  enable_xml_poll: true
+  xml_mapping_path: embedded
+  xml_sensors:
+    - field: "TR32_TotalProducts"
+      name: "Bezüge gesamt"
+    - field: "TG43_FilterChange"
+      name: "Filterwechsel"
+    - field: "TGC0_Cleaning"
+      name: "Reinigung fällig"
+      unit_of_measurement: "%"
+      accuracy_decimals: 1
+```
+
+Alle hier definierten Sensoren behalten die in YAML gesetzten Eigenschaften (`name`, `unit_of_measurement`, `icon`, …).
+Nicht aufgeführte Felder werden weiterhin automatisch als interne Sensoren angelegt, damit Legacy-Installationen
+unverändert funktionieren. Wer ausschließlich eigene Sensoren sichtbar haben möchte, blendet die übrigen Entitäten in
+Home Assistant einfach aus.
 
 #### Sensoraufbau im Detail
 

--- a/esphome/components/jutta_proto/__init__.py
+++ b/esphome/components/jutta_proto/__init__.py
@@ -3,7 +3,7 @@ import os
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
-from esphome.components import text_sensor, uart
+from esphome.components import sensor, text_sensor, uart
 from esphome.const import CONF_ID
 from esphome.core import CORE
 
@@ -27,6 +27,8 @@ CONF_MACHINE_DATA = "machine_data"
 CONF_ENABLE_XML_POLL = "enable_xml_poll"
 CONF_XML_MAPPING_PATH = "xml_mapping_path"
 CONF_XML_POLL_INTERVAL_MS = "xml_poll_interval_ms"
+CONF_XML_SENSORS = "xml_sensors"
+CONF_FIELD = "field"
 
 jutta_component_ns = cg.esphome_ns.namespace("jutta_component")
 jutta_proto_ns = cg.global_ns.namespace("jutta_proto")
@@ -99,6 +101,11 @@ CONFIG_SCHEMA = (
         {
             cv.GenerateID(): cv.declare_id(JuraComponent),
             cv.Optional(CONF_MACHINE_DATA): text_sensor.text_sensor_schema(),
+            cv.Optional(CONF_XML_SENSORS, default=[]): cv.ensure_list(
+                cv.Schema({cv.Required(CONF_FIELD): cv.string}).extend(
+                    sensor.sensor_schema()
+                )
+            ),
             cv.Optional(CONF_ENABLE_XML_POLL, default=False): cv.boolean,
             cv.Optional(CONF_XML_MAPPING_PATH, default="embedded"): cv.string,
             cv.Optional(CONF_XML_POLL_INTERVAL_MS, default=30000): cv.All(
@@ -299,6 +306,11 @@ async def to_code(config):
         )
     )
     cg.add(var.set_xml_poll_interval(config[CONF_XML_POLL_INTERVAL_MS]))
+
+    for sensor_config in config.get(CONF_XML_SENSORS, []):
+        field_name = sensor_config[CONF_FIELD]
+        sens = await sensor.new_sensor(sensor_config)
+        cg.add(var.add_configured_xml_sensor(cg.std_string(field_name), sens))
 
     if CONF_MACHINE_DATA in config:
         sensor = await text_sensor.new_text_sensor(config[CONF_MACHINE_DATA])

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -235,9 +235,12 @@ const char *JuraComponent::handshake_stage_name(JuraComponent::HandshakeStage st
 
 JuraComponent::~JuraComponent() {
   for (auto &entry : this->xml_sensors_) {
-    delete entry.second;
+    if (this->xml_owned_sensors_.find(entry.second) != this->xml_owned_sensors_.end()) {
+      delete entry.second;
+    }
   }
   this->xml_sensors_.clear();
+  this->xml_owned_sensors_.clear();
 }
 
 void JuraComponent::setup() {
@@ -819,6 +822,7 @@ bool JuraComponent::process_tgc0_response_(const std::vector<uint8_t> &decoded) 
 
 void JuraComponent::register_xml_sensor_(const XmlField &field, XmlSensorKind kind) {
   auto &meta = this->xml_sensor_meta_[field.name];
+  bool user_configured = this->xml_user_configured_.find(field.name) != this->xml_user_configured_.end();
   meta.kind = kind;
   meta.min_value = (kind == XmlSensorKind::Counter) ? XML_COUNTER_MIN : XML_MEASUREMENT_MIN;
   meta.max_value = (kind == XmlSensorKind::Counter) ? XML_COUNTER_MAX : XML_MEASUREMENT_MAX;
@@ -836,7 +840,22 @@ void JuraComponent::register_xml_sensor_(const XmlField &field, XmlSensorKind ki
     meta.is_tgc0 = true;
   }
   meta.configured = true;
+  meta.user_provided = user_configured;
+  meta.force_label = !user_configured;
   this->get_or_create_sensor_(field.name, field.label);
+}
+
+void JuraComponent::add_configured_xml_sensor(const std::string &name, sensor::Sensor *sensor) {
+  if (sensor == nullptr) {
+    return;
+  }
+  this->xml_sensors_[name] = sensor;
+  this->xml_user_configured_.insert(name);
+  this->xml_owned_sensors_.erase(sensor);
+  auto &meta = this->xml_sensor_meta_[name];
+  meta.user_provided = true;
+  meta.force_label = false;
+  meta.configured = true;
 }
 
 void JuraComponent::ensure_xml_sensors_created_() {
@@ -1152,19 +1171,24 @@ sensor::Sensor *JuraComponent::get_or_create_sensor_(const std::string &name, co
   if (it != this->xml_sensors_.end()) {
     auto *sensor_obj = it->second;
     sensor_obj->set_unique_id(unique_id);
-    sensor_obj->set_accuracy_decimals(accuracy);
-    sensor_obj->set_state_class(state_class);
-    if (meta != nullptr && meta->has_unit) {
-      sensor_obj->set_unit_of_measurement(meta->unit_of_measurement);
+    if (meta == nullptr || !meta->user_provided) {
+      sensor_obj->set_accuracy_decimals(accuracy);
+      sensor_obj->set_state_class(state_class);
+      if (meta != nullptr && meta->has_unit) {
+        sensor_obj->set_unit_of_measurement(meta->unit_of_measurement);
+      }
+      if (meta != nullptr && meta->has_icon) {
+        sensor_obj->set_icon(meta->icon);
+      }
     }
-    if (meta != nullptr && meta->has_icon) {
-      sensor_obj->set_icon(meta->icon);
+    if (meta == nullptr || meta->force_label) {
+      auto label_it = this->xml_sensor_labels_.find(name);
+      if (label_it == this->xml_sensor_labels_.end() || label_it->second != effective_label) {
+        sensor_obj->set_name(effective_label);
+        this->xml_sensor_labels_[name] = effective_label;
+      }
     }
-    auto label_it = this->xml_sensor_labels_.find(name);
-    if (label_it == this->xml_sensor_labels_.end() || label_it->second != effective_label) {
-      sensor_obj->set_name(effective_label);
-      this->xml_sensor_labels_[name] = effective_label;
-    }
+    try_set_parent(sensor_obj, this, 0);
     return sensor_obj;
   }
 
@@ -1184,6 +1208,7 @@ sensor::Sensor *JuraComponent::get_or_create_sensor_(const std::string &name, co
   sensor_obj->set_name(effective_label);
   this->xml_sensor_labels_[name] = effective_label;
   this->xml_sensors_[name] = sensor_obj;
+  this->xml_owned_sensors_.insert(sensor_obj);
   return sensor_obj;
 }
 

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -8,6 +8,7 @@
 #include <string_view>
 #include <deque>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "esphome/core/automation.h"
@@ -102,6 +103,8 @@ struct XmlSensorMeta {
   bool has_icon{false};
   std::string icon;
   bool is_tgc0{false};
+  bool user_provided{false};
+  bool force_label{true};
 };
 
 class JuraComponent : public esphome::Component, public esphome::uart::UARTDevice {
@@ -153,6 +156,7 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   void publish_xml_stats_();
   void publish_single_stat_(const std::string &name, double value, const std::string &label);
   void register_xml_sensor_(const XmlField &field, XmlSensorKind kind);
+  void add_configured_xml_sensor(const std::string &name, sensor::Sensor *sensor);
   sensor::Sensor *get_or_create_sensor_(const std::string &name, const std::string &label);
   static const char *xml_command_for_index_(size_t index);
   static const char *xml_log_label_for_index_(size_t index);
@@ -193,6 +197,8 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   Stats xml_stats_{};
   std::unordered_map<std::string, sensor::Sensor *> xml_sensors_{};
   std::unordered_map<std::string, std::string> xml_sensor_labels_{};
+  std::unordered_set<std::string> xml_user_configured_{};
+  std::unordered_set<sensor::Sensor *> xml_owned_sensors_{};
   struct Tgc0FilterState {
     std::deque<float> window;
     uint8_t consecutive_valid{0};


### PR DESCRIPTION
## Summary
- add an `xml_sensors` YAML option that instantiates regular ESPHome sensors linked to XML fields
- make the C++ component reuse user-provided sensors without overwriting their names and avoid deleting foreign instances
- document how to declare XML sensors manually in YAML with concrete examples

## Testing
- python -m compileall esphome/components/jutta_proto

------
https://chatgpt.com/codex/tasks/task_e_68e287aafea08328a82287c518eeebac