### PR TITLE
Harden XML polling and TGC0 scaling

### DIFF
--- a/esphome/components/jutta_proto/jutta_connection.cpp
+++ b/esphome/components/jutta_proto/jutta_connection.cpp
@@ -5,6 +5,7 @@
 #include <cctype>
 #include <cstddef>
 #include <cstdio>
+#include <cstring>
 #include <iomanip>
 #include <sstream>
 #include <string>
@@ -581,6 +582,7 @@ void JuttaConnection::tx_db_command(const std::string& ascii, bool flush) {
     if (flush) {
         this->serial.flush();
     }
+    this->drain_serial_input_quick();
 }
 
 bool JuttaConnection::read_db_frame(std::vector<uint8_t>& decoded, uint32_t timeout_ms, bool* had_crlf,
@@ -647,6 +649,10 @@ bool JuttaConnection::read_db_frame(std::vector<uint8_t>& decoded, uint32_t time
         }
         if (decoded_len != nullptr) {
             *decoded_len = frame_decoded_len;
+        }
+
+        if (reason != nullptr && std::strcmp(reason, "CRLF") == 0) {
+            this->drain_serial_input_quick();
         }
 
         if (consume_len > 0) {
@@ -753,6 +759,39 @@ void JuttaConnection::reset_all_rx_buffers() {
 
 void JuttaConnection::drain_serial_input_nonblocking() {
     this->flush_serial_input();
+}
+
+void JuttaConnection::drain_serial_input_quick(uint32_t max_duration_ms) {
+    if (max_duration_ms == 0) {
+        max_duration_ms = 1;
+    }
+    uint32_t start = esphome::millis();
+    std::array<uint8_t, 4> discard{};
+    size_t total_dropped = 0;
+    if (!this->encoded_rx_buffer_.empty() || !this->decoded_rx_buffer_.empty()) {
+        ESP_LOGV(TAG, "Quick-drain: clearing %zu encoded and %zu decoded buffered byte%s.",
+                 this->encoded_rx_buffer_.size(), this->decoded_rx_buffer_.size(),
+                 (this->encoded_rx_buffer_.size() + this->decoded_rx_buffer_.size()) == 1 ? "" : "s");
+        this->encoded_rx_buffer_.clear();
+        this->decoded_rx_buffer_.clear();
+    }
+    while (true) {
+        size_t read = this->serial.read_serial(discard);
+        if (read == 0) {
+            break;
+        }
+        total_dropped += read;
+        std::vector<uint8_t> view(discard.begin(), discard.begin() + std::min(read, discard.size()));
+        ESP_LOGVV(TAG, "Quick-drain dropped %zu byte%s: %s", read, read == 1 ? "" : "s",
+                  format_hex(view).c_str());
+        if (static_cast<int32_t>(esphome::millis() - start - max_duration_ms) >= 0) {
+            break;
+        }
+    }
+    if (total_dropped > 0) {
+        ESP_LOGV(TAG, "Quick-drain discarded %zu stray byte%s from UART.", total_dropped,
+                 total_dropped == 1 ? "" : "s");
+    }
 }
 
 void JuttaConnection::activate_tx_echo_suppressor_(const std::vector<uint8_t>& frame) {

--- a/esphome/components/jutta_proto/jutta_connection.hpp
+++ b/esphome/components/jutta_proto/jutta_connection.hpp
@@ -126,6 +126,8 @@ class JuttaConnection {
     void reset_all_rx_buffers();
     /** Verwirft nicht abgeholte Bytes aus dem UART-Puffer ohne zu blockieren. */
     void drain_serial_input_nonblocking();
+    /** Entfernt eingehende Bytes für eine kurze Dauer, um Alt-Daten loszuwerden. */
+    void drain_serial_input_quick(uint32_t max_duration_ms = 10);
 
     /**
      * Encodes the given byte into 4 JUTTA bytes and writes them to the coffee maker.

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -5,6 +5,7 @@
 #include <cctype>
 #include <cmath>
 #include <cstdio>
+#include <cstring>
 #include <iomanip>
 #include <limits>
 #include <sstream>
@@ -28,7 +29,9 @@ constexpr uint32_t MACHINE_DATA_REQUEST_TIMEOUT_MS = 2000;
 const char *const MACHINE_DATA_COMMAND = "&STAT?\r\n";
 constexpr uint32_t kXmlRxTimeoutMs = 1000;
 constexpr uint32_t kInterCmdGapMs = 120;
+constexpr uint32_t kTr32InterCmdGapMs = 220;
 constexpr uint32_t kXmlQuietMs = 120;
+constexpr uint32_t kXmlQuietTr32Ms = 220;
 constexpr uint32_t kCycleSleepMs = 2000;
 constexpr uint32_t kSettingsRefreshMs = 600000;
 constexpr uint32_t kErrorPollIntervalMs = 5000;
@@ -710,6 +713,24 @@ bool JuraComponent::validate_xml_frame_(XmlPollState state, const std::vector<ui
     return false;
   }
 
+  const char *expected_command = this->xml_state_command_(state);
+  if (expected_command != nullptr && expected_command[0] != '\0') {
+    std::size_t command_len = std::strlen(expected_command);
+    constexpr std::size_t kCommandOffset = 1;
+    if (payload.size() < kCommandOffset + command_len) {
+      ESP_LOGW(TAG, "XML %s: Kommando-Präfix zu kurz (decoded_len=%u)", this->xml_state_label_(state),
+               static_cast<unsigned>(payload.size()));
+      return false;
+    }
+    auto begin = payload.begin() + static_cast<std::ptrdiff_t>(kCommandOffset);
+    if (!std::equal(begin, begin + static_cast<std::ptrdiff_t>(command_len), expected_command,
+                    expected_command + command_len)) {
+      ESP_LOGW(TAG, "XML %s: unerwarteter Präfix '%s'", this->xml_state_label_(state),
+               format_printable_string(std::string(begin, begin + command_len)).c_str());
+      return false;
+    }
+  }
+
   const char *command = this->xml_state_command_(state);
   ESP_LOGD(TAG, "XML RX cmd=%s decoded_len=%u expected_min_len=%u head0=0x%02X", command,
            static_cast<unsigned>(decoded_len), static_cast<unsigned>(expected_min_len),
@@ -780,9 +801,15 @@ bool JuraComponent::process_valid_tgc0_frame_(const std::vector<uint8_t> &frame,
     if (!this->decode_field_value_(frame, raw_field, little_endian, raw_value)) {
       continue;
     }
-    double percent = static_cast<double>(raw_value) * field.scale;
-    if (field.has_add) {
-      percent += field.add;
+    double percent = 0.0;
+    if (field.has_scale) {
+      percent = static_cast<double>(raw_value) * field.scale;
+      if (field.has_add) {
+        percent += field.add;
+      }
+    } else {
+      percent = std::round(static_cast<double>(raw_value) * 100.0 / 65535.0);
+      percent = std::clamp(percent, 0.0, 110.0);
     }
     if (!std::isfinite(percent)) {
       auto &state = this->tgc0_filters_[field.name];
@@ -822,7 +849,7 @@ bool JuraComponent::should_retry_current_(XmlPollState wait_state, uint32_t now)
                                   : (wait_state == XmlPollState::WAIT_TG43 ? XmlPollState::SEND_TG43
                                                                            : XmlPollState::SEND_TGC0);
   ESP_LOGW(TAG, "XML %s: erneuter Versuch", this->xml_state_label_(wait_state));
-  this->transition_to_state_(resend_state, now, kInterCmdGapMs);
+  this->transition_to_state_(resend_state, now, this->inter_command_gap_after_(wait_state));
   return true;
 }
 
@@ -873,7 +900,7 @@ void JuraComponent::handle_xml_failure_(XmlPollState wait_state, bool is_timeout
     this->xml_next_poll_ = deadline;
     this->transition_to_state_(XmlPollState::SLEEP, now);
   } else {
-    this->transition_to_state_(next_state, now, kInterCmdGapMs);
+    this->transition_to_state_(next_state, now, this->inter_command_gap_after_(wait_state));
   }
 }
 
@@ -1279,7 +1306,7 @@ void JuraComponent::handle_xml_state_machine_(uint32_t now) {
           this->xml_next_poll_ = deadline;
           this->transition_to_state_(XmlPollState::SLEEP, now);
         } else {
-          this->transition_to_state_(next, now, kInterCmdGapMs);
+          this->transition_to_state_(next, now, this->inter_command_gap_after_(this->xml_state_));
         }
         return;
       }
@@ -1299,11 +1326,13 @@ void JuraComponent::handle_xml_state_machine_(uint32_t now) {
         uint8_t head0 = 0;
         if (!this->validate_xml_frame_(this->xml_state_, decoded, had_crlf, decoded_len, payload, expected_min_len,
                                        head0)) {
+          connection->drain_serial_input_quick();
           this->handle_xml_failure_(this->xml_state_, false, decoded_len, now);
           return;
         }
         if (this->xml_state_ == XmlPollState::WAIT_TGC0) {
           if (!this->process_valid_tgc0_frame_(payload, false)) {
+            connection->drain_serial_input_quick();
             this->handle_xml_failure_(this->xml_state_, false, payload.size(), now);
             return;
           }
@@ -1337,7 +1366,8 @@ void JuraComponent::handle_xml_state_machine_(uint32_t now) {
         this->publish_xml_stats_();
       }
       this->xml_stats_.clear();
-      this->transition_to_state_(XmlPollState::SEND_TG43, now, kInterCmdGapMs);
+      this->transition_to_state_(XmlPollState::SEND_TG43, now,
+                                 this->inter_command_gap_after_(XmlPollState::WAIT_TR32));
       return;
     }
     case XmlPollState::PARSE_TG43: {
@@ -1353,7 +1383,8 @@ void JuraComponent::handle_xml_state_machine_(uint32_t now) {
         this->publish_xml_stats_();
       }
       this->xml_stats_.clear();
-      this->transition_to_state_(XmlPollState::SEND_TGC0, now, kInterCmdGapMs);
+      this->transition_to_state_(XmlPollState::SEND_TGC0, now,
+                                 this->inter_command_gap_after_(XmlPollState::WAIT_TG43));
       return;
     }
     case XmlPollState::PARSE_TGC0: {
@@ -1472,6 +1503,20 @@ const char *JuraComponent::xml_state_label_(XmlPollState state) const {
   return "?";
 }
 
+uint32_t JuraComponent::quiet_delay_for_state_(XmlPollState wait_state) const {
+  if (wait_state == XmlPollState::WAIT_TR32) {
+    return kXmlQuietTr32Ms;
+  }
+  return kXmlQuietMs;
+}
+
+uint32_t JuraComponent::inter_command_gap_after_(XmlPollState wait_state) const {
+  if (wait_state == XmlPollState::WAIT_TR32) {
+    return kTr32InterCmdGapMs;
+  }
+  return kInterCmdGapMs;
+}
+
 void JuraComponent::transition_to_state_(XmlPollState state, uint32_t now, uint32_t delay_ms) {
   this->xml_state_ = state;
   if (delay_ms > 0) {
@@ -1503,7 +1548,8 @@ bool JuraComponent::send_xml_command_(const char *command, XmlPollState wait_sta
   this->xml_inflight_ = true;
   this->xml_last_command_ = command;
   this->xml_deadline_ms_ = now + kXmlRxTimeoutMs;
-  this->xml_next_action_ms_ = now + kXmlQuietMs;
+  uint32_t quiet_delay = this->quiet_delay_for_state_(wait_state);
+  this->xml_next_action_ms_ = quiet_delay > 0 ? now + quiet_delay : 0;
   this->xml_state_ = wait_state;
   return true;
 }

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -257,6 +257,8 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   bool xml_state_has_mapping_(XmlPollState state) const;
   const char *xml_state_command_(XmlPollState state) const;
   const char *xml_state_label_(XmlPollState state) const;
+  uint32_t quiet_delay_for_state_(XmlPollState wait_state) const;
+  uint32_t inter_command_gap_after_(XmlPollState wait_state) const;
   void transition_to_state_(XmlPollState state, uint32_t now, uint32_t delay_ms = 0);
   bool send_xml_command_(const char *command, XmlPollState wait_state, uint32_t now);
   void handle_xml_timeout_(XmlPollState next_state, const char *label, uint32_t now);

--- a/esphome/components/jutta_proto/jutta_proto_xml.cpp
+++ b/esphome/components/jutta_proto/jutta_proto_xml.cpp
@@ -360,8 +360,10 @@ bool parse_field_tag(const std::string &tag_text, XmlCommandMapping &mapping) {
   double scale = field.scale;
   if (parse_double_attr(attrs, {"scale"}, scale)) {
     field.scale = scale;
+    field.has_scale = true;
   } else if (contains_percent_hint(field.name) || contains_percent_hint(field.label)) {
     field.scale = 0.01;
+    field.has_scale = true;
   }
   double add = field.add;
   if (parse_double_attr(attrs, {"offset_value", "bias", "add"}, add)) {

--- a/esphome/components/jutta_proto/jutta_proto_xml.h
+++ b/esphome/components/jutta_proto/jutta_proto_xml.h
@@ -16,6 +16,7 @@ struct XmlField {
   std::size_t size{0};
   bool has_endian{false};
   bool little_endian{false};
+  bool has_scale{false};
   double scale{1.0};
   bool has_add{false};
   double add{0.0};


### PR DESCRIPTION
## Summary
- add a short UART drain helper and use it after DB transmissions and frame completion to resync the decoder
- tighten XML frame validation by checking the command prefix and adjusting inter-command quiet times
- apply a safe fallback scaling for @TG:C0 percentages and track explicit scale metadata in the XML mapping parser

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4d93c8fa4832881492c1ba5b16329