### PR TITLE
Improve UART line handling and XML parsing resilience

### DIFF
--- a/esphome/components/jutta_proto/jutta_connection.cpp
+++ b/esphome/components/jutta_proto/jutta_connection.cpp
@@ -103,14 +103,23 @@ std::string format_printable(uint8_t byte) {
 }
 
 bool try_extract_line(std::string& buffer, std::string& line) {
-    auto terminator = buffer.find("\r\n");
-    if (terminator == std::string::npos) {
+    auto lf_pos = buffer.find('\n');
+    if (lf_pos == std::string::npos) {
         return false;
     }
-
-    line = buffer.substr(0, terminator);
-    buffer.erase(0, terminator + 2);
+    size_t end = lf_pos;
+    if (end > 0 && buffer[end - 1] == '\r') {
+        --end;
+    }
+    line.assign(buffer.begin(), buffer.begin() + static_cast<std::ptrdiff_t>(end));
+    buffer.erase(0, lf_pos + 1);
     return true;
+}
+
+void trim_trailing_crlf(std::string& line) {
+    while (!line.empty() && (line.back() == '\r' || line.back() == '\n')) {
+        line.pop_back();
+    }
 }
 
 inline bool is_printable_ascii(uint8_t byte) {
@@ -515,7 +524,20 @@ void JuttaConnection::reinject_decoded_front(const std::string& data) const {
 bool JuttaConnection::read_line_until(std::string& line) {
     if (try_extract_line(this->response_line_buffer_, line)) {
         ESP_LOGD(TAG, "Polled buffered response line: '%s'", format_printable(line).c_str());
+        this->response_line_last_activity_us_ = esphome::micros();
         return true;
+    }
+
+    auto now_us = esphome::micros();
+    if (!this->response_line_buffer_.empty() && this->response_line_last_activity_us_ != 0) {
+        if (static_cast<int32_t>(now_us - this->response_line_last_activity_us_ - JUTTA_LINE_IDLE_US) >= 0) {
+            line = this->response_line_buffer_;
+            trim_trailing_crlf(line);
+            this->response_line_buffer_.clear();
+            this->response_line_last_activity_us_ = now_us;
+            ESP_LOGD(TAG, "Polled idle-terminated response line: '%s'", format_printable(line).c_str());
+            return true;
+        }
     }
 
     std::vector<uint8_t> buffer;
@@ -523,6 +545,8 @@ bool JuttaConnection::read_line_until(std::string& line) {
         return false;
     }
 
+    now_us = esphome::micros();
+    this->response_line_last_activity_us_ = now_us;
     std::string incoming = vec_to_string(buffer);
     this->response_line_buffer_.append(incoming);
     ESP_LOGD(TAG, "Received chunk while polling for response line: '%s' (hex %s) -> buffer '%s'",
@@ -531,6 +555,15 @@ bool JuttaConnection::read_line_until(std::string& line) {
 
     if (try_extract_line(this->response_line_buffer_, line)) {
         ESP_LOGD(TAG, "Polled response line: '%s'", format_printable(line).c_str());
+        this->response_line_last_activity_us_ = esphome::micros();
+        return true;
+    }
+
+    if (this->response_line_buffer_.size() >= JUTTA_LINE_MAX) {
+        line.swap(this->response_line_buffer_);
+        trim_trailing_crlf(line);
+        ESP_LOGW(TAG, "Response line exceeded %u bytes – forcing close", static_cast<unsigned>(JUTTA_LINE_MAX));
+        this->response_line_last_activity_us_ = esphome::micros();
         return true;
     }
 
@@ -544,6 +577,7 @@ void JuttaConnection::reset_response_line_buffer() {
                  this->response_line_buffer_.size() == 1 ? "" : "s");
         this->response_line_buffer_.clear();
     }
+    this->response_line_last_activity_us_ = 0;
 }
 
 void JuttaConnection::tx_db_command(const std::string& ascii, bool flush) {

--- a/esphome/components/jutta_proto/jutta_connection.hpp
+++ b/esphome/components/jutta_proto/jutta_connection.hpp
@@ -8,6 +8,13 @@
 #include <vector>
 #include <deque>
 
+#ifndef JUTTA_LINE_MAX
+#define JUTTA_LINE_MAX 256
+#endif
+#ifndef JUTTA_LINE_IDLE_US
+#define JUTTA_LINE_IDLE_US 10000
+#endif
+
 #include "serial_connection.hpp"
 
 //---------------------------------------------------------------------------
@@ -102,8 +109,10 @@ class JuttaConnection {
                                                                  std::chrono::milliseconds{5000});
 
     /**
-     * Reads the next CRLF-terminated response line if available.
-     * Returns true if a complete line became available and stores it in "line" without the trailing CRLF.
+     * Reads the next CR/LF terminated response line if available.
+     * A line is also returned if the input stayed idle for JUTTA_LINE_IDLE_US microseconds
+     * or if it exceeds JUTTA_LINE_MAX bytes.
+     * Returns true if a complete line became available and stores it in "line" without trailing CR/LF.
      * Returns false when no complete line has been received yet.
      */
     bool read_line_until(std::string& line);
@@ -302,8 +311,9 @@ class JuttaConnection {
     // Buffer for decoded bytes that were read ahead of the consumer.
     mutable std::deque<uint8_t> decoded_rx_buffer_{};
 
-    // Buffer for decoded bytes collected while looking for complete CRLF-terminated lines.
+    // Buffer for decoded bytes collected while looking for complete lines.
     mutable std::string response_line_buffer_{};
+    mutable uint32_t response_line_last_activity_us_{0};
 
     void reinject_decoded_front(const std::string& data) const;
 

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -33,6 +33,7 @@ constexpr uint32_t kTr32InterCmdGapMs = 220;
 constexpr uint32_t kXmlQuietMs = 120;
 constexpr uint32_t kXmlQuietTr32Ms = 220;
 constexpr uint32_t kCycleSleepMs = 2000;
+constexpr uint32_t kXmlTimeoutBackoffMs = 300;
 constexpr uint32_t kSettingsRefreshMs = 600000;
 constexpr uint32_t kErrorPollIntervalMs = 5000;
 constexpr uint32_t kCommandTimeoutMs = 1500;
@@ -466,9 +467,16 @@ void JuraComponent::process_handshake() {
       ESP_LOGD(TAG, "SEND_T3: sending '@t3\\r\\n' to finish handshake.");
       if (this->connection_->write_decoded("@t3\r\n")) {
         ESP_LOGI(TAG, "Handshake finished successfully.");
+        ESP_LOGD(TAG, "Handshake finished – settling before first poll");
+        esphome::delay(250);
+        this->connection_->reset_all_rx_buffers();
+        this->connection_->reset_response_line_buffer();
         this->handshake_stage_ = HandshakeStage::DONE;
         this->handshake_buffer_.clear();
         this->handshake_deadline_ = 0;
+        uint32_t settle_deadline = esphome::millis() + 250;
+        this->xml_next_poll_ = settle_deadline;
+        this->xml_next_action_ms_ = settle_deadline;
         if (this->enable_xml_poll_) {
           this->ensure_xml_mapping_loaded_();
         }
@@ -885,7 +893,16 @@ void JuraComponent::handle_xml_failure_(XmlPollState wait_state, bool is_timeout
   this->xml_deadline_ms_ = 0;
   this->xml_rx_buffer_.clear();
 
+  uint32_t extra_delay = is_timeout ? kXmlTimeoutBackoffMs : 0;
+
   if (this->should_retry_current_(wait_state, now)) {
+    if (is_timeout) {
+      if (this->xml_next_action_ms_ != 0) {
+        this->xml_next_action_ms_ += extra_delay;
+      } else {
+        this->xml_next_action_ms_ = now + extra_delay;
+      }
+    }
     return;
   }
   this->xml_retry_count_[index] = 0;
@@ -900,7 +917,7 @@ void JuraComponent::handle_xml_failure_(XmlPollState wait_state, bool is_timeout
     this->xml_next_poll_ = deadline;
     this->transition_to_state_(XmlPollState::SLEEP, now);
   } else {
-    this->transition_to_state_(next_state, now, this->inter_command_gap_after_(wait_state));
+    this->transition_to_state_(next_state, now, this->inter_command_gap_after_(wait_state) + extra_delay);
   }
 }
 
@@ -1562,6 +1579,10 @@ void JuraComponent::handle_xml_timeout_(XmlPollState next_state, const char *lab
     label = "?";
   }
   ESP_LOGW(TAG, "RX_DB timeout %s", label);
+  if (this->coffee_maker_ != nullptr && this->coffee_maker_->connection != nullptr) {
+    this->coffee_maker_->connection->reset_db_rx_buffer();
+    this->coffee_maker_->connection->drain_serial_input_nonblocking();
+  }
   this->handle_xml_failure_(this->xml_state_, true, 0, now);
 }
 

--- a/esphome/components/jutta_proto/jutta_proto_xml.cpp
+++ b/esphome/components/jutta_proto/jutta_proto_xml.cpp
@@ -91,6 +91,14 @@ std::string format_hex_string(const std::vector<uint8_t> &data) {
   return format_hex_string(data.data(), data.size(), true);
 }
 
+std::string strip_to_xml_start(const std::string &input) {
+  auto pos = input.find('<');
+  if (pos == std::string::npos) {
+    return {};
+  }
+  return input.substr(pos);
+}
+
 std::string format_hex_head(const std::vector<uint8_t> &data, std::size_t max_bytes) {
   if (data.empty() || max_bytes == 0) {
     return {};
@@ -731,29 +739,36 @@ const std::unordered_map<std::string, StatValue> &Stats::values() const { return
 
 bool load_mapping_from_string(const std::string &xml) {
   g_mapping = XmlMapping{};
-  bool tr32_found = parse_tr32_mapping(xml, g_mapping.tr32);
+  std::string source = strip_to_xml_start(xml);
+  if (source.empty()) {
+    ESP_LOGW(TAG, "XML Mapping enthält kein '<' – Eingabe verworfen");
+    g_mapping_loaded = true;
+    g_mapping.valid = false;
+    return false;
+  }
+  bool tr32_found = parse_tr32_mapping(source, g_mapping.tr32);
   bool tr32_has_fields = tr32_found && !g_mapping.tr32.empty();
   if (!tr32_has_fields) {
     g_mapping.tr32 = XmlCommandMapping{};
-    bool legacy_tr32 = parse_command_block(xml, "@tr:32", g_mapping.tr32);
+    bool legacy_tr32 = parse_command_block(source, "@tr:32", g_mapping.tr32);
     tr32_found = tr32_found || legacy_tr32;
     tr32_has_fields = legacy_tr32 && !g_mapping.tr32.empty();
   }
 
-  bool tg43_found = parse_textitem_mapping(xml, "@tg:43", "TG43", 2, 6, g_mapping.tg43);
+  bool tg43_found = parse_textitem_mapping(source, "@tg:43", "TG43", 2, 6, g_mapping.tg43);
   bool tg43_has_fields = tg43_found && !g_mapping.tg43.empty();
   if (!tg43_has_fields) {
     g_mapping.tg43 = XmlCommandMapping{};
-    bool legacy_tg43 = parse_command_block(xml, "@tg:43", g_mapping.tg43);
+    bool legacy_tg43 = parse_command_block(source, "@tg:43", g_mapping.tg43);
     tg43_found = tg43_found || legacy_tg43;
     tg43_has_fields = legacy_tg43 && !g_mapping.tg43.empty();
   }
 
-  bool tgc0_found = parse_textitem_mapping(xml, "@tg:c0", "TGC0", 4, 3, g_mapping.tgc0);
+  bool tgc0_found = parse_textitem_mapping(source, "@tg:c0", "TGC0", 4, 3, g_mapping.tgc0);
   bool tgc0_has_fields = tgc0_found && !g_mapping.tgc0.empty();
   if (!tgc0_has_fields) {
     g_mapping.tgc0 = XmlCommandMapping{};
-    bool legacy_tgc0 = parse_command_block(xml, "@tg:c0", g_mapping.tgc0);
+    bool legacy_tgc0 = parse_command_block(source, "@tg:c0", g_mapping.tgc0);
     tgc0_found = tgc0_found || legacy_tgc0;
     tgc0_has_fields = legacy_tgc0 && !g_mapping.tgc0.empty();
   }

--- a/esphome/components/jutta_proto/xml_errors.cpp
+++ b/esphome/components/jutta_proto/xml_errors.cpp
@@ -49,6 +49,14 @@ std::string trim_copy(std::string value) {
   return value;
 }
 
+std::string strip_to_xml_start(const std::string &input) {
+  auto pos = input.find('<');
+  if (pos == std::string::npos) {
+    return {};
+  }
+  return input.substr(pos);
+}
+
 AttributeMap parse_attributes(const std::string &tag_text) {
   AttributeMap map;
   static const std::regex attr_regex(R"(([A-Za-z0-9_:\-]+)\s*=\s*\"([^\"]*)\")");
@@ -120,22 +128,27 @@ std::string g_error_source_cmd;
 bool load_errors_from_xml(const std::string &xml_content) {
   g_errors.clear();
   g_error_source_cmd.clear();
-  std::string lower = to_lower_copy(xml_content);
+  std::string source = strip_to_xml_start(xml_content);
+  if (source.empty()) {
+    ESP_LOGW(TAG, "XML enthält kein '<' – Errors verworfen");
+    return false;
+  }
+  std::string lower = to_lower_copy(source);
   std::string needle = "<errors";
   auto pos = lower.find(needle);
   if (pos != std::string::npos) {
     auto tag_end = lower.find('>', pos);
     if (tag_end != std::string::npos) {
-      std::string tag_text = xml_content.substr(pos, tag_end - pos + 1);
+      std::string tag_text = source.substr(pos, tag_end - pos + 1);
       auto attrs = parse_attributes(tag_text);
       g_error_source_cmd = attrs.get("source_cmd");
       trim(g_error_source_cmd);
     }
   }
   std::string block;
-  if (!extract_section(xml_content, "errors", block)) {
+  if (!extract_section(source, "errors", block)) {
     ESP_LOGW(TAG, "XML enthält keinen <Errors>-Block");
-    block = xml_content;
+    block = source;
   }
   for_each_error_tag(block, [](const std::string &tag_text) {
     auto attrs = parse_attributes(tag_text);

--- a/esphome/components/jutta_proto/xml_settings.cpp
+++ b/esphome/components/jutta_proto/xml_settings.cpp
@@ -49,6 +49,14 @@ std::string trim_copy(std::string value) {
   return value;
 }
 
+std::string strip_to_xml_start(const std::string &input) {
+  auto pos = input.find('<');
+  if (pos == std::string::npos) {
+    return {};
+  }
+  return input.substr(pos);
+}
+
 AttributeMap parse_attributes(const std::string &tag_text) {
   AttributeMap map;
   static const std::regex attr_regex(R"(([A-Za-z0-9_:\-]+)\s*=\s*\"([^\"]*)\")");
@@ -203,10 +211,15 @@ bool g_settings_loaded = false;
 bool load_settings_from_xml(const std::string &xml_content) {
   g_settings.clear();
   g_settings_loaded = true;
+  std::string source = strip_to_xml_start(xml_content);
+  if (source.empty()) {
+    ESP_LOGW(TAG, "XML enthält kein '<' – Settings verworfen");
+    return false;
+  }
   std::string settings_block;
-  if (!extract_section(xml_content, "settings", settings_block)) {
+  if (!extract_section(source, "settings", settings_block)) {
     ESP_LOGW(TAG, "XML enthält keinen <Settings>-Block");
-    settings_block = xml_content;
+    settings_block = source;
   }
   for_each_setting_tag(settings_block, [](const std::string &tag) {
     SettingDesc desc;


### PR DESCRIPTION
## Summary
- add idle timeout and length limits to the UART line reader to close partial lines more reliably
- pause and flush after completing the handshake before starting XML polling, including timeout backoff handling
- strip garbage before the first `<` when loading XML mapping/settings/error files to tolerate prefixed data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e52eeb6eec83289f97fddd0af3e722