### PR TITLE
Optimize settings polling deduplication

### DIFF
--- a/docs/FEHLER.md
+++ b/docs/FEHLER.md
@@ -1,0 +1,58 @@
+# JUTTA Proto – Fehlercodes
+
+Die Fehlerzustände der Maschine werden über den in der XML hinterlegten
+`<Errors>`-Block ermittelt. Jede Fehlermeldung ist ein Mapping von numerischem
+Code zu Text und Schweregrad.
+
+## Polling
+
+* Abfragekommando: Attribut `source_cmd` des `<Errors>`-Elements (z. B. `@ER:00`).
+* Intervall: alle 5 s (`kErrorPollIntervalMs`).
+* Dekodierung: identisch zu den Einstellungen – die Antwort wird als hexadezimale
+  Bytefolge ausgewertet und zu einem 32-Bit-Code zusammengesetzt.
+
+## Entities
+
+| Entity ID             | Typ            | Beschreibung                               |
+|-----------------------|----------------|---------------------------------------------|
+| `sensor.jura_error_code`      | `sensor`       | Numerischer Fehlercode.                     |
+| `text_sensor.jura_error_text` | `text_sensor`  | Fehlerbeschreibung laut XML.                |
+| `text_sensor.jura_error_severity` | `text_sensor` | Severity (`info`, `warning`, `block`, …).   |
+| `binary_sensor.jura_has_error` | `binary_sensor` | `true`, wenn `code != 0`.                   |
+
+Werden neue Fehlercodes in der XML ergänzt, steht der Text automatisch zur
+Verfügung (`find_error`). Unbekannte Codes werden mit `unbekannt`/`unknown`
+veröffentlicht.
+
+## Beispielkonfiguration
+
+```yaml
+text_sensor:
+  - platform: jutta_proto
+    id: jura_error_text
+    name: "${devicename} Fehlertext"
+  - platform: jutta_proto
+    id: jura_error_severity
+    name: "${devicename} Fehler-Schwere"
+
+sensor:
+  - platform: jutta_proto
+    id: jura_error_code
+    name: "${devicename} Fehlercode"
+    unit_of_measurement: ""
+
+binary_sensor:
+  - platform: jutta_proto
+    id: jura_has_error
+    name: "${devicename} Fehler aktiv"
+```
+
+## Beispiel-Ansicht in Home Assistant
+
+```
+Fehlercode: 0
+Fehlertext: kein Fehler
+Fehler-Schwere: none
+Fehler aktiv: aus
+```
+

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -1,0 +1,53 @@
+# Einbindung der neuen Entities
+
+## Benötigte Plattformen
+
+* `sensor.jutta_proto` – numerische Einstellungen sowie Fehlercode.
+* `text_sensor.jutta_proto` – String-Einstellungen und Fehlertexte.
+* `binary_sensor.jutta_proto` – Fehlerstatus (`jura_has_error`).
+
+Alle Plattformen akzeptieren optional `jutta_id`, falls mehrere Komponenten
+konfiguriert sind.
+
+## Minimalbeispiel
+
+```yaml
+jutta_proto:
+  id: my_jura
+  uart_id: uart_bus
+  enable_xml_poll: true
+
+sensor:
+  - platform: jutta_proto
+    jutta_id: my_jura
+    id: jura_error_code
+    name: "${devicename} Fehlercode"
+
+  - platform: jutta_proto
+    jutta_id: my_jura
+    id: jura_setting_water_hardness
+    name: "${devicename} Wasserhärte"
+    unit_of_measurement: "°dH"
+
+text_sensor:
+  - platform: jutta_proto
+    jutta_id: my_jura
+    id: jura_error_text
+    name: "${devicename} Fehlertext"
+
+binary_sensor:
+  - platform: jutta_proto
+    jutta_id: my_jura
+    id: jura_has_error
+    name: "${devicename} Fehler aktiv"
+```
+
+## Hinweise
+
+* Die IDs `jura_error_code`, `jura_error_text`, `jura_error_severity` und
+  `jura_has_error` sind fest verdrahtet.
+* Einstellungs-Entities müssen mit dem Präfix `jura_setting_` beginnen. Der
+  Rest der ID muss mit dem XML-Attribut `id` übereinstimmen.
+* Werte werden automatisch aktualisiert (Einstellungen alle 10 Minuten,
+  Fehler alle 5 Sekunden).
+

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -1,0 +1,62 @@
+# JUTTA Proto – Geräteeinstellungen
+
+Die Komponente liest alle in der J.O.E.-XML hinterlegten `<Setting>`-Einträge und
+stellt sie als zusätzliche Home-Assistant-Entities zur Verfügung. Die Zuordnung
+erfolgt ausschließlich über die XML-Definition.
+
+## Felder und Metadaten
+
+| Feld                | Beschreibung                                    |
+|---------------------|--------------------------------------------------|
+| `id`                | Stabiles Kennzeichen, wird als Entity-Suffix genutzt. |
+| `name`              | Menschlich lesbarer Name (Debug-Log).            |
+| `unit`              | Einheit (falls vorhanden, z. B. `°dH`).          |
+| `source_cmd`        | UART-Befehl, der den Wert liefert (z. B. `@TM:02`). |
+| `offset` / `width`  | Byte-Offset und -breite im Antwortframe.         |
+| `scale`             | Multiplikator zur Skalierung des Rohwerts.       |
+| `type`              | `u8`, `u16`, `u32`, `bool`, `enum` oder `string`. |
+
+Numerische Einstellungen werden als `sensor` veröffentlicht. String-Werte werden
+als `text_sensor` bereitgestellt.
+
+## Quelle (source_cmd)
+
+Jeder Eintrag in der XML enthält das Attribut `source_cmd`. Der Befehl wird beim
+Komponentenstart einmalig abgesetzt und danach zyklisch alle 10 Minuten
+(`kSettingsRefreshMs`) erneut abgefragt. Der gleiche Dekodierpfad wie bei den
+bestehenden TR/TG/TGC0-Polls wird verwendet (`write_decoded_with_response`).
+
+## Einheit und Skalierung
+
+Die Unit (`unit`) sowie `scale` werden direkt aus der XML übernommen. `scale`
+wird auf den Rohwert angewendet, bevor der Sensorwert veröffentlicht wird. Damit
+lassen sich z. B. Halbgrad-Schritte (`scale = 0.5`) korrekt darstellen.
+
+## Update-Strategie
+
+* Initiales Bootstrap (`settings_boot_polled_`) unmittelbar nach erfolgreichem
+  Handshake.
+* Wiederholungsabfrage alle 600 s (`kSettingsRefreshMs`).
+* Eine Abfrage kann optional per `jutta_id` auf eine von mehreren Instanzen
+  geroutet werden.
+
+## YAML-Beispiel
+
+```yaml
+sensor:
+  - platform: jutta_proto
+    jutta_id: my_jura
+    id: jura_setting_water_hardness
+    name: "${devicename} Einstellung Wasserhärte"
+    unit_of_measurement: "°dH"
+```
+
+String-Werte verwenden die Text-Sensor-Plattform:
+
+```yaml
+text_sensor:
+  - platform: jutta_proto
+    id: jura_setting_welcome_text
+    name: "${devicename} Begrüßung"
+```
+

