### PR TITLE
Improve UART line handling and handshake settling

### DIFF
--- a/esphome/components/jutta_proto/jutta_connection.cpp
+++ b/esphome/components/jutta_proto/jutta_connection.cpp
@@ -24,6 +24,8 @@ constexpr uint32_t JUTTA_TX_ECHO_WINDOW_MS = 200;
 constexpr uint8_t JUTTA_ENCODE_BASE = 0xFF;
 constexpr uint8_t JUTTA_BIT0_MASK = static_cast<uint8_t>(1u << 2);
 constexpr uint8_t JUTTA_BIT1_MASK = static_cast<uint8_t>(1u << 5);
+constexpr size_t RESPONSE_LINE_MAX_BYTES = 256;
+constexpr uint32_t RESPONSE_LINE_IDLE_TIMEOUT_US = 10000;
 std::string format_hex(const uint8_t* data, size_t length) {
     if (length == 0) {
         return "[]";
@@ -102,14 +104,21 @@ std::string format_printable(uint8_t byte) {
     return format_printable(&byte, 1);
 }
 
+void strip_trailing_newlines(std::string& line) {
+    while (!line.empty() && (line.back() == '\r' || line.back() == '\n')) {
+        line.pop_back();
+    }
+}
+
 bool try_extract_line(std::string& buffer, std::string& line) {
-    auto terminator = buffer.find("\r\n");
-    if (terminator == std::string::npos) {
+    auto newline = buffer.find('\n');
+    if (newline == std::string::npos) {
         return false;
     }
 
-    line = buffer.substr(0, terminator);
-    buffer.erase(0, terminator + 2);
+    line = buffer.substr(0, newline);
+    buffer.erase(0, newline + 1);
+    strip_trailing_newlines(line);
     return true;
 }
 
@@ -519,19 +528,46 @@ bool JuttaConnection::read_line_until(std::string& line) {
     }
 
     std::vector<uint8_t> buffer;
-    if (!read_decoded_unsafe(buffer) || buffer.empty()) {
+    bool have_chunk = read_decoded_unsafe(buffer) && !buffer.empty();
+    uint32_t now = esphome::micros();
+    if (this->response_line_last_rx_us_ == 0) {
+        this->response_line_last_rx_us_ = now;
+    }
+
+    if (have_chunk) {
+        std::string incoming = vec_to_string(buffer);
+        this->response_line_buffer_.append(incoming);
+        this->response_line_last_rx_us_ = now;
+        ESP_LOGD(TAG, "Received chunk while polling for response line: '%s' (hex %s) -> buffer '%s'",
+                 format_printable(incoming).c_str(), format_hex(buffer).c_str(),
+                 format_printable(this->response_line_buffer_).c_str());
+
+        if (try_extract_line(this->response_line_buffer_, line)) {
+            ESP_LOGD(TAG, "Polled response line: '%s'", format_printable(line).c_str());
+            return true;
+        }
+
+        if (this->response_line_buffer_.size() >= RESPONSE_LINE_MAX_BYTES) {
+            line = this->response_line_buffer_;
+            strip_trailing_newlines(line);
+            this->response_line_buffer_.clear();
+            ESP_LOGW(TAG, "Response line exceeded %zu bytes – forcing flush: '%s'",
+                     static_cast<size_t>(RESPONSE_LINE_MAX_BYTES), format_printable(line).c_str());
+            return true;
+        }
         return false;
     }
 
-    std::string incoming = vec_to_string(buffer);
-    this->response_line_buffer_.append(incoming);
-    ESP_LOGD(TAG, "Received chunk while polling for response line: '%s' (hex %s) -> buffer '%s'",
-             format_printable(incoming).c_str(), format_hex(buffer).c_str(),
-             format_printable(this->response_line_buffer_).c_str());
-
-    if (try_extract_line(this->response_line_buffer_, line)) {
-        ESP_LOGD(TAG, "Polled response line: '%s'", format_printable(line).c_str());
-        return true;
+    if (!this->response_line_buffer_.empty()) {
+        if (static_cast<int32_t>(now - this->response_line_last_rx_us_) >=
+            static_cast<int32_t>(RESPONSE_LINE_IDLE_TIMEOUT_US)) {
+            line = this->response_line_buffer_;
+            strip_trailing_newlines(line);
+            this->response_line_buffer_.clear();
+            this->response_line_last_rx_us_ = now;
+            ESP_LOGD(TAG, "Idle timeout closed partial response line: '%s'", format_printable(line).c_str());
+            return true;
+        }
     }
 
     return false;
@@ -544,6 +580,7 @@ void JuttaConnection::reset_response_line_buffer() {
                  this->response_line_buffer_.size() == 1 ? "" : "s");
         this->response_line_buffer_.clear();
     }
+    this->response_line_last_rx_us_ = esphome::micros();
 }
 
 void JuttaConnection::tx_db_command(const std::string& ascii, bool flush) {

--- a/esphome/components/jutta_proto/jutta_connection.hpp
+++ b/esphome/components/jutta_proto/jutta_connection.hpp
@@ -302,8 +302,10 @@ class JuttaConnection {
     // Buffer for decoded bytes that were read ahead of the consumer.
     mutable std::deque<uint8_t> decoded_rx_buffer_{};
 
-    // Buffer for decoded bytes collected while looking for complete CRLF-terminated lines.
+    // Buffer for decoded bytes collected while looking for complete CR/LF-terminated lines.
     mutable std::string response_line_buffer_{};
+    // Timestamp of the most recent byte received for the current line (micros()).
+    mutable uint32_t response_line_last_rx_us_{0};
 
     void reinject_decoded_front(const std::string& data) const;
 

--- a/esphome/components/jutta_proto/jutta_proto.cpp
+++ b/esphome/components/jutta_proto/jutta_proto.cpp
@@ -469,6 +469,10 @@ void JuraComponent::process_handshake() {
         this->handshake_stage_ = HandshakeStage::DONE;
         this->handshake_buffer_.clear();
         this->handshake_deadline_ = 0;
+        this->handshake_settle_deadline_ = esphome::millis() + 250;
+        ESP_LOGD(TAG, "Handshake finished – settling for 250 ms");
+        this->connection_->reset_response_line_buffer();
+        this->connection_->reset_all_rx_buffers();
         if (this->enable_xml_poll_) {
           this->ensure_xml_mapping_loaded_();
         }
@@ -484,9 +488,15 @@ void JuraComponent::process_handshake() {
 
   if (this->handshake_stage_ == HandshakeStage::DONE && this->connection_ != nullptr &&
       this->coffee_maker_ == nullptr) {
+    uint32_t now = esphome::millis();
+    if (this->handshake_settle_deadline_ != 0 &&
+        static_cast<int32_t>(now - this->handshake_settle_deadline_) < 0) {
+      return;
+    }
     auto connection = std::move(this->connection_);
     this->coffee_maker_ = std::make_unique<::jutta_proto::CoffeeMaker>(std::move(connection));
     ESP_LOGI(TAG, "Coffee maker controller initialized.");
+    this->handshake_settle_deadline_ = 0;
     this->reset_xml_poll_state_();
   }
 }
@@ -497,6 +507,7 @@ void JuraComponent::restart_handshake(const char *reason) {
   }
   this->handshake_buffer_.clear();
   this->handshake_deadline_ = 0;
+  this->handshake_settle_deadline_ = 0;
   this->handshake_hello_request_sent_ = false;
   this->handshake_stage_ = HandshakeStage::HELLO;
   this->last_logged_stage_ = HandshakeStage::FAILED;

--- a/esphome/components/jutta_proto/jutta_proto.h
+++ b/esphome/components/jutta_proto/jutta_proto.h
@@ -280,6 +280,7 @@ class JuraComponent : public esphome::Component, public esphome::uart::UARTDevic
   std::string handshake_t2_response_;
   std::string handshake_t3_response_;
   uint32_t handshake_deadline_{0};
+  uint32_t handshake_settle_deadline_{0};
   bool handshake_hello_request_sent_{false};
   bool custom_cancel_flag_{false};
   text_sensor::TextSensor *machine_data_sensor_{nullptr};


### PR DESCRIPTION
## Summary
- make the line reader tolerant of LF delimiters, idle timeouts, and oversized fragments
- track timing information for buffered line fragments to close lines after quiet periods
- add a settling delay and RX flush after completing the handshake before starting regular polling

## Testing
- No tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e53389fa2083288fd67c644fd43697