--- a/esphome/components/jutta_proto/binary_sensor/__init__.py
+++ b/esphome/components/jutta_proto/binary_sensor/__init__.py
@@ -1,0 +1,39 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import binary_sensor
+
+from .. import JURA_COMPONENT_IDS, JuraComponent
+
+CONF_JUTTA_ID = "jutta_id"
+
+
+CONFIG_SCHEMA = binary_sensor.binary_sensor_schema().extend(
+    {cv.Optional(CONF_JUTTA_ID): cv.use_id(JuraComponent)}
+)
+
+
+async def _resolve_parent(config):
+    if CONF_JUTTA_ID in config:
+        return await cg.get_variable(config[CONF_JUTTA_ID])
+    if not JURA_COMPONENT_IDS:
+        raise cv.Invalid("Es ist kein jutta_proto-Component konfiguriert")
+    if len(JURA_COMPONENT_IDS) > 1:
+        raise cv.Invalid("Mehrere jutta_proto-Instanzen gefunden, bitte 'jutta_id' setzen")
+    return await cg.get_variable(JURA_COMPONENT_IDS[0])
+
+
+async def to_code(config):
+    parent = await _resolve_parent(config)
+    sens = await binary_sensor.new_binary_sensor(config)
+
+    id_obj = config.get(cv.CONF_ID)
+    if id_obj is None:
+        raise cv.Invalid("Binary Sensor benötigt ein id-Attribut")
+    identifier = id_obj.id
+
+    if identifier == "jura_has_error":
+        cg.add(parent.set_error_active_sensor(sens))
+        return
+
+    raise cv.Invalid("Unbekannter jutta_proto Binary Sensor '{}'.".format(identifier))
+

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -9,6 +9,7 @@
 #include <limits>
 #include <sstream>
 #include <utility>
+#include <unordered_set>
 
 #include "esphome/core/application.h"
 #include "esphome/core/time.h"
@@ -29,6 +30,9 @@ constexpr uint32_t kXmlRxTimeoutMs = 1000;
 constexpr uint32_t kInterCmdGapMs = 120;
 constexpr uint32_t kXmlQuietMs = 120;
 constexpr uint32_t kCycleSleepMs = 2000;
+constexpr uint32_t kSettingsRefreshMs = 600000;
+constexpr uint32_t kErrorPollIntervalMs = 5000;
+constexpr uint32_t kCommandTimeoutMs = 1500;
 
 constexpr double XML_COUNTER_MIN = 0.0;
 constexpr double XML_COUNTER_MAX = 1'000'000.0;
@@ -225,6 +229,8 @@ void JuraComponent::loop() {
 
   this->process_machine_data_query();
   this->process_xml_polling();
+  this->poll_settings_once_();
+  this->poll_error_cycle_();
 }
 
 void JuraComponent::dump_config() {
@@ -904,6 +910,22 @@ void JuraComponent::add_configured_xml_sensor(const std::string &field, sensor::
   }
 }
 
+void JuraComponent::register_setting_sensor(const std::string &id, sensor::Sensor *sensor) {
+  if (id.empty() || sensor == nullptr) {
+    return;
+  }
+  this->setting_sensors_[id] = sensor;
+  this->settings_entities_created_ = false;
+}
+
+void JuraComponent::register_setting_text_sensor(const std::string &id, text_sensor::TextSensor *sensor) {
+  if (id.empty() || sensor == nullptr) {
+    return;
+  }
+  this->setting_text_sensors_[id] = sensor;
+  this->settings_entities_created_ = false;
+}
+
 void JuraComponent::publish_xml_stats_() {
   if (!this->enable_xml_poll_) {
     return;
@@ -1091,6 +1113,8 @@ bool JuraComponent::ensure_xml_mapping_loaded_() {
 
   std::string xml_source(this->xml_mapping_data_, this->xml_mapping_length_);
   bool valid = load_mapping_from_string(xml_source);
+  load_settings_from_xml(xml_source);
+  load_errors_from_xml(xml_source);
   this->xml_mapping_ = get_xml_mapping();
   this->xml_mapping_loaded_ = true;
   this->xml_mapping_logged_ = false;
@@ -1098,6 +1122,10 @@ bool JuraComponent::ensure_xml_mapping_loaded_() {
   this->xml_sensor_meta_.clear();
   this->tgc0_filters_.clear();
   this->xml_missing_sensor_logged_.clear();
+  this->settings_entities_created_ = false;
+  this->settings_boot_polled_ = false;
+  this->last_error_code_ = 0;
+  this->errors_entities_created_ = false;
   this->log_xml_mapping_status_();
   if (this->xml_mapping_.valid) {
     this->ensure_xml_sensors_created_();
@@ -1493,6 +1521,259 @@ void JuraComponent::handle_xml_timeout_(XmlPollState next_state, const char *lab
 
 void JuraComponent::prepare_tgc0_request_() {
   // Keine zusätzlichen Flush-Operationen während des XML-Pollings.
+}
+
+void JuraComponent::ensure_setting_entities_created_() {
+  if (this->settings_entities_created_) {
+    return;
+  }
+  this->setting_descs_.clear();
+  const auto &settings = get_settings();
+  for (const auto &desc : settings) {
+    if (!desc.id.empty()) {
+      this->setting_descs_[desc.id] = desc;
+    }
+  }
+  this->settings_entities_created_ = true;
+}
+
+bool JuraComponent::query_setting_command_(const std::string &command, std::vector<uint8_t> &decoded) {
+  decoded.clear();
+  if (command.empty()) {
+    return false;
+  }
+  if (this->coffee_maker_ == nullptr || this->coffee_maker_->connection == nullptr) {
+    return false;
+  }
+  std::string cmd = command;
+  if (cmd.find("\r\n") == std::string::npos) {
+    cmd.append("\r\n");
+  }
+  auto response = this->coffee_maker_->connection->write_decoded_with_response(
+      cmd, std::chrono::milliseconds{kCommandTimeoutMs});
+  if (response == nullptr) {
+    ESP_LOGW(TAG, "Einstellungspoll: keine Antwort für %s", command.c_str());
+    return false;
+  }
+  std::string payload = *response;
+  payload.erase(std::remove(payload.begin(), payload.end(), '\r'), payload.end());
+  payload.erase(std::remove(payload.begin(), payload.end(), '\n'), payload.end());
+  std::string filtered;
+  filtered.reserve(payload.size());
+  for (unsigned char c : payload) {
+    if (!std::isspace(c)) {
+      filtered.push_back(static_cast<char>(c));
+    }
+  }
+  for (std::size_t i = 0; i + 1 < filtered.size(); i += 2) {
+    std::string byte_hex = filtered.substr(i, 2);
+    char *end = nullptr;
+    auto value = std::strtoul(byte_hex.c_str(), &end, 16);
+    if (end == byte_hex.c_str()) {
+      decoded.clear();
+      break;
+    }
+    decoded.push_back(static_cast<uint8_t>(value));
+  }
+  if (decoded.empty() && !filtered.empty()) {
+    decoded.assign(filtered.begin(), filtered.end());
+  }
+  return !decoded.empty();
+}
+
+bool JuraComponent::query_error_command_(const std::string &command, std::vector<uint8_t> &decoded) {
+  return this->query_setting_command_(command, decoded);
+}
+
+void JuraComponent::publish_setting_value_(const SettingDesc &desc, float value, const std::string &raw_text) {
+  if (desc.type != SettingValueType::String) {
+    auto it = this->setting_sensors_.find(desc.id);
+    if (it != this->setting_sensors_.end() && it->second != nullptr) {
+      it->second->publish_state(value);
+    }
+  }
+  auto text_it = this->setting_text_sensors_.find(desc.id);
+  if (text_it != this->setting_text_sensors_.end() && text_it->second != nullptr) {
+    text_it->second->publish_state(raw_text);
+  }
+}
+
+void JuraComponent::poll_settings_refresh_() {
+  this->ensure_setting_entities_created_();
+  if (this->setting_descs_.empty()) {
+    return;
+  }
+  std::unordered_map<std::string, std::vector<uint8_t>> command_cache;
+  std::unordered_set<std::string> failed_commands;
+
+  auto get_command_payload = [&](const std::string &command) -> const std::vector<uint8_t> * {
+    if (command.empty()) {
+      return nullptr;
+    }
+    if (failed_commands.find(command) != failed_commands.end()) {
+      return nullptr;
+    }
+    auto cache_it = command_cache.find(command);
+    if (cache_it != command_cache.end()) {
+      return &cache_it->second;
+    }
+    std::vector<uint8_t> decoded;
+    if (!this->query_setting_command_(command, decoded)) {
+      failed_commands.insert(command);
+      return nullptr;
+    }
+    auto inserted = command_cache.emplace(command, std::move(decoded));
+    return &inserted.first->second;
+  };
+
+  auto format_numeric_text = [](float value) -> std::string {
+    char buffer[32];
+    int written = std::snprintf(buffer, sizeof(buffer), "%.6f", static_cast<double>(value));
+    if (written < 0) {
+      return std::to_string(static_cast<double>(value));
+    }
+    std::string text(buffer, static_cast<size_t>(written));
+    auto dot = text.find('.');
+    if (dot != std::string::npos) {
+      while (!text.empty() && text.back() == '0') {
+        text.pop_back();
+      }
+      if (!text.empty() && text.back() == '.') {
+        text.pop_back();
+      }
+      if (text.empty()) {
+        text = "0";
+      }
+    }
+    return text;
+  };
+
+  for (const auto &entry : this->setting_descs_) {
+    const auto &desc = entry.second;
+    if (desc.source_cmd.empty()) {
+      continue;
+    }
+    const auto *decoded_ptr = get_command_payload(desc.source_cmd);
+    if (decoded_ptr == nullptr) {
+      continue;
+    }
+    const auto &decoded = *decoded_ptr;
+    if (desc.offset + desc.width > decoded.size()) {
+      ESP_LOGW(TAG, "Einstellung %s: Antwort zu kurz (offset=%u width=%u size=%u)", desc.id.c_str(),
+               static_cast<unsigned>(desc.offset), static_cast<unsigned>(desc.width),
+               static_cast<unsigned>(decoded.size()));
+      continue;
+    }
+    const uint8_t *ptr = decoded.data() + desc.offset;
+    std::uint64_t raw = 0;
+    for (std::size_t i = 0; i < desc.width; ++i) {
+      raw = (raw << 8U) | static_cast<std::uint64_t>(ptr[i]);
+    }
+    float scaled = static_cast<float>(raw) * desc.scale;
+    std::string text_value;
+    switch (desc.type) {
+      case SettingValueType::Bool:
+        text_value = raw ? "on" : "off";
+        scaled = raw ? 1.0f : 0.0f;
+        break;
+      case SettingValueType::Enum:
+      case SettingValueType::U8:
+      case SettingValueType::U16:
+      case SettingValueType::U32:
+        text_value = format_numeric_text(scaled);
+        break;
+      case SettingValueType::String:
+        text_value.assign(reinterpret_cast<const char *>(ptr), desc.width);
+        auto zero_pos = text_value.find('\0');
+        if (zero_pos != std::string::npos) {
+          text_value.resize(zero_pos);
+        }
+        this->publish_setting_value_(desc, 0.0f, text_value);
+        continue;
+    }
+    this->publish_setting_value_(desc, scaled, text_value);
+  }
+}
+
+void JuraComponent::poll_settings_once_() {
+  if (!this->is_ready()) {
+    return;
+  }
+  if (this->coffee_maker_ == nullptr || this->coffee_maker_->connection == nullptr) {
+    return;
+  }
+  uint32_t now = esphome::millis();
+  if (!this->settings_boot_polled_) {
+    this->poll_settings_refresh_();
+    this->settings_boot_polled_ = true;
+    this->settings_next_refresh_ = now + kSettingsRefreshMs;
+    return;
+  }
+  if (this->settings_next_refresh_ != 0 && !time_reached(now, this->settings_next_refresh_)) {
+    return;
+  }
+  this->poll_settings_refresh_();
+  this->settings_next_refresh_ = now + kSettingsRefreshMs;
+}
+
+void JuraComponent::publish_error_state_(uint32_t code) {
+  if (this->error_code_sensor_ != nullptr) {
+    this->error_code_sensor_->publish_state(static_cast<float>(code));
+  }
+  bool has_error = code != 0;
+  if (this->error_active_sensor_ != nullptr) {
+    this->error_active_sensor_->publish_state(has_error);
+  }
+  const ErrorDesc *desc = find_error(code);
+  if (desc != nullptr) {
+    if (this->error_text_sensor_ != nullptr) {
+      this->error_text_sensor_->publish_state(desc->text);
+    }
+    if (this->error_severity_sensor_ != nullptr) {
+      this->error_severity_sensor_->publish_state(desc->severity);
+    }
+  } else {
+    if (this->error_text_sensor_ != nullptr) {
+      this->error_text_sensor_->publish_state(has_error ? "unbekannt" : "kein Fehler");
+    }
+    if (this->error_severity_sensor_ != nullptr) {
+      this->error_severity_sensor_->publish_state(has_error ? "unknown" : "none");
+    }
+  }
+  this->last_error_code_ = code;
+  this->errors_entities_created_ = true;
+}
+
+void JuraComponent::poll_error_cycle_() {
+  if (this->coffee_maker_ == nullptr || this->coffee_maker_->connection == nullptr) {
+    return;
+  }
+  if (!this->is_ready()) {
+    return;
+  }
+  uint32_t now = esphome::millis();
+  if (this->errors_next_poll_ != 0 && !time_reached(now, this->errors_next_poll_)) {
+    return;
+  }
+  this->errors_next_poll_ = now + kErrorPollIntervalMs;
+  std::string command = error_source_command();
+  if (command.empty()) {
+    return;
+  }
+  std::vector<uint8_t> decoded;
+  if (!this->query_error_command_(command, decoded)) {
+    return;
+  }
+  if (decoded.empty()) {
+    return;
+  }
+  uint32_t code = 0;
+  for (uint8_t byte : decoded) {
+    code = (code << 8U) | byte;
+  }
+  if (!this->errors_entities_created_ || code != this->last_error_code_) {
+    this->publish_error_state_(code);
+  }
 }
 
 void JuraComponent::start_brew(::jutta_proto::CoffeeMaker::coffee_t coffee) {

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -113,6 +113,31 @@ class TextSensor {
 }  // namespace esphome
 #endif
 #undef ESPHOME_JUTTA_TEXT_SENSOR_STUB
+
+#if defined(__has_include)
+#if __has_include("esphome/components/binary_sensor/binary_sensor.h")
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#else
+#define ESPHOME_JUTTA_BINARY_SENSOR_STUB
+#endif
+#else
+#define ESPHOME_JUTTA_BINARY_SENSOR_STUB
+#endif
+
+#ifdef ESPHOME_JUTTA_BINARY_SENSOR_STUB
+namespace esphome {
+namespace binary_sensor {
+
+class BinarySensor {
+ public:
+  virtual ~BinarySensor() = default;
+  virtual void publish_state(bool) {}
+};
+
+}  // namespace binary_sensor
+}  // namespace esphome
+#endif
+#undef ESPHOME_JUTTA_BINARY_SENSOR_STUB
 #include "esphome/components/uart/uart.h"
 
 #include "coffee_maker.hpp"
@@ -120,6 +145,8 @@ class TextSensor {
 #include "jutta_connection.hpp"
 #include "jutta_commands.hpp"
 #include "jutta_proto_xml.h"
+#include "xml_settings.hpp"
+#include "xml_errors.hpp"
 
 namespace esphome {
 namespace jutta_component {
@@ -170,6 +197,12 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   }
   void set_xml_poll_interval(uint32_t interval_ms) { this->xml_poll_interval_ms_ = interval_ms; }
   void add_configured_xml_sensor(const std::string &field, sensor::Sensor *sensor);
+  void register_setting_sensor(const std::string &id, sensor::Sensor *sensor);
+  void register_setting_text_sensor(const std::string &id, text_sensor::TextSensor *sensor);
+  void set_error_code_sensor(sensor::Sensor *sensor) { this->error_code_sensor_ = sensor; }
+  void set_error_text_sensor(text_sensor::TextSensor *sensor) { this->error_text_sensor_ = sensor; }
+  void set_error_severity_sensor(text_sensor::TextSensor *sensor) { this->error_severity_sensor_ = sensor; }
+  void set_error_active_sensor(binary_sensor::BinarySensor *sensor) { this->error_active_sensor_ = sensor; }
 
  protected:
   enum class HandshakeStage { IDLE, HELLO, SEND_T1, WAIT_T2, SEND_T2, WAIT_T3, SEND_T3, DONE, FAILED };
@@ -227,6 +260,14 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   void transition_to_state_(XmlPollState state, uint32_t now, uint32_t delay_ms = 0);
   bool send_xml_command_(const char *command, XmlPollState wait_state, uint32_t now);
   void handle_xml_timeout_(XmlPollState next_state, const char *label, uint32_t now);
+  void poll_settings_once_();
+  void poll_settings_refresh_();
+  void poll_error_cycle_();
+  void ensure_setting_entities_created_();
+  void publish_setting_value_(const SettingDesc &desc, float value, const std::string &raw_text);
+  void publish_error_state_(uint32_t code);
+  bool query_setting_command_(const std::string &command, std::vector<uint8_t> &decoded);
+  bool query_error_command_(const std::string &command, std::vector<uint8_t> &decoded);
 
   std::unique_ptr<::jutta_proto::JuttaConnection> connection_;
   std::unique_ptr<::jutta_proto::CoffeeMaker> coffee_maker_;
@@ -277,6 +318,20 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   uint8_t xml_tgc0_timeout_streak_{0};
   bool xml_skip_tgc0_{false};
   void prepare_tgc0_request_();
+
+  bool settings_boot_polled_{false};
+  uint32_t settings_next_refresh_{0};
+  uint32_t errors_next_poll_{0};
+  sensor::Sensor *error_code_sensor_{nullptr};
+  text_sensor::TextSensor *error_text_sensor_{nullptr};
+  text_sensor::TextSensor *error_severity_sensor_{nullptr};
+  binary_sensor::BinarySensor *error_active_sensor_{nullptr};
+  std::unordered_map<std::string, sensor::Sensor *> setting_sensors_{};
+  std::unordered_map<std::string, text_sensor::TextSensor *> setting_text_sensors_{};
+  std::unordered_map<std::string, SettingDesc> setting_descs_{};
+  bool settings_entities_created_{false};
+  bool errors_entities_created_{false};
+  uint32_t last_error_code_{0};
 };
 
 class StartBrewAction : public esphome::Action<> {

--- a/esphome/components/jutta_proto/sensor/__init__.py
+++ b/esphome/components/jutta_proto/sensor/__init__.py
@@ -1,0 +1,57 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import sensor
+
+from .. import JURA_COMPONENT_IDS, JuraComponent
+
+
+def _setting_id_from_sensor_id(id_obj):
+    if id_obj is None:
+        return None
+    name = id_obj.id
+    prefix = "jura_setting_"
+    if name.startswith(prefix):
+        return name[len(prefix) :]
+    return None
+
+
+CONF_JUTTA_ID = "jutta_id"
+
+
+CONFIG_SCHEMA = sensor.sensor_schema().extend(
+    {cv.Optional(CONF_JUTTA_ID): cv.use_id(JuraComponent)}
+)
+
+
+async def _resolve_parent(config):
+    if CONF_JUTTA_ID in config:
+        return await cg.get_variable(config[CONF_JUTTA_ID])
+    if not JURA_COMPONENT_IDS:
+        raise cv.Invalid("Es ist kein jutta_proto-Component konfiguriert")
+    if len(JURA_COMPONENT_IDS) > 1:
+        raise cv.Invalid("Mehrere jutta_proto-Instanzen gefunden, bitte 'jutta_id' setzen")
+    return await cg.get_variable(JURA_COMPONENT_IDS[0])
+
+
+async def to_code(config):
+    parent = await _resolve_parent(config)
+    sens = await sensor.new_sensor(config)
+
+    id_obj = config.get(cv.CONF_ID)
+    if id_obj is None:
+        raise cv.Invalid("Sensor requires an id")
+    identifier = id_obj.id
+    setting_id = _setting_id_from_sensor_id(id_obj)
+
+    if setting_id is not None:
+        cg.add(parent.register_setting_sensor(cg.std_string(setting_id), sens))
+        return
+
+    if identifier == "jura_error_code":
+        cg.add(parent.set_error_code_sensor(sens))
+        return
+
+    raise cv.Invalid(
+        f"Unbekannter jutta_proto Sensor '{identifier}'. Erwartet 'jura_error_code' oder 'jura_setting_*'."
+    )
+

--- a/esphome/components/jutta_proto/text_sensor/__init__.py
+++ b/esphome/components/jutta_proto/text_sensor/__init__.py
@@ -1,0 +1,61 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import text_sensor
+
+from .. import JURA_COMPONENT_IDS, JuraComponent
+
+
+def _setting_id_from_text_id(id_obj):
+    if id_obj is None:
+        return None
+    name = id_obj.id
+    prefix = "jura_setting_"
+    if name.startswith(prefix):
+        return name[len(prefix) :]
+    return None
+
+
+CONF_JUTTA_ID = "jutta_id"
+
+
+CONFIG_SCHEMA = text_sensor.text_sensor_schema().extend(
+    {cv.Optional(CONF_JUTTA_ID): cv.use_id(JuraComponent)}
+)
+
+
+async def _resolve_parent(config):
+    if CONF_JUTTA_ID in config:
+        return await cg.get_variable(config[CONF_JUTTA_ID])
+    if not JURA_COMPONENT_IDS:
+        raise cv.Invalid("Es ist kein jutta_proto-Component konfiguriert")
+    if len(JURA_COMPONENT_IDS) > 1:
+        raise cv.Invalid("Mehrere jutta_proto-Instanzen gefunden, bitte 'jutta_id' setzen")
+    return await cg.get_variable(JURA_COMPONENT_IDS[0])
+
+
+async def to_code(config):
+    parent = await _resolve_parent(config)
+    sens = await text_sensor.new_text_sensor(config)
+
+    id_obj = config.get(cv.CONF_ID)
+    if id_obj is None:
+        raise cv.Invalid("Text-Sensor benötigt ein id-Attribut")
+    identifier = id_obj.id
+    setting_id = _setting_id_from_text_id(id_obj)
+
+    if setting_id is not None:
+        cg.add(parent.register_setting_text_sensor(cg.std_string(setting_id), sens))
+        return
+
+    if identifier == "jura_error_text":
+        cg.add(parent.set_error_text_sensor(sens))
+        return
+
+    if identifier == "jura_error_severity":
+        cg.add(parent.set_error_severity_sensor(sens))
+        return
+
+    raise cv.Invalid(
+        f"Unbekannter jutta_proto Text-Sensor '{identifier}'. Erwartet Fehlertext/-severity oder jura_setting_*."
+    )
+

--- a/esphome/components/jutta_proto/xml_errors.cpp
+++ b/esphome/components/jutta_proto/xml_errors.cpp
@@ -1,0 +1,175 @@
+#include "esphome/components/jutta_proto/xml_errors.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <functional>
+#include <regex>
+#include <unordered_map>
+
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace jutta_component {
+
+namespace {
+
+static const char *const TAG = "jutta_proto.errors";
+
+struct AttributeMap {
+  std::unordered_map<std::string, std::string> values;
+
+  std::string get(const std::string &key) const {
+    auto it = this->values.find(key);
+    if (it != this->values.end()) {
+      return it->second;
+    }
+    return {};
+  }
+};
+
+std::string to_lower_copy(std::string value) {
+  std::transform(value.begin(), value.end(), value.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return value;
+}
+
+void trim(std::string &value) {
+  auto begin = value.find_first_not_of(" \t\r\n");
+  auto end = value.find_last_not_of(" \t\r\n");
+  if (begin == std::string::npos || end == std::string::npos) {
+    value.clear();
+    return;
+  }
+  value = value.substr(begin, end - begin + 1);
+}
+
+std::string trim_copy(std::string value) {
+  trim(value);
+  return value;
+}
+
+AttributeMap parse_attributes(const std::string &tag_text) {
+  AttributeMap map;
+  static const std::regex attr_regex(R"(([A-Za-z0-9_:\-]+)\s*=\s*\"([^\"]*)\")");
+  auto begin = std::sregex_iterator(tag_text.begin(), tag_text.end(), attr_regex);
+  auto end = std::sregex_iterator();
+  for (auto it = begin; it != end; ++it) {
+    std::string key = to_lower_copy((*it)[1].str());
+    std::string value = (*it)[2].str();
+    trim(value);
+    map.values[key] = value;
+  }
+  return map;
+}
+
+bool extract_section(const std::string &xml, const std::string &tag, std::string &out) {
+  std::string lower = to_lower_copy(xml);
+  std::string open = "<" + to_lower_copy(tag);
+  auto start = lower.find(open);
+  if (start == std::string::npos) {
+    return false;
+  }
+  auto open_end = lower.find('>', start);
+  if (open_end == std::string::npos) {
+    return false;
+  }
+  auto close = lower.find("</" + to_lower_copy(tag), open_end);
+  if (close == std::string::npos) {
+    return false;
+  }
+  out = xml.substr(open_end + 1, close - open_end - 1);
+  return true;
+}
+
+void for_each_error_tag(const std::string &block, const std::function<void(const std::string &)> &callback) {
+  std::string lower = to_lower_copy(block);
+  std::size_t pos = 0;
+  while (true) {
+    auto tag_pos = lower.find("<error", pos);
+    if (tag_pos == std::string::npos) {
+      break;
+    }
+    auto tag_end = lower.find('>', tag_pos);
+    if (tag_end == std::string::npos) {
+      break;
+    }
+    callback(block.substr(tag_pos, tag_end - tag_pos + 1));
+    pos = tag_end + 1;
+  }
+}
+
+bool parse_uint32(const std::string &value, uint32_t &out) {
+  if (value.empty()) {
+    return false;
+  }
+  char *end = nullptr;
+  auto parsed = std::strtoul(value.c_str(), &end, 0);
+  if (end == value.c_str()) {
+    return false;
+  }
+  out = static_cast<uint32_t>(parsed);
+  return true;
+}
+
+std::vector<ErrorDesc> g_errors;
+std::string g_error_source_cmd;
+
+}  // namespace
+
+bool load_errors_from_xml(const std::string &xml_content) {
+  g_errors.clear();
+  g_error_source_cmd.clear();
+  std::string lower = to_lower_copy(xml_content);
+  std::string needle = "<errors";
+  auto pos = lower.find(needle);
+  if (pos != std::string::npos) {
+    auto tag_end = lower.find('>', pos);
+    if (tag_end != std::string::npos) {
+      std::string tag_text = xml_content.substr(pos, tag_end - pos + 1);
+      auto attrs = parse_attributes(tag_text);
+      g_error_source_cmd = attrs.get("source_cmd");
+      trim(g_error_source_cmd);
+    }
+  }
+  std::string block;
+  if (!extract_section(xml_content, "errors", block)) {
+    ESP_LOGW(TAG, "XML enthält keinen <Errors>-Block");
+    block = xml_content;
+  }
+  for_each_error_tag(block, [](const std::string &tag_text) {
+    auto attrs = parse_attributes(tag_text);
+    ErrorDesc desc;
+    if (!parse_uint32(attrs.get("code"), desc.code)) {
+      ESP_LOGW(TAG, "Error ohne gültigen Code ignoriert");
+      return;
+    }
+    desc.text = attrs.get("text");
+    trim(desc.text);
+    desc.severity = attrs.get("severity");
+    trim(desc.severity);
+    g_errors.push_back(desc);
+  });
+  std::sort(g_errors.begin(), g_errors.end(), [](const ErrorDesc &a, const ErrorDesc &b) { return a.code < b.code; });
+  g_errors.erase(std::unique(g_errors.begin(), g_errors.end(),
+                             [](const ErrorDesc &a, const ErrorDesc &b) { return a.code == b.code; }),
+                 g_errors.end());
+  return !g_errors.empty();
+}
+
+const ErrorDesc *find_error(uint32_t code) {
+  auto it = std::lower_bound(g_errors.begin(), g_errors.end(), code,
+                             [](const ErrorDesc &err, uint32_t value) { return err.code < value; });
+  if (it != g_errors.end() && it->code == code) {
+    return &*it;
+  }
+  return nullptr;
+}
+
+const std::vector<ErrorDesc> &all_errors() { return g_errors; }
+
+const std::string &error_source_command() { return g_error_source_cmd; }
+
+}  // namespace jutta_component
+}  // namespace esphome
+

--- a/esphome/components/jutta_proto/xml_errors.hpp
+++ b/esphome/components/jutta_proto/xml_errors.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace esphome {
+namespace jutta_component {
+
+struct ErrorDesc {
+  uint32_t code{0};
+  std::string text;
+  std::string severity;
+};
+
+bool load_errors_from_xml(const std::string &xml_content);
+const ErrorDesc *find_error(uint32_t code);
+const std::vector<ErrorDesc> &all_errors();
+const std::string &error_source_command();
+
+}  // namespace jutta_component
+}  // namespace esphome
+

--- a/esphome/components/jutta_proto/xml_settings.cpp
+++ b/esphome/components/jutta_proto/xml_settings.cpp
@@ -1,0 +1,224 @@
+#include "esphome/components/jutta_proto/xml_settings.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <functional>
+#include <regex>
+#include <unordered_map>
+
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace jutta_component {
+
+namespace {
+
+static const char *const TAG = "jutta_proto.settings";
+
+struct AttributeMap {
+  std::unordered_map<std::string, std::string> values;
+
+  std::string get(const std::string &key) const {
+    auto it = this->values.find(key);
+    if (it != this->values.end()) {
+      return it->second;
+    }
+    return {};
+  }
+};
+
+std::string to_lower_copy(std::string value) {
+  std::transform(value.begin(), value.end(), value.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return value;
+}
+
+void trim(std::string &value) {
+  auto begin = value.find_first_not_of(" \t\r\n");
+  auto end = value.find_last_not_of(" \t\r\n");
+  if (begin == std::string::npos || end == std::string::npos) {
+    value.clear();
+    return;
+  }
+  value = value.substr(begin, end - begin + 1);
+}
+
+std::string trim_copy(std::string value) {
+  trim(value);
+  return value;
+}
+
+AttributeMap parse_attributes(const std::string &tag_text) {
+  AttributeMap map;
+  static const std::regex attr_regex(R"(([A-Za-z0-9_:\-]+)\s*=\s*\"([^\"]*)\")");
+  auto begin = std::sregex_iterator(tag_text.begin(), tag_text.end(), attr_regex);
+  auto end = std::sregex_iterator();
+  for (auto it = begin; it != end; ++it) {
+    std::string key = to_lower_copy((*it)[1].str());
+    std::string value = (*it)[2].str();
+    trim(value);
+    map.values[key] = value;
+  }
+  return map;
+}
+
+bool parse_size_t(const AttributeMap &attrs, const std::string &key, std::size_t &out) {
+  std::string value = attrs.get(key);
+  if (value.empty()) {
+    return false;
+  }
+  char *end = nullptr;
+  auto parsed = std::strtoul(value.c_str(), &end, 0);
+  if (end == value.c_str()) {
+    return false;
+  }
+  out = static_cast<std::size_t>(parsed);
+  return true;
+}
+
+bool parse_float(const AttributeMap &attrs, const std::string &key, float &out) {
+  std::string value = attrs.get(key);
+  if (value.empty()) {
+    return false;
+  }
+  char *end = nullptr;
+  auto parsed = std::strtof(value.c_str(), &end);
+  if (end == value.c_str()) {
+    return false;
+  }
+  out = parsed;
+  return true;
+}
+
+bool parse_type(const AttributeMap &attrs, SettingValueType &out) {
+  std::string value = to_lower_copy(attrs.get("type"));
+  if (value.empty()) {
+    return false;
+  }
+  if (value == "u8" || value == "uint8" || value == "byte") {
+    out = SettingValueType::U8;
+    return true;
+  }
+  if (value == "u16" || value == "uint16") {
+    out = SettingValueType::U16;
+    return true;
+  }
+  if (value == "u32" || value == "uint32") {
+    out = SettingValueType::U32;
+    return true;
+  }
+  if (value == "bool" || value == "boolean") {
+    out = SettingValueType::Bool;
+    return true;
+  }
+  if (value == "enum") {
+    out = SettingValueType::Enum;
+    return true;
+  }
+  if (value == "str" || value == "string") {
+    out = SettingValueType::String;
+    return true;
+  }
+  ESP_LOGW(TAG, "Unbekannter Setting-Typ '%s'", value.c_str());
+  return false;
+}
+
+bool parse_setting_tag(const std::string &tag_text, SettingDesc &out) {
+  auto attrs = parse_attributes(tag_text);
+  out = SettingDesc{};
+  out.id = attrs.get("id");
+  trim(out.id);
+  if (out.id.empty()) {
+    ESP_LOGW(TAG, "Setting ohne id ignoriert");
+    return false;
+  }
+  out.name = attrs.get("name");
+  trim(out.name);
+  out.unit = attrs.get("unit");
+  trim(out.unit);
+  out.source_cmd = attrs.get("source_cmd");
+  trim(out.source_cmd);
+  parse_size_t(attrs, "offset", out.offset);
+  parse_size_t(attrs, "width", out.width);
+  parse_float(attrs, "scale", out.scale);
+  parse_type(attrs, out.type);
+  if (out.width == 0) {
+    switch (out.type) {
+      case SettingValueType::U16:
+        out.width = 2;
+        break;
+      case SettingValueType::U32:
+        out.width = 4;
+        break;
+      default:
+        out.width = 1;
+        break;
+    }
+  }
+  return true;
+}
+
+bool extract_section(const std::string &xml, const std::string &tag, std::string &out) {
+  std::string lower = to_lower_copy(xml);
+  std::string open = "<" + to_lower_copy(tag);
+  auto start = lower.find(open);
+  if (start == std::string::npos) {
+    return false;
+  }
+  auto open_end = lower.find('>', start);
+  if (open_end == std::string::npos) {
+    return false;
+  }
+  auto close = lower.find("</" + to_lower_copy(tag), open_end);
+  if (close == std::string::npos) {
+    return false;
+  }
+  out = xml.substr(open_end + 1, close - open_end - 1);
+  return true;
+}
+
+void for_each_setting_tag(const std::string &block, const std::function<void(const std::string &)> &callback) {
+  std::string lower = to_lower_copy(block);
+  std::size_t pos = 0;
+  while (true) {
+    auto tag_pos = lower.find("<setting", pos);
+    if (tag_pos == std::string::npos) {
+      break;
+    }
+    auto tag_end = lower.find('>', tag_pos);
+    if (tag_end == std::string::npos) {
+      break;
+    }
+    callback(block.substr(tag_pos, tag_end - tag_pos + 1));
+    pos = tag_end + 1;
+  }
+}
+
+std::vector<SettingDesc> g_settings;
+bool g_settings_loaded = false;
+
+}  // namespace
+
+bool load_settings_from_xml(const std::string &xml_content) {
+  g_settings.clear();
+  g_settings_loaded = true;
+  std::string settings_block;
+  if (!extract_section(xml_content, "settings", settings_block)) {
+    ESP_LOGW(TAG, "XML enthält keinen <Settings>-Block");
+    settings_block = xml_content;
+  }
+  for_each_setting_tag(settings_block, [](const std::string &tag) {
+    SettingDesc desc;
+    if (parse_setting_tag(tag, desc)) {
+      g_settings.push_back(desc);
+    }
+  });
+  return !g_settings.empty();
+}
+
+const std::vector<SettingDesc> &get_settings() { return g_settings; }
+
+}  // namespace jutta_component
+}  // namespace esphome
+

--- a/esphome/components/jutta_proto/xml_settings.hpp
+++ b/esphome/components/jutta_proto/xml_settings.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace esphome {
+namespace jutta_component {
+
+enum class SettingValueType {
+  U8,
+  U16,
+  U32,
+  Bool,
+  Enum,
+  String,
+};
+
+struct SettingDesc {
+  std::string id;
+  std::string name;
+  std::string unit;
+  std::string source_cmd;
+  std::size_t offset{0};
+  std::size_t width{0};
+  float scale{1.0f};
+  SettingValueType type{SettingValueType::U8};
+};
+
+bool load_settings_from_xml(const std::string &xml_content);
+const std::vector<SettingDesc> &get_settings();
+
+}  // namespace jutta_component
+}  // namespace esphome
+

--- a/tests/stubs/esphome/core/log.h
+++ b/tests/stubs/esphome/core/log.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#define ESP_LOGW(tag, fmt, ...) (void) sizeof(tag), (void) sizeof(fmt)
+#define ESP_LOGD(tag, fmt, ...) (void) sizeof(tag), (void) sizeof(fmt)
+#define ESP_LOGI(tag, fmt, ...) (void) sizeof(tag), (void) sizeof(fmt)
+#define ESP_LOGCONFIG(tag, fmt, ...) (void) sizeof(tag), (void) sizeof(fmt)
+

--- a/tests/xml_parsing_test.cpp
+++ b/tests/xml_parsing_test.cpp
@@ -1,0 +1,61 @@
+#include "esphome/components/jutta_proto/xml_settings.hpp"
+#include "esphome/components/jutta_proto/xml_errors.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+using namespace esphome::jutta_component;
+
+int main() {
+  const std::string sample_xml =
+      "<settings>"
+      "<setting id=\"water_hardness\" name=\"Water Hardness\" unit=\"°dH\" source_cmd=\"@TM:02\" offset=\"0\" width=\"1\" scale=\"1\" type=\"u8\" />"
+      "<setting id=\"brew_temp\" name=\"Brew Temp\" unit=\"°C\" source_cmd=\"@TM:09\" offset=\"1\" width=\"1\" scale=\"0.5\" type=\"u8\" />"
+      "</settings>"
+      "<errors source_cmd=\"@ER:00\">"
+      "<error code=\"0\" text=\"OK\" severity=\"none\" />"
+      "<error code=\"1\" text=\"Generic\" severity=\"warning\" />"
+      "</errors>";
+
+
+  bool settings_loaded = load_settings_from_xml(sample_xml);
+  if (!settings_loaded) {
+    std::cerr << "Settings block not parsed" << std::endl;
+  }
+  const auto &settings = get_settings();
+  std::cout << "Settings parsed: " << settings.size() << std::endl;
+  assert(settings.size() == 2);
+  assert(settings[0].id == "water_hardness");
+  assert(settings[1].id == "brew_temp");
+
+  bool errors_loaded = load_errors_from_xml(sample_xml);
+  if (!errors_loaded) {
+    std::cerr << "Errors block not parsed" << std::endl;
+  }
+  const auto &errors = all_errors();
+  std::cout << "Errors parsed: " << errors.size() << std::endl;
+  assert(errors.size() == 2);
+  assert(error_source_command() == "@ER:00");
+  const ErrorDesc *err = find_error(1);
+  assert(err != nullptr);
+  assert(err->text == "Generic");
+  assert(err->severity == "warning");
+
+  // Simple decode emulation for the settings.
+  const SettingDesc &hardness = settings[0];
+  std::vector<uint8_t> payload = {0x05, 0x02};  // hardness=5, temp raw=0x02 -> 1°C after scaling 0.5
+  std::uint64_t raw_hardness = payload[hardness.offset];
+  float scaled_hardness = static_cast<float>(raw_hardness) * hardness.scale;
+  assert(scaled_hardness == 5.0f);
+
+  const SettingDesc &temp = settings[1];
+  std::uint64_t raw_temp = payload[temp.offset];
+  float scaled_temp = static_cast<float>(raw_temp) * temp.scale;
+  assert(scaled_temp == 1.0f);
+
+  std::cout << "XML settings/errors tests passed." << std::endl;
+  return 0;
+}
+


### PR DESCRIPTION
## Summary
- cache setting command responses to avoid requerying identical source_cmd values during a refresh cycle
- format published numeric and string setting values for more user-friendly text sensor output

## Testing
- g++ -std=c++17 -I. -Itests/stubs tests/xml_parsing_test.cpp esphome/components/jutta_proto/xml_settings.cpp esphome/components/jutta_proto/xml_errors.cpp -o tests/xml_parsing_test
- ./tests/xml_parsing_test


------
https://chatgpt.com/codex/tasks/task_e_68e4c1ad7e1083288e90316d2d25db5